### PR TITLE
Temporary fix for SUPNXP-9065: opening a file with ndrive that is not yet downloaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ MANIFEST
 .project
 .settings
 .pydevproject
+.idea
+**/.idea

--- a/nuxeo-drive-client/nxdrive/controller.py
+++ b/nuxeo-drive-client/nxdrive/controller.py
@@ -101,6 +101,9 @@ class Controller(object):
         # share cookies using threadsafe jar
         self.cookie_jar = CookieJar()
 
+    def register_frontend(self, frontend):
+        self._frontend = frontend
+
     def get_session(self):
         """Reuse the thread local session for this controller
 
@@ -528,6 +531,13 @@ class Controller(object):
             # TODO: synchronize to a dedicated special root for one time edit
             log.warning('Could not find local file for server_url=%s '
                         'and remote_ref=%s', server_url, remote_ref)
+
+            # Display a user-friendly message in systemtray area. For more
+            # information, please see https://jira.nuxeo.com/browse/SUPNXP-9065
+            if self._frontend is not None:
+                self._frontend.notify_user_message(
+                    'Cannot edit',
+                    'File %s not yet downloaded, please try again shortly' % server_url)
             return
 
         # TODO: check synchronization of this state first

--- a/nuxeo-drive-client/nxdrive/controller.py
+++ b/nuxeo-drive-client/nxdrive/controller.py
@@ -532,19 +532,27 @@ class Controller(object):
             log.warning('Could not find local file for server_url=%s '
                         'and remote_ref=%s', server_url, remote_ref)
 
-            # Display a user-friendly message in systemtray area. For more
-            # information, please see https://jira.nuxeo.com/browse/SUPNXP-9065
-            if self._frontend is not None:
-                self._frontend.notify_user_message(
-                    'Cannot edit',
-                    'File %s not yet downloaded, please try again shortly' % server_url)
+            self._notify_cannot_live_edit()
             return
 
         # TODO: check synchronization of this state first
 
         # Find the best editor for the file according to the OS configuration
         file_path = state.get_local_abspath()
-        self.open_local_file(file_path)
+        if not os.path.exists(file_path):
+            self._notify_cannot_live_edit()
+        else:
+            self.open_local_file(file_path)
+
+    def _notify_cannot_live_edit(self,file_path=None):
+        # Display a user-friendly message in systemtray area. For more
+        # information, please see https://jira.nuxeo.com/browse/SUPNXP-9065
+        if self._frontend is not None:
+            msg_body = 'The requested file not yet downloaded, please try again shortly'
+            if file_path is not None:
+                msg_body = "File '%s' not yet downloaded, please try again shortly" % file_path
+            self._frontend.notify_user_message('Cannot edit', msg_body)
+
 
     def open_local_file(self, file_path):
         """Launch the local OS program on the given file / folder."""

--- a/nuxeo-drive-client/nxdrive/gui/win32_msg_app.py
+++ b/nuxeo-drive-client/nxdrive/gui/win32_msg_app.py
@@ -1,7 +1,7 @@
 '''https://jira.nuxeo.com/browse/SUPNXP-9065
 
 On win32 platform, when a separate ndrivew.exe process is launched by a 'edit'
-command, which is triggered a custom URL 'nxdrive://...' user clicking,
+command, which is triggered by a user clicking on a custom URL 'nxdrive://...',
 the QApplication object is not initialized at all, so no system tray is
 initialised for this process. Therefore, it's not able to show message in
 system tray area as it does on Mac OS.

--- a/nuxeo-drive-client/nxdrive/gui/win32_msg_app.py
+++ b/nuxeo-drive-client/nxdrive/gui/win32_msg_app.py
@@ -1,0 +1,68 @@
+'''https://jira.nuxeo.com/browse/SUPNXP-9065
+
+On win32 platform, when a separate ndrivew.exe process is launched by a 'edit'
+command, which is triggered a custom URL 'nxdrive://...' user clicking,
+the QApplication object is not initialized at all, so no system tray is
+initialised for this process. Therefore, it's not able to show message in
+system tray area as it does on Mac OS.
+
+This class is a temporary solution to this issue on Win32.
+'''
+
+__author__ = 'jiakuanwang'
+
+from PyQt4 import QtCore
+from PyQt4 import QtGui
+
+from nxdrive.logging_config import get_logger
+from nxdrive.gui.resources import find_icon
+from nxdrive.gui.application import Communicator
+
+log = get_logger(__name__)
+
+class Win32MsgApplication(QtGui.QApplication):
+    def __init__(self, controller, argv=()):
+        super(Win32MsgApplication, self).__init__(list(argv))
+        self.controller = controller
+
+        self._setup_systray()
+        self._create_systray_menu()
+
+        self.communicator = Communicator()
+        self.communicator.stop.connect(self.quit)
+
+        # Register frontend into the controller so that user message can be
+        # notified inside the controller. For more information, please see
+        # https://jira.nuxeo.com/browse/SUPNXP-9065
+        self.controller.register_frontend(self)
+
+        # Shutdown the app after 10 seconds
+
+    def notify_user_message(self, msg_title, msg_body):
+        if msg_title is not None and msg_body is not None:
+            self._tray_icon.showMessage(msg_title, msg_body)
+        else:
+            log.error("Both message title and message body cannot be empty")
+
+    def _setup_systray(self):
+        self._tray_icon = QtGui.QSystemTrayIcon()
+        self.update_running_icon()
+        self._tray_icon.show()
+
+    def _create_systray_menu(self):
+        tray_icon_menu = QtGui.QMenu()
+        quit_action = QtGui.QAction("&Quit Editor Launcher", tray_icon_menu,
+                                    triggered=self.quit)
+        tray_icon_menu.addAction(quit_action)
+        self._tray_icon.setContextMenu(tray_icon_menu)
+
+    def update_running_icon(self):
+        icon = find_icon('nuxeo_drive_systray_icon_%s_18.png' % 'enabled')
+        if icon is not None:
+            self._tray_icon.setIcon(QtGui.QIcon(icon))
+        else:
+            log.warning('Icon not found: %s', icon)
+
+    def stop(self):
+        log.debug('Stopping win32 message application...')
+        self.communicator.stop.emit()

--- a/nuxeo-drive-server/nuxeo-drive-core/pom.xml
+++ b/nuxeo-drive-server/nuxeo-drive-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.nuxeo.ecm</groupId>
     <artifactId>nuxeo-drive-server</artifactId>
-    <version>5.7.3-SNAPSHOT</version>
+    <version>5.7.3</version>
   </parent>
   <groupId>org.nuxeo.ecm</groupId>
   <artifactId>nuxeo-drive-core</artifactId>

--- a/nuxeo-drive-server/nuxeo-drive-hierarchy-permission/pom.xml
+++ b/nuxeo-drive-server/nuxeo-drive-hierarchy-permission/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.nuxeo.ecm</groupId>
     <artifactId>nuxeo-drive-server</artifactId>
-    <version>5.7.3-SNAPSHOT</version>
+    <version>5.7.3</version>
   </parent>
   <groupId>org.nuxeo.ecm</groupId>
   <artifactId>nuxeo-drive-hierarchy-permission</artifactId>

--- a/nuxeo-drive-server/nuxeo-drive-jsf/pom.xml
+++ b/nuxeo-drive-server/nuxeo-drive-jsf/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.nuxeo.ecm</groupId>
     <artifactId>nuxeo-drive-server</artifactId>
-    <version>5.7.3-SNAPSHOT</version>
+    <version>5.7.3</version>
   </parent>
 
   <groupId>org.nuxeo.ecm</groupId>

--- a/nuxeo-drive-server/nuxeo-drive-operations/pom.xml
+++ b/nuxeo-drive-server/nuxeo-drive-operations/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.nuxeo.ecm</groupId>
     <artifactId>nuxeo-drive-server</artifactId>
-    <version>5.7.3-SNAPSHOT</version>
+    <version>5.7.3</version>
   </parent>
 
   <groupId>org.nuxeo.ecm</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.nuxeo</groupId>
     <artifactId>nuxeo-addons-parent</artifactId>
-    <version>5.7.3-SNAPSHOT</version>
+    <version>5.7.3</version>
   </parent>
 
   <groupId>org.nuxeo.ecm</groupId>


### PR DESCRIPTION
For this ticket https://jira.nuxeo.com/browse/SUPNXP-9065, I implemented a temporary fix for both Mac and Windows, and I manually tested on Mac OS X 10.8 and Windows 7 VM. Please see the screenshots attached.

![screen shot 2013-11-22 at 12 45 23 pm](https://f.cloud.github.com/assets/533236/1598567/7a7b805c-5336-11e3-843b-19de9009fca7.png)
![screen shot 2013-11-22 at 12 58 55 pm](https://f.cloud.github.com/assets/533236/1598568/7a7ee922-5336-11e3-97eb-43a441f94993.png)

I created a new branch, named 'SUPNXP-9065', based on the 'release-5.7.3' tag. (I tried to work with the latest master branch, but got some issues and just didn't bother to investigate that issues, so just worked with 5.7.3 source code).

Please note that, on win32 platform, when a separate ndrivew.exe process is launched by a 'edit' command, which is triggered by a user clicking on a custom URL 'nxdrive://...', the QApplication object is not initialized at all, so no system tray is initialised for this process. Therefore, it's not able to show message in system tray area as it does on Mac OS. I then implemented a temporary solution to launch a minimum app to show the message, and then quit automatically after about 10 seconds. Please let me know if there are any better solutions! If launching a temporary message app is an acceptable solution, then perhaps we can use a slightly different icon in system tray, like a 'nuxeo editor' icon.
