### PR TITLE
PR/8671-handle-remote-scan-exceptions

### DIFF
--- a/nuxeo-drive-client/nxdrive/engine/dao/sqlite.py
+++ b/nuxeo-drive-client/nxdrive/engine/dao/sqlite.py
@@ -1041,6 +1041,8 @@ class EngineDAO(ConfigurationDAO):
             if (parent is None and local_parent_path == '') or (parent is not None and parent.pair_state != "remotely_created"):
                 self._queue_pair_state(row_id, info.folderish, pair_state)
             self._items_count = self._items_count + 1
+        except sqlite3.IntegrityError:
+            pass
         finally:
             self._lock.release()
         return row_id
@@ -1239,6 +1241,8 @@ class EngineDAO(ConfigurationDAO):
                 # Parent can be None if the parent is filtered
                 if (parent is not None and parent.pair_state != "remotely_created") or parent is None:
                     self._queue_pair_state(row.id, info.folderish, pair_state)
+        except sqlite3.IntegrityError:
+            pass
         finally:
             self._lock.release()
 


### PR DESCRIPTION
Remote scan would restart from the beginning when IntegrityError exceptions are thrown. With many files this could happen many times. 
Handle the IntegrityError exceptions in insert_remote_state and update_remote_state methods.