### PR TITLE
NXDRIVE-227: close manager.db near the end of uninstallation so manager....

### DIFF
--- a/nuxeo-drive-client/nxdrive/commandline.py
+++ b/nuxeo-drive-client/nxdrive/commandline.py
@@ -438,6 +438,7 @@ class CliHandler(object):
             self.manager.get_osi().uninstall()
             # Remove all token first
             self.manager.unbind_all()
+            self.manager.dispose_db()
             import shutil
             shutil.rmtree(self.manager.nxdrive_home)
         except Exception, e:

--- a/nuxeo-drive-client/nxdrive/manager.py
+++ b/nuxeo-drive-client/nxdrive/manager.py
@@ -830,6 +830,10 @@ class Manager(QtCore.QObject):
         for engine in self._engine_definitions:
             self.unbind_engine(engine.uid)
 
+    def dispose_db(self):
+        if self._dao is not None:
+            self._dao.dispose()
+
     def get_engines(self):
         return self._engines
 


### PR DESCRIPTION
...nxdrive_home can be removed completely.