### PR TITLE
PR/9001 changes to blacklist

### DIFF
--- a/nuxeo-drive-client/nxdrive/engine/blacklist_queue.py
+++ b/nuxeo-drive-client/nxdrive/engine/blacklist_queue.py
@@ -2,15 +2,23 @@
 Created on 1 juil. 2015
 
 @author: Remi Cattiau
+
+Updated on Feb 17, 2016
+
+@author: Michael Constantin
 '''
+
 from __future__ import division
-from threading import Lock
+from threading import RLock
 import time
 import random
 import math
-
+import pprint
+from nxdrive.logging_config import get_logger
 
 OFFSET_PERCENT = 20
+
+log = get_logger(__name__)
 
 
 class BlacklistItem(object):
@@ -22,7 +30,7 @@ class BlacklistItem(object):
         self._item_id = item_id
         self._interval = next_try
         # add a random number between -20% and +20% of the next_try value
-        limit = int(math.ceil(next_try * OFFSET_PERCENT/ 100))
+        limit = int(math.ceil(next_try * OFFSET_PERCENT / 100))
         offset = random.randint(-limit, limit)
         self._next_interval = next_try + offset
         self._next_try = self._next_interval + int(time.time())
@@ -40,23 +48,27 @@ class BlacklistItem(object):
 
     def increase(self, next_try=None):
         cur_time = int(time.time())
+        self._count += 1
         if next_try is not None:
             self._next_try = next_try + cur_time
         else:
-            next_interval = self._interval * 2 ** self._count
-            self._count += 1
+            next_interval = self._interval * 2 ** (self._count - 1)
             # add a random number between -20% and +20% of the next_try value
             limit = int(math.ceil(next_interval * OFFSET_PERCENT/ 100))
             offset = random.randint(-limit, limit)
             self._next_interval = next_interval + offset
             self._next_try = self._next_interval + cur_time
 
+    def __repr__(self):
+        return 'id={}\nitem={}\ncount={}\ninterval={}\nnext interval={}'\
+            .format(self._item_id, self._item, self._count, self._interval, self._next_interval)
+
 
 class BlacklistQueue(object):
 
     def __init__(self, delay=30):
         self._queue = dict()
-        self._lock = Lock()
+        self._lock = RLock()
         self._delay = delay
 
     def push(self, id_obj, obj):
@@ -78,8 +90,20 @@ class BlacklistQueue(object):
         self._lock.acquire()
         try:
             self._queue[item.get_id()] = item
+            return item._next_interval
         finally:
             self._lock.release()
+
+    def repush_by_id(self, item_id, increase_wait=True):
+        item = None
+        self._lock.acquire()
+        try:
+            item = self._queue[item_id]
+        finally:
+            self._lock.release()
+
+        if item is not None:
+            return self.repush(item, increase_wait=increase_wait)
 
     def get(self):
         cur_time = int(time.time())
@@ -92,6 +116,24 @@ class BlacklistQueue(object):
         finally:
             self._lock.release()
 
+    def process_items(self, remove=False):
+        cur_time = int(time.time())
+        self._lock.acquire()
+        try:
+            for item in self._queue.values():
+                if item.check(cur_time=cur_time):
+                    if remove:
+                        del self._queue[item.get_id()]
+                    yield item
+        finally:
+            self._lock.release()
+
+    def remove(self, item_id):
+        try:
+            del self._queue[item_id]
+        except KeyError:
+            pass
+
     def is_empty(self):
         self._lock.acquire()
         try:
@@ -102,7 +144,9 @@ class BlacklistQueue(object):
     def exists(self, item_id):
         self._lock.acquire()
         try:
-            return self._queue.has_key(item_id)
+            result = item_id in self._queue
+            log.debug('key %s is%s in the queue', item_id, '' if result else ' not')
+            return result
         finally:
             self._lock.release()
 
@@ -119,3 +163,6 @@ class BlacklistQueue(object):
             return self._queue.values()
         finally:
             self._lock.release()
+
+    def __repr__(self):
+        return 'delay={}\nqueue={}'.format(self._delay, pprint.pformat(self._queue, indent=2))

--- a/nuxeo-drive-client/nxdrive/engine/blacklist_queue.py
+++ b/nuxeo-drive-client/nxdrive/engine/blacklist_queue.py
@@ -3,8 +3,14 @@ Created on 1 juil. 2015
 
 @author: Remi Cattiau
 '''
+from __future__ import division
 from threading import Lock
 import time
+import random
+import math
+
+
+OFFSET_PERCENT = 20
 
 
 class BlacklistItem(object):
@@ -15,7 +21,11 @@ class BlacklistItem(object):
         self._item = item
         self._item_id = item_id
         self._interval = next_try
-        self._next_try = next_try + int(time.time())
+        # add a random number between -20% and +20% of the next_try value
+        limit = int(math.ceil(next_try * OFFSET_PERCENT/ 100))
+        offset = random.randint(-limit, limit)
+        self._next_interval = next_try + offset
+        self._next_try = self._next_interval + int(time.time())
 
     def check(self, cur_time=None):
         if cur_time is None:
@@ -30,11 +40,16 @@ class BlacklistItem(object):
 
     def increase(self, next_try=None):
         cur_time = int(time.time())
-        self._count = self._count + 1
         if next_try is not None:
             self._next_try = next_try + cur_time
         else:
-            self._next_try = self._count * self._interval + cur_time
+            next_interval = self._interval * 2 ** self._count
+            self._count += 1
+            # add a random number between -20% and +20% of the next_try value
+            limit = int(math.ceil(next_interval * OFFSET_PERCENT/ 100))
+            offset = random.randint(-limit, limit)
+            self._next_interval = next_interval + offset
+            self._next_try = self._next_interval + cur_time
 
 
 class BlacklistQueue(object):
@@ -49,6 +64,7 @@ class BlacklistQueue(object):
         self._lock.acquire()
         try:
             self._queue[item.get_id()] = item
+            return item._next_interval
         finally:
             self._lock.release()
 
@@ -73,5 +89,33 @@ class BlacklistQueue(object):
                 if item.check(cur_time=cur_time):
                     del self._queue[item.get_id()]
                     return item
+        finally:
+            self._lock.release()
+
+    def is_empty(self):
+        self._lock.acquire()
+        try:
+            return not self._queue
+        finally:
+            self._lock.release()
+
+    def exists(self, item_id):
+        self._lock.acquire()
+        try:
+            return self._queue.has_key(item_id)
+        finally:
+            self._lock.release()
+
+    def size(self):
+        self._lock.acquire()
+        try:
+            return len(self._queue)
+        finally:
+            self._lock.release()
+
+    def items(self):
+        self._lock.acquire()
+        try:
+            return self._queue.values()
         finally:
             self._lock.release()

--- a/nuxeo-drive-client/nxdrive/engine/dao/sqlite.py
+++ b/nuxeo-drive-client/nxdrive/engine/dao/sqlite.py
@@ -815,7 +815,7 @@ class EngineDAO(ConfigurationDAO):
     def get_conflict_count(self):
         return self.get_count("pair_state='conflicted'")
 
-    def get_error_count(self, threshold=3):
+    def get_error_count(self, threshold=15):
         return self.get_count("error_count > " + str(threshold))
 
     def get_syncing_count(self, threshold=3):

--- a/nuxeo-drive-client/nxdrive/engine/dao/sqlite.py
+++ b/nuxeo-drive-client/nxdrive/engine/dao/sqlite.py
@@ -815,7 +815,7 @@ class EngineDAO(ConfigurationDAO):
     def get_conflict_count(self):
         return self.get_count("pair_state='conflicted'")
 
-    def get_error_count(self, threshold=15):
+    def get_error_count(self, threshold=16):
         return self.get_count("error_count > " + str(threshold))
 
     def get_syncing_count(self, threshold=3):

--- a/nuxeo-drive-client/nxdrive/tests/test_blacklist_queue.py
+++ b/nuxeo-drive-client/nxdrive/tests/test_blacklist_queue.py
@@ -6,21 +6,26 @@ Created on 2 juil. 2015
 import unittest
 from nxdrive.engine.blacklist_queue import BlacklistQueue
 from time import sleep
+from nxdrive.tests.common_unit_test import log
 
 
 class BlacklistQueueTest(unittest.TestCase):
 
-    def testDelay(self):
+    def test_delay(self):
         sleep_time = 3
         # Push two items with a delay of 1s
         queue = BlacklistQueue(delay=1)
-        queue.push(1, "Item1")
-        queue.push(2, "Item2")
+        interval1 = queue.push(1, "Item1")
+        interval2 = queue.push(2, "Item2")
+        log.debug('interval1=%d', interval1)
+        log.debug('interval2=%d', interval2)
+        log.debug('queue:\n%s', str(queue))
+
         # Verify no item is returned back before 1s
         item = queue.get()
         self.assertIsNone(item)
         sleep(sleep_time)
-        # Verfiy we get the two items now
+        # Verify we get the two items now
         item = queue.get()
         self.assertIsNotNone(item)
         self.assertEquals(item.get(), "Item1")
@@ -41,16 +46,101 @@ class BlacklistQueueTest(unittest.TestCase):
         self.assertEquals(item.get(), "Item2")
         self.assertEquals(item.get_id(), 2)
         self.assertEquals(item._count, 2)
+
         # Repush item with increase
-        queue.repush(item, increase_wait=True)
-        sleep(sleep_time)
+        interval3 = queue.push(3, "Item3")
+        log.debug('interval3=%d', interval3)
         item = queue.get()
         self.assertIsNone(item)
         sleep(sleep_time)
+        # Verify we get the item now
         item = queue.get()
         self.assertIsNotNone(item)
-        self.assertEquals(item.get(), "Item2")
-        self.assertEquals(item.get_id(), 2)
-        self.assertEquals(item._count, 3)
-        item = queue.get()
-        self.assertIsNone(item)
+        self.assertEquals(item.get(), "Item3")
+        self.assertEquals(item.get_id(), 3)
+        log.debug('queue:\n%s', str(queue))
+
+        for i in range(1, 3):
+            queue.repush(item, increase_wait=True)
+            log.debug('item after repush:\n%s', str(item))
+            log.debug('queue after repush:\n%s', str(queue))
+            # sleep time should be at least 2 ** i + 20%
+            min_sleep_time = int(0.8 * 2 ** i) - 1
+            max_sleep_time = int(1.2 * 2 ** i) + 2
+            if min_sleep_time < 0:
+                min_sleep_time = 0
+
+            log.debug('min sleep time=%d', min_sleep_time)
+            log.debug('max sleep time=%d', max_sleep_time)
+            if min_sleep_time > 0:
+                log.debug('sleep %d', min_sleep_time)
+                sleep(min_sleep_time)
+                max_sleep_time -= min_sleep_time
+            item = queue.get()
+            self.assertIsNone(item)
+            log.debug('sleep %d', max_sleep_time)
+            sleep(max_sleep_time)
+            item = queue.get()
+            self.assertIsNotNone(item)
+            self.assertEquals(item.get(), "Item3")
+            self.assertEquals(item.get_id(), 3)
+            self.assertEquals(item._count, i + 1)
+
+    def test_looping(self):
+        # Push several items with a delay of 1s
+        queue = BlacklistQueue(delay=1)
+        queue.push(1, "Item1")
+        queue.push(2, "Item2")
+        queue.push(3, "Item3")
+        queue.push(4, "Item4")
+        queue.push(5, "Item5")
+        queue.push(6, "Item6")
+        queue.push(7, "Item7")
+        log.debug('queue:\n%s', str(queue))
+
+        count = 0
+        for item in queue.process_items():
+            if item:
+                log.debug('item: %s', item.get_id())
+                count += 1
+
+        self.assertEqual(queue.size(), 7, "queue size has changed")
+        self.assertEqual(count, 0, "no item should have been ready for processing")
+
+        sleep_time = 3
+        sleep(sleep_time)
+        for item in queue.process_items():
+            if item:
+                log.debug('item: %s', item.get_id())
+                count += 1
+                queue.repush(item)
+
+        self.assertEqual(queue.size(), 7, "queue size has changed")
+        self.assertEqual(count, 7, "all items should have been ready for processing")
+
+        log.debug('queue:\n%s', str(queue))
+        count = 0
+        for item in queue.process_items():
+            if item:
+                log.debug('item: %s', item.get_id())
+                count += 1
+
+        self.assertEqual(queue.size(), 7, "queue size has changed")
+        self.assertEqual(count, 0, "no item should have been ready for processing after repush")
+
+        sleep_time = 4
+        sleep(sleep_time)
+        log.debug('queue:\n%s', str(queue))
+        count = 0
+        for item in queue.process_items():
+            if item:
+                log.debug('item: %s', item.get_id())
+                count += 1
+
+        self.assertEqual(queue.size(), 7, "queue size has changed")
+        self.assertEqual(count, 7, "all items should have been ready for processing after repush")
+
+        for item in queue.process_items(remove=True):
+            log.debug('item: %s', item.get_id())
+
+        self.assertTrue(queue.is_empty(), 'queue is not empty')

--- a/nuxeo-drive-client/nxdrive/tests/test_blacklist_queue.py
+++ b/nuxeo-drive-client/nxdrive/tests/test_blacklist_queue.py
@@ -137,10 +137,5 @@ class BlacklistQueueTest(unittest.TestCase):
                 log.debug('item: %s', item.get_id())
                 count += 1
 
-        self.assertEqual(queue.size(), 7, "queue size has changed")
-        self.assertEqual(count, 7, "all items should have been ready for processing after repush")
-
-        for item in queue.process_items(remove=True):
-            log.debug('item: %s', item.get_id())
-
         self.assertTrue(queue.is_empty(), 'queue is not empty')
+        self.assertEqual(count, 7, "all items should have been ready for processing after repush")


### PR DESCRIPTION
If the server is too busy to respond and DS gets an error (e.g. 500, or 429/503 with the recent throttling mechanism using nginx), it give up after 3 tries in relative quick succession..  
A common thread is that customers see correct folders/files in DM after DS uploads but then a second DS client on same folder (or share the same folder) doesn’t get the update, from DM.  
- What happens if missing the event to update for the second DS client? 
- Is DM not including in changelist?
- Is DS not processing changelist due to server response timeout or error?
- Does DS recover by trying later or is the change lost forever?

This change increases the number of attempts to 15, using an "exponential back off" scheme (which extends the retry period to ~3d).
