### PR TITLE
NXDRIVE-356: Fixed pid file check error

### DIFF
--- a/nuxeo-drive-client/nxdrive/utils.py
+++ b/nuxeo-drive-client/nxdrive/utils.py
@@ -428,7 +428,8 @@ class PidLockFile(object):
                     pid = int(f.read().strip())
                     p = psutil.Process(pid)
                     # If process has been created after the lock file
-                    if p.create_time() > os.path.getctime(pid_filepath):
+                    # Changed from getctime() to getmtime() because of Windows' 'file system tunneling'
+                    if p.create_time() > os.path.getmtime(pid_filepath):
                         raise ValueError
                     return pid
                 except (ValueError, psutil.NoSuchProcess):


### PR DESCRIPTION
Windows doesn't change creation time if file is deleted and then created quickly. This may create multiple instances of running nxdrives.