### PR TITLE
PR/SUPNXP-15494-add-test-for-not-all-files-uploads-sync

### DIFF
--- a/nuxeo-drive-client/nxdrive/tests/common_unit_test.py
+++ b/nuxeo-drive-client/nxdrive/tests/common_unit_test.py
@@ -149,7 +149,7 @@ class UnitTestCase(unittest.TestCase):
         self.root_remote_client = RemoteDocumentClient(
             self.nuxeo_url, self.admin_user,
             u'nxdrive-test-administrator-device', self.version,
-            password=self.password, base_folder=u'/', timeout=60)
+            password=self.admin_password, base_folder=u'/', timeout=60)
 
         # Activate given profile if needed, eg. permission hierarchy
         if server_profile is not None:
@@ -189,13 +189,17 @@ class UnitTestCase(unittest.TestCase):
         if AbstractOSIntegration.is_windows():
             from nxdrive.tests.win_local_client import WindowsLocalClient
             return WindowsLocalClient(path)
-        return LocalClient(path)
+        elif AbstractOSIntegration.is_mac():
+            from nxdrive.tests.mac_local_client import MacLocalClient
+            return MacLocalClient(path)
+        else:
+            return LocalClient(path)
 
     def setUpApp(self, server_profile=None):
         # Check the Nuxeo server test environment
         self.nuxeo_url = os.environ.get('NXDRIVE_TEST_NUXEO_URL')
         self.admin_user = os.environ.get('NXDRIVE_TEST_USER')
-        self.password = os.environ.get('NXDRIVE_TEST_PASSWORD')
+        self.admin_password = os.environ.get('NXDRIVE_TEST_PASSWORD')
         self.build_workspace = os.environ.get('WORKSPACE')
         self.result = None
         self.tearedDown = False
@@ -205,8 +209,8 @@ class UnitTestCase(unittest.TestCase):
             self.nuxeo_url = "http://localhost:8080/nuxeo"
         if self.admin_user is None:
             self.admin_user = "Administrator"
-        if self.password is None:
-            self.password = "Administrator"
+        if self.admin_password is None:
+            self.admin_password = "Administrator"
         self.tmpdir = None
         if self.build_workspace is not None:
             self.tmpdir = os.path.join(self.build_workspace, "tmp")
@@ -214,7 +218,7 @@ class UnitTestCase(unittest.TestCase):
                 os.makedirs(self.tmpdir)
         self.upload_tmp_dir = tempfile.mkdtemp(u'-nxdrive-uploads', dir=self.tmpdir)
 
-        if None in (self.nuxeo_url, self.admin_user, self.password):
+        if None in (self.nuxeo_url, self.admin_user, self.admin_password):
             raise unittest.SkipTest(
                 "No integration server configuration found in environment.")
 

--- a/nuxeo-drive-client/nxdrive/tests/mac_local_client.py
+++ b/nuxeo-drive-client/nxdrive/tests/mac_local_client.py
@@ -7,6 +7,7 @@ Using SHFileOperation as the MSDN advise to use it for multithread
 IFileOperation can only be applied in a single-threaded apartment (STA) situation. It cannot be used for a multithreaded apartment (MTA) situation. For MTA, you still must use SHFileOperation.
 '''
 from nxdrive.client.local_client import LocalClient
+from common import log
 
 import os
 import sys
@@ -15,83 +16,133 @@ if sys.platform == 'darwin':
 
 
 class MacLocalClient(LocalClient):
-       def __init__(self, base_folder, digest_func='md5', ignored_prefixes=None,
-                        ignored_suffixes=None, check_suspended=None, case_sensitive=None, disable_duplication=False):
-            super(MacLocalClient, self).__init__(base_folder, digest_func, ignored_prefixes, ignored_suffixes,
-                                                 check_suspended, case_sensitive, disable_duplication)
-            self.fm = Cocoa.NSFileManager.defaultManager()
+    def __init__(self, base_folder, digest_func='md5', ignored_prefixes=None,
+                    ignored_suffixes=None, check_suspended=None, case_sensitive=None, disable_duplication=False):
+        super(MacLocalClient, self).__init__(base_folder, digest_func, ignored_prefixes, ignored_suffixes,
+                                             check_suspended, case_sensitive, disable_duplication)
+        self.fm = Cocoa.NSFileManager.defaultManager()
 
-        '''
-        Copy either a file, or an entire directory at relative (to the local client's base_folder) path 'srcref'
-        to the relative path 'dstref'.
-        If the 'srcref' is a file and 'dstref' is a file, it means it rename the source file or the new name (in the 'dstref').
-        If the 'srcref' is a directory and 'dstref' is a directory, it copies the directory and its content with the same name,
-        under the 'dstref'.
-        If the 'srcref' is a file and 'dstref' is a directory, it copies the file with the same name under the 'dstref'.
-        '''
-        def copy(self, srcref, dstref):
-            if os.path.exists(srcref):
-                src = srcref
-            else:
-                src = self._abspath(srcref)
-            if os.path.exists(dstref):
-                dst = dstref
-            else:
-                dst = self._abspath(dstref)
-            path, name = os.path.split(src)
-            if not os.path.exists(dst) and not os.path.exists(os.path.dirname(dst)):
-                raise ValueError('parent destination directory %s does not exist', os.path.dirname(dst))
-            if os.path.isdir(src) and os.path.exists(dst) and os.path.isfile(dst):
-                raise ValueError('cannnot copy directory %s to a file %s', src, dst)
-            if os.path.exists(dst) and os.path.isdir(dst):
-                dst = os.path.join(dst, name)
+    '''
+    Copy either a file, or an entire directory at relative (to the local client's base_folder) path 'srcref'
+    to the relative path 'dstref'.
+    If the 'srcref' is a file and 'dstref' is a file, it means it rename the source file or the new name (in the 'dstref').
+    If the 'srcref' is a directory and 'dstref' is a directory, it copies the directory and its content with the same name,
+    under the 'dstref'.
+    If the 'srcref' is a file and 'dstref' is a directory, it copies the file with the same name under the 'dstref'.
+    '''
+    def copy(self, srcref, dstref):
+        if os.path.exists(srcref):
+            src = srcref
+        else:
+            src = self._abspath(srcref)
+        if os.path.exists(dstref):
+            dst = dstref
+        else:
+            dst = self._abspath(dstref)
+        path, name = os.path.split(src)
+        if not os.path.exists(dst) and not os.path.exists(os.path.dirname(dst)):
+            raise ValueError('parent destination directory %s does not exist', os.path.dirname(dst))
+        if os.path.isdir(src) and os.path.exists(dst) and os.path.isfile(dst):
+            raise ValueError('cannnot copy directory %s to a file %s', src, dst)
+        if os.path.exists(dst) and os.path.isdir(dst):
+            dst = os.path.join(dst, name)
 
-            error = None
-            result = self.fm.copyItemAtPath_toPath_error_(src, dst, error)
-            self._process_result(result)
+        error = None
+        result = self.fm.copyItemAtPath_toPath_error_(src, dst, error)
+        self._process_result(result)
 
-        def move(self, srcref, parentref, name=None):
-            if os.path.exists(srcref):
-                src = srcref
-            else:
-                src = self._abspath(srcref)
-            if os.path.exists(parentref):
-                parent = parentref
-            else:
-                parent = self._abspath(parentref)
-            path, srcname = os.path.split(src)
-            if not os.path.exists(parent):
-                raise ValueError('parent destination directory %s does not exist', parent)
+    def move(self, srcref, parentref, name=None):
+        if os.path.exists(srcref):
+            src = srcref
+        else:
+            src = self._abspath(srcref)
+        if os.path.exists(parentref):
+            parent = parentref
+        else:
+            parent = self._abspath(parentref)
+        path, srcname = os.path.split(src)
+        if not os.path.exists(parent):
+            raise ValueError('parent destination directory %s does not exist', parent)
 
-            if name:
-                srcname = name
-            dst = os.path.join(parent, srcname)
+        if name:
+            srcname = name
+        dst = os.path.join(parent, srcname)
 
-            error = None
-            result = self.fm.moveItemAtPath_toPath_error_(src, dst, error)
-            self._process_result(result)
+        error = None
+        result = self.fm.moveItemAtPath_toPath_error_(src, dst, error)
+        self._process_result(result)
 
-        def duplicate_file(self, srcref):
-            parent = os.path.dirname(srcref)
-            name = os.path.basename(srcref)
-            os_path, name = self._abspath_deduped(parent, name)
-            dstref = os.path.join(parent, name)
-            self.copy(srcref, dstref)
-            return dstref
+    def duplicate_file(self, srcref):
+        parent = os.path.dirname(srcref)
+        name = os.path.basename(srcref)
+        os_path, name = self._abspath_deduped(parent, name)
+        dstref = os.path.join(parent, name)
+        self.copy(srcref, dstref)
+        return dstref
 
-        def rename(self, srcref, to_name):
-            parent = os.path.dirname(srcref)
-            dstref = os.path.join(parent, name)
-            self.move(srcref, dstref)
+    def rename(self, srcref, to_name):
+        parent = os.path.dirname(srcref)
+        name = os.path.basename(srcref)
+        dstref = os.path.join(parent, name)
+        self.move(srcref, dstref)
 
-        def delete(self, ref):
-            path = self._abspath(ref)
-            error = None
-            result = self.fm.removeItemAtPath_error_(path, error)
-            self._process_result(result)
+    def delete(self, ref):
+        path = self._abspath(ref)
+        error = None
+        result = self.fm.removeItemAtPath_error_(path, error)
+        self._process_result(result)
 
-        def _process_result(self, result):
-            log.debug('result: %s%s', 'ok' if result[0] else 'error (', '' if result[0] else result[1] + ')')
-            if not result[0]:
-                raise IOError(result[1])
+    def _process_result(self, result):
+        log.debug('result: %s%s', 'ok' if result[0] else 'error (', '' if result[0] else result[1] + ')')
+        if not result[0]:
+            raise IOError(result[1])
 
+
+class MacFileManagerUtils(object):
+    fm = Cocoa.NSFileManager.defaultManager()
+
+    @staticmethod
+    def copy(cls, src, dst):
+        path, name = os.path.split(src)
+        if not os.path.exists(dst) and not os.path.exists(os.path.dirname(dst)):
+            raise ValueError('parent destination directory %s does not exist', os.path.dirname(dst))
+        if os.path.isdir(src) and os.path.exists(dst) and os.path.isfile(dst):
+            raise ValueError('cannnot copy directory %s to a file %s', src, dst)
+        if os.path.exists(dst) and os.path.isdir(dst):
+            dst = os.path.join(dst, name)
+
+        error = None
+        result = cls.fm.copyItemAtPath_toPath_error_(src, dst, error)
+        cls._process_result(cls, result)
+
+    @staticmethod
+    def move(cls, src, parent, name=None):
+        path, srcname = os.path.split(src)
+        if not os.path.exists(parent):
+            raise ValueError('parent destination directory %s does not exist', parent)
+
+        if name:
+            srcname = name
+        dst = os.path.join(parent, srcname)
+
+        error = None
+        result = cls.fm.moveItemAtPath_toPath_error_(src, dst, error)
+        cls._process_result(cls, result)
+
+    @staticmethod
+    def rename(cls, src, to_name):
+        parent = os.path.dirname(src)
+        dst = os.path.join(parent, to_name)
+        cls.move(cls, src, dst)
+
+    @staticmethod
+    def delete(cls, path):
+        error = None
+        result = cls.fm.removeItemAtPath_error_(path, error)
+        cls._process_result(cls, result)
+
+    @staticmethod
+    def _process_result(cls, result):
+        log.debug('result: %s%s', 'ok' if result[0] else 'error (', '' if result[0] else str(result[1]) + ')')
+        if not result[0]:
+            raise IOError(result[1])

--- a/nuxeo-drive-client/nxdrive/tests/mac_local_client.py
+++ b/nuxeo-drive-client/nxdrive/tests/mac_local_client.py
@@ -1,0 +1,97 @@
+'''
+Intent of this file is ...
+
+https://msdn.microsoft.com/en-us/library/windows/desktop/bb775771(v=vs.85).aspx
+Using SHFileOperation as the MSDN advise to use it for multithread
+
+IFileOperation can only be applied in a single-threaded apartment (STA) situation. It cannot be used for a multithreaded apartment (MTA) situation. For MTA, you still must use SHFileOperation.
+'''
+from nxdrive.client.local_client import LocalClient
+
+import os
+import sys
+if sys.platform == 'darwin':
+    import Cocoa
+
+
+class MacLocalClient(LocalClient):
+       def __init__(self, base_folder, digest_func='md5', ignored_prefixes=None,
+                        ignored_suffixes=None, check_suspended=None, case_sensitive=None, disable_duplication=False):
+            super(MacLocalClient, self).__init__(base_folder, digest_func, ignored_prefixes, ignored_suffixes,
+                                                 check_suspended, case_sensitive, disable_duplication)
+            self.fm = Cocoa.NSFileManager.defaultManager()
+
+        '''
+        Copy either a file, or an entire directory at relative (to the local client's base_folder) path 'srcref'
+        to the relative path 'dstref'.
+        If the 'srcref' is a file and 'dstref' is a file, it means it rename the source file or the new name (in the 'dstref').
+        If the 'srcref' is a directory and 'dstref' is a directory, it copies the directory and its content with the same name,
+        under the 'dstref'.
+        If the 'srcref' is a file and 'dstref' is a directory, it copies the file with the same name under the 'dstref'.
+        '''
+        def copy(self, srcref, dstref):
+            if os.path.exists(srcref):
+                src = srcref
+            else:
+                src = self._abspath(srcref)
+            if os.path.exists(dstref):
+                dst = dstref
+            else:
+                dst = self._abspath(dstref)
+            path, name = os.path.split(src)
+            if not os.path.exists(dst) and not os.path.exists(os.path.dirname(dst)):
+                raise ValueError('parent destination directory %s does not exist', os.path.dirname(dst))
+            if os.path.isdir(src) and os.path.exists(dst) and os.path.isfile(dst):
+                raise ValueError('cannnot copy directory %s to a file %s', src, dst)
+            if os.path.exists(dst) and os.path.isdir(dst):
+                dst = os.path.join(dst, name)
+
+            error = None
+            result = self.fm.copyItemAtPath_toPath_error_(src, dst, error)
+            self._process_result(result)
+
+        def move(self, srcref, parentref, name=None):
+            if os.path.exists(srcref):
+                src = srcref
+            else:
+                src = self._abspath(srcref)
+            if os.path.exists(parentref):
+                parent = parentref
+            else:
+                parent = self._abspath(parentref)
+            path, srcname = os.path.split(src)
+            if not os.path.exists(parent):
+                raise ValueError('parent destination directory %s does not exist', parent)
+
+            if name:
+                srcname = name
+            dst = os.path.join(parent, srcname)
+
+            error = None
+            result = self.fm.moveItemAtPath_toPath_error_(src, dst, error)
+            self._process_result(result)
+
+        def duplicate_file(self, srcref):
+            parent = os.path.dirname(srcref)
+            name = os.path.basename(srcref)
+            os_path, name = self._abspath_deduped(parent, name)
+            dstref = os.path.join(parent, name)
+            self.copy(srcref, dstref)
+            return dstref
+
+        def rename(self, srcref, to_name):
+            parent = os.path.dirname(srcref)
+            dstref = os.path.join(parent, name)
+            self.move(srcref, dstref)
+
+        def delete(self, ref):
+            path = self._abspath(ref)
+            error = None
+            result = self.fm.removeItemAtPath_error_(path, error)
+            self._process_result(result)
+
+        def _process_result(self, result):
+            log.debug('result: %s%s', 'ok' if result[0] else 'error (', '' if result[0] else result[1] + ')')
+            if not result[0]:
+                raise IOError(result[1])
+

--- a/nuxeo-drive-client/nxdrive/tests/test_local_move_and_rename.py
+++ b/nuxeo-drive-client/nxdrive/tests/test_local_move_and_rename.py
@@ -523,7 +523,7 @@ class TestLocalMoveAndRename(UnitTestCase):
         remote_client = RemoteDocumentClient(
             self.nuxeo_url, self.admin_user,
             'nxdrive-test-administrator-device', self.version,
-            password=self.password, base_folder=self.workspace)
+            password=self.admin_password, base_folder=self.workspace)
 
         folder_1_uid = remote_client.get_info(u'/Original Folder 1').uid
 

--- a/nuxeo-drive-client/nxdrive/tests/test_upload_100_plus_files.py
+++ b/nuxeo-drive-client/nxdrive/tests/test_upload_100_plus_files.py
@@ -1,0 +1,152 @@
+'''
+Created on Mar 10, 2016
+
+@author: constantinm
+'''
+
+import os
+import sys
+import tempfile
+import shutil
+from functools import partial
+from multiprocessing import Pool
+from unittest import skipIf
+
+from common_unit_test import UnitTestCase
+from common import log
+if sys.platform == 'darwin':
+    from nxdrive.tests.mac_local_client import MacFileManagerUtils
+
+TEST_DIR = 'test_data'
+TEST_ZIP = 'files.zip'
+DEST_DIR = 'folder1'
+
+SUPER_LONG_TIMEOUT = 300
+
+
+def copy(src, dst):
+    MacFileManagerUtils.copy(MacFileManagerUtils, src, dst)
+
+
+def _get_copy_to(dst):
+    return partial(copy, dst=dst)
+
+
+def _get_copy_from(src):
+    return partial(copy, src=src)
+
+
+class TestUpload100PlusFiles(UnitTestCase):
+    MY_DOCS = u'/My Docs'
+    __name__ = 'TestUpload100PlusFiles'
+
+    @classmethod
+    def setUpClass(cls):
+        '''
+        cannot prepare the set of files with xattr here since it requires the infrastructure of
+        engine, manager, clients, etc. to be setup
+        '''
+        root_path = cls._get_root_path()
+        cls.tempdir = tempfile.mkdtemp(dir=root_path)
+
+    def setUp(self):
+        super(TestUpload100PlusFiles, self).setUp()
+
+        log.debug('*** enter TestUpload100PlusFiles.setUp()')
+        log.debug('*** engine1 starting')
+        self.engine_1.start()
+        self.wait_sync()
+        self.native_client = self.get_local_client(self.local_nxdrive_folder_1)
+
+        if not os.path.exists(os.path.join(TestUpload100PlusFiles.tempdir, DEST_DIR)):
+            # create the destination folder
+            self.local_root_client_1.make_folder('/', DEST_DIR)
+
+            # and copy data from root (<root>/test_data/files.zip) into the folder
+            root_path = self._get_root_path()
+            self._extract_test_files(os.path.join(root_path, TEST_ZIP), self.local_root_client_1._abspath('/' + DEST_DIR))
+
+            self.engine_1.start()
+            self.wait_sync(timeout=SUPER_LONG_TIMEOUT)
+
+            # move the synced folder into a temporary directory
+            shutil.move(self.local_root_client_1._abspath(u'/' + DEST_DIR), TestUpload100PlusFiles.tempdir)
+
+        log.debug('*** exit TestUpload100PlusFiles.setUp()')
+
+    def tearDown(self):
+        if getattr(self, 'native_client', None):
+            del self.native_client
+            self.native_client = None
+        super(TestUpload100PlusFiles, self).tearDown()
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tempdir)
+
+    def test_sync_folder(self):
+        self.native_client.make_folder(u'/', u'to_folder')
+
+        # copy all files from tempdir to the new folder under My Docs
+        self.native_client.copy(os.path.join(TestUpload100PlusFiles.tempdir, DEST_DIR),
+                                self.native_client._abspath(u'/to_folder'))
+
+        self.wait_sync(timeout=SUPER_LONG_TIMEOUT)
+        dest_remote_ref = self.local_root_client_1.get_remote_id(u'/to_folder/' + DEST_DIR)
+        remote_children = self.remote_file_system_client_1.get_children_info(dest_remote_ref)
+        local_children = os.listdir(self.local_root_client_1._abspath(u'/to_folder/' + DEST_DIR))
+        self.assertEqual(len(remote_children), len(local_children),
+                         'number of remote children (%d) does not match number of local children (%d)' %
+                         (len(remote_children), len(local_children)))
+
+    @skipIf(sys.platform != 'darwin', 'test is only for Mac')
+    def test_sync_folder_multi(self):
+        self.native_client.make_folder(u'/', u'to_folder2')
+        # copy all files from tempdir to the new folder under My Docs
+        copy_to = _get_copy_to(self.native_client._abspath(u'/to_folder2'))
+        src_path = os.path.join(TestUpload100PlusFiles.tempdir, DEST_DIR)
+        pool = Pool(5)
+        pool.map(copy_to, [os.path.join(src_path, f) for f in os.listdir(src_path)])
+
+        self.wait_sync(timeout=SUPER_LONG_TIMEOUT)
+        pool.close()
+        pool.join()
+        dest_remote_ref = self.local_root_client_1.get_remote_id(u'/to_folder2/' + DEST_DIR)
+        remote_children = self.remote_file_system_client_1.get_children_info(dest_remote_ref)
+        local_children = os.listdir(self.local_root_client_1._abspath(u'/to_folder2/' + DEST_DIR))
+        self.assertEqual(len(remote_children), len(local_children),
+                         'number of remote children (%d) does not match number of local children (%d)' %
+                         (len(remote_children), len(local_children)))
+
+    @classmethod
+    def _get_root_path(cls):
+        import nxdrive as nxd
+
+        # TODO this only works in the sharp-cpo-clients git repo;
+        # adjust accordingly if your zip resource is somewhere else
+        try:
+            test_resources_path = os.path.join(
+                os.path.join(
+                    os.path.join(
+                        os.path.join(os.path.dirname(os.path.dirname(nxd.__file__)),
+                            os.pardir), os.pardir), TEST_DIR))
+            return test_resources_path
+        except Exception as e:
+            log.error('path error: ', e)
+
+    def _extract_test_files(self, zip_file, dest_dir):
+        import zipfile
+
+        with zipfile.ZipFile(zip_file) as zf:
+            for member in zf.infolist():
+                # Path traversal defense copied from
+                # http://hg.python.org/cpython/file/tip/Lib/http/server.py#l789
+                words = member.filename.split('/')
+                path = dest_dir
+                for word in words[:-1]:
+                    drive, word = os.path.splitdrive(word)
+                    head, word = os.path.split(word)
+                    if word in (os.curdir, os.pardir, ''):
+                        continue
+                    path = os.path.join(path, word)
+                zf.extract(member, path)


### PR DESCRIPTION
The test requires a 'files.zip' (mine has ~110 image files, for aprox. 60MB) and is 'sharp-cpo-clients/test_data/files.zip'.   
Need to place a similar zip somewhere and modify the '_get_root_path' class method accordingly.

'test_sync_folder' passes.  
'test_sync_folder_multi' fails with DS/CPO with an HTTP error 500 for GetChildren (investigating).  
Tried to run the nuxeo-drive test with a Nuxeo server but our deployment gets HTTP error 403 for Document.Fetch (using admin credentials).  Could you try and run these 2 tests?