### PR TITLE
NXDRIVE-438: Update set proxy to return string

### DIFF
--- a/nuxeo-drive-client/nxdrive/manager.py
+++ b/nuxeo-drive-client/nxdrive/manager.py
@@ -763,6 +763,7 @@ class Manager(QtCore.QObject):
         proxy_settings.save(self._dao)
         self.refresh_proxies(proxy_settings)
         log.info("Proxy settings successfully updated: %r", proxy_settings)
+        return ""
 
     def refresh_proxies(self, proxy_settings=None, device_config=None):
         """Refresh current proxies with the given settings"""

--- a/nuxeo-drive-client/nxdrive/wui/settings.py
+++ b/nuxeo-drive-client/nxdrive/wui/settings.py
@@ -320,7 +320,7 @@ class WebSettingsApi(WebDriveApi):
             settings.authenticated = "true" == authenticated
             settings.username = str(username)
             settings.password = str(password)
-            self._manager.set_proxy_settings(settings)
+            return self._manager.set_proxy_settings(settings)
         except Exception as e:
             log.exception(e)
         return ""


### PR DESCRIPTION
@loopingz 
Bonjour,
I have updated the code to return a value from ```set_proxy_settings``` under settings.py. And I have overriden the same method under ```CPOManager``` class to validate the proxy, which handles the result that the UI projects to the user. So inorder to return the value(Valid or Invalid) I had to change this part.

CPO side code changes have been already made. 
https://github.com/nuxeo/sharp-cpo-clients/pull/154
