### PR TITLE
NXDRIVE-393: Avoid exception when last_remote_modifier is None

### DIFF
--- a/nuxeo-drive-client/nxdrive/wui/conflicts.py
+++ b/nuxeo-drive-client/nxdrive/wui/conflicts.py
@@ -77,7 +77,8 @@ class WebConflictsApi(WebDriveApi):
         if state is None:
             return None
         result = super(WebConflictsApi, self)._export_state(state)
-        result["last_contributor"] = self._engine.get_user_full_name(state.last_remote_modifier)
+        result["last_contributor"] = " " if state.last_remote_modifier is None \
+                                        else self._engine.get_user_full_name(state.last_remote_modifier)
         date_time = self.get_date_from_sqlite(state.last_remote_updated)
         result["last_remote_update"] = "" if date_time == 0 else Translator.format_datetime(date_time)
         date_time = self.get_date_from_sqlite(state.last_local_updated)


### PR DESCRIPTION
When sync fails for locally_created documents the last_remote_modifier is None. So the call ``self._engine.get_user_full_name(state.last_remote_modifier)`` will raise exception. This will result in empty conflict/error window.