### PR TITLE
PR/9203 use correct app version

### DIFF
--- a/nuxeo-drive-client/nxdrive/commandline.py
+++ b/nuxeo-drive-client/nxdrive/commandline.py
@@ -474,6 +474,7 @@ class CliHandler(object):
 
     def get_manager(self, options):
         from nxdrive.manager import Manager
+        setattr(options, 'version', __version__)
         return Manager(options)
 
     def _get_application(self, options, console=False):

--- a/nuxeo-drive-client/nxdrive/manager.py
+++ b/nuxeo-drive-client/nxdrive/manager.py
@@ -18,7 +18,6 @@ from nxdrive.utils import normalized_path
 from nxdrive.updater import AppUpdater
 from nxdrive.osi import AbstractOSIntegration
 from nxdrive.commandline import DEFAULT_UPDATE_SITE_URL
-from nxdrive import __version__
 from nxdrive.utils import ENCODING, OSX_SUFFIX
 
 log = get_logger(__name__)
@@ -223,7 +222,7 @@ class Manager(QtCore.QObject):
         else:
             log.info("--consider-ssl-errors option is True, will verify HTTPS certificates")
         self._autolock_service = None
-        self.client_version = __version__
+        self.client_version = options.version
         self.nxdrive_home = os.path.expanduser(options.nxdrive_home)
         self.nxdrive_home = os.path.realpath(self.nxdrive_home)
         if not os.path.exists(self.nxdrive_home):

--- a/nuxeo-drive-client/nxdrive/tests/common_unit_test.py
+++ b/nuxeo-drive-client/nxdrive/tests/common_unit_test.py
@@ -247,8 +247,10 @@ class UnitTestCase(unittest.TestCase):
         options.beta_update_site_url = None
         options.autolock_interval = 30
         options.nxdrive_home = self.nxdrive_conf_folder_1
+        options.version == __version__
         self.manager_1 = Manager(options)
         self.connected = False
+        self.version = self.manager_1.get_version()
         import nxdrive
         nxdrive_path = os.path.dirname(nxdrive.__file__)
         i18n_path = os.path.join(nxdrive_path, 'tests', 'resources', "i18n.js")
@@ -256,7 +258,6 @@ class UnitTestCase(unittest.TestCase):
         options.nxdrive_home = self.nxdrive_conf_folder_2
         Manager._singleton = None
         self.manager_2 = Manager(options)
-        self.version = __version__
         url = self.nuxeo_url
         log.debug("Will use %s as url", url)
         if '#' in url:


### PR DESCRIPTION
When base_automation_client communicates with the server, it gets its client_version (which constitutes the version part of the "User-Agent") from its creator, which is the Manager.   
The manager gets its version from the __init__.py of the root package.  
In DesktopSync, CPOManager inherits from the Nuxeo Manager, and has its own version in the __init__.py files under tits respective root package.

Sometimes the server is contacted before the CPOManager has a chance to set up the version.   
These calls uses Nuxeo version:
class CPOManager(Manager):
    def __init__(self, options):
        super(CPOManager, self).__init__(options)  <== server is contacted in the init process
        ...
        self.client_version = __version__
But subsequently all requests should use the CPOManager's version.

However, as observed in the field, some clients from the same build seems to send out different versions for the same server call.   
This change initializes the "manager" with a version provided at app launching (from commandline.py).