### PR TITLE
SUPNXP-17513: refactor ignored files mechanism

### DIFF
--- a/nuxeo-drive-client/nxdrive/client/base_automation_client.py
+++ b/nuxeo-drive-client/nxdrive/client/base_automation_client.py
@@ -13,10 +13,9 @@ from urllib import urlencode
 from poster.streaminghttp import get_handlers
 from nxdrive.logging_config import get_logger
 from nxdrive.client.common import BaseClient
+from nxdrive.client.common import add_ignore_filter, remove_ignore_filter, ignore_prefixes, ignore_suffixes
 from nxdrive.client.common import DEFAULT_REPOSITORY_NAME
 from nxdrive.client.common import FILE_BUFFER_SIZE
-from nxdrive.client.common import DEFAULT_IGNORED_PREFIXES
-from nxdrive.client.common import DEFAULT_IGNORED_SUFFIXES
 from nxdrive.client.common import safe_filename
 from nxdrive.engine.activity import Action, FileAction
 from nxdrive.utils import DEVICE_DESCRIPTIONS
@@ -185,14 +184,18 @@ class BaseAutomationClient(BaseClient):
             blob_timeout = 60
         self.blob_timeout = blob_timeout
         if ignored_prefixes is not None:
-            self.ignored_prefixes = ignored_prefixes
-        else:
-            self.ignored_prefixes = DEFAULT_IGNORED_PREFIXES
+            # remove default prefixes and register with these new ones
+            fname = ignore_prefixes.func.func_name
+            func = remove_ignore_filter(fname)
+            # reregister the "ignore_prefixes filter with the new prefixes
+            add_ignore_filter(fname, prefixes=ignored_prefixes, apply_to_parent=func.apply_to_parent)
 
         if ignored_suffixes is not None:
-            self.ignored_suffixes = ignored_suffixes
-        else:
-            self.ignored_suffixes = DEFAULT_IGNORED_SUFFIXES
+            # remove default suffixes and register with these new ones
+            fname = ignore_suffixes.func.func_name
+            func = remove_ignore_filter(fname)
+            # reregister the "ignore_suffixes filter with the new suffixes
+            add_ignore_filter(fname, suffixes=ignored_suffixes, apply_to_parent=func.apply_to_parent)
 
         self.upload_tmp_dir = (upload_tmp_dir if upload_tmp_dir is not None
                                else tempfile.gettempdir())

--- a/nuxeo-drive-client/nxdrive/client/common.py
+++ b/nuxeo-drive-client/nxdrive/client/common.py
@@ -3,6 +3,119 @@
 import re
 import os
 import stat
+from functools import partial
+from collections import Iterable
+
+
+registry = set()
+
+
+def register(*args, **kwargs):
+    def decorator(func):
+        try:
+            apply_to_parent = kwargs['apply_to_parent']
+        except KeyError:
+            apply_to_parent = False
+        func2 = partial(func, *args, **kwargs)
+        func2.apply_to_parent = apply_to_parent
+        registry.add(func2)
+        return func2
+    return decorator
+
+
+def remove_ignore_filter(func_name):
+    partial_func = None
+    for f in registry:
+        if f.func.func_name == func_name:
+            partial_func = f
+            break
+    if partial_func:
+        registry.remove(partial_func)
+    return partial_func
+
+
+def add_ignore_filter(func, **kwargs):
+    # func could be the actual function of a partial function (from the registry)
+    if func is not None and hasattr(func, "func"):
+        func = getattr(func, "func", None)
+    if func:
+        register(**kwargs)(func)
+    return func
+
+
+@register(prefixes=(
+        '.',  # hidden Unix files
+        '~$',  # Windows lock files
+        'Thumbs.db',  # Thumbnails files
+        'Icon\r',  # Mac Icon
+        'desktop.ini',  # Icon for windows
+), apply_to_parent=True
+)
+def ignore_prefixes(client, parent, name, **kwargs):
+    # only needs the (file) name, client and parent are not used
+    prefixes = kwargs['prefixes']
+    if prefixes is None:
+        return False
+    if isinstance(prefixes, Iterable):
+        for prefix in prefixes:
+            if name.startswith(prefix):
+                return True
+    elif isinstance(prefixes, str):
+        if name.startswith(prefixes):
+            return True
+    else:
+        return False
+
+
+@register(suffixes=(
+        '~',  # editor buffers
+        '.swp',  # vim swap files
+        '.lock',  # some process use file locks
+        '.LOCK',  # other locks
+        '.part', '.crdownload', '.partial',  # partially downloaded files by browsers
+))
+def ignore_suffixes(client, parent, name, **kwargs):
+    # only needs the (file) name, client and parent are not used
+    suffixes = kwargs['suffixes']
+    if suffixes is None:
+        return False
+    if isinstance(suffixes, Iterable):
+        for suffix in suffixes:
+            if name.endswith(suffix):
+                return True
+    elif isinstance(suffixes, str):
+        if name.endswith(suffixes):
+            return True
+    else:
+        return False
+
+
+@register(prefixes=('~', '#',), suffixes=('.tmp', '#',))
+def ignore_prefix_and_suffix(client, parent, name, **kwargs):
+    # only needs the (file) name, client and parent are not used
+    prefixes = kwargs['prefixes']
+    suffixes = kwargs['suffixes']
+    if prefixes is None or suffixes is None:
+        return False
+    if len(name) < 2:
+        return False
+    if isinstance(prefixes, str) and isinstance(suffixes, str):
+        return name.startswith(prefixes) and name.endswith(suffixes)
+
+    if isinstance(prefixes, Iterable) and isinstance(suffixes, Iterable):
+        for prefix, suffix in zip(prefixes, suffixes):
+            if name.startswith(prefix) and name.endswith(suffix):
+                return True
+    return False
+
+
+def base_is_ignored(client, parent_ref, file_name):
+    ignore_parent = False
+    if parent_ref:
+        grandparent_ref, dir_name = os.path.split(parent_ref)
+        if dir_name:
+            ignore_parent = any(f(client, grandparent_ref, dir_name) for f in registry if f.apply_to_parent)
+    return ignore_parent or any(f(client, parent_ref, file_name) for f in registry)
 
 
 class BaseClient(object):
@@ -66,21 +179,6 @@ class NotFound(Exception):
 
 DEFAULT_REPOSITORY_NAME = 'default'
 
-DEFAULT_IGNORED_PREFIXES = [
-    '.',  # hidden Unix files
-    '~$',  # Windows lock files
-    'Thumbs.db',  # Thumbnails files
-    'Icon\r',  # Mac Icon
-    'desktop.ini',  # Icon for windows
-]
-
-DEFAULT_IGNORED_SUFFIXES = [
-    '~',  # editor buffers
-    '.swp',  # vim swap files
-    '.lock',  # some process use file locks
-    '.LOCK',  # other locks
-    '.part', '.crdownload', '.partial',  # partially downloaded files by browsers
-]
 
 # Default buffer size for file upload / download and digest computation
 FILE_BUFFER_SIZE = 1024 ** 2
@@ -91,6 +189,7 @@ LOCALLY_EDITED_FOLDER_NAME = 'Locally Edited'
 COLLECTION_SYNC_ROOT_FACTORY_NAME = 'collectionSyncRootFolderItemFactory'
 
 UNACCESSIBLE_HASH = "TO_COMPUTE"
+
 
 def safe_filename(name, replacement=u'-'):
     """Replace invalid character in candidate filename"""

--- a/nuxeo-drive-client/nxdrive/client/local_client.py
+++ b/nuxeo-drive-client/nxdrive/client/local_client.py
@@ -14,9 +14,9 @@ from nxdrive.client.base_automation_client import DOWNLOAD_TMP_FILE_PREFIX
 from nxdrive.client.base_automation_client import DOWNLOAD_TMP_FILE_SUFFIX
 from nxdrive.logging_config import get_logger
 from nxdrive.client.common import safe_filename
+from nxdrive.client.common import register, add_ignore_filter, remove_ignore_filter, \
+    ignore_prefixes, ignore_suffixes, base_is_ignored
 from nxdrive.client.common import NotFound
-from nxdrive.client.common import DEFAULT_IGNORED_PREFIXES
-from nxdrive.client.common import DEFAULT_IGNORED_SUFFIXES
 from nxdrive.utils import normalized_path
 from nxdrive.utils import safe_long_path
 from nxdrive.utils import guess_digest_algorithm
@@ -116,14 +116,18 @@ class LocalClient(BaseClient):
         self.check_suspended = check_suspended
 
         if ignored_prefixes is not None:
-            self.ignored_prefixes = ignored_prefixes
-        else:
-            self.ignored_prefixes = DEFAULT_IGNORED_PREFIXES
+            # remove default prefixes and register with these new ones
+            fname = ignore_prefixes.func.func_name
+            func = remove_ignore_filter(fname)
+            # reregister the "ignore_prefixes filter with the new prefixes
+            add_ignore_filter(func, prefixes=ignored_prefixes, apply_to_parent=func.apply_to_parent)
 
         if ignored_suffixes is not None:
-            self.ignored_suffixes = ignored_suffixes
-        else:
-            self.ignored_suffixes = DEFAULT_IGNORED_SUFFIXES
+            # remove default suffixes and register with these new ones
+            fname = ignore_suffixes.func.func_name
+            func = remove_ignore_filter(fname)
+            # reregister the "ignore_suffixes filter with the new suffixes
+            add_ignore_filter(func, suffixes=ignored_suffixes, apply_to_parent=func.apply_to_parent)
 
         while len(base_folder) > 1 and base_folder.endswith(os.path.sep):
             base_folder = base_folder[:-1]
@@ -461,41 +465,53 @@ class LocalClient(BaseClient):
             return False
         return bool(ord(attrs[8]) & 0x20)
 
-    def is_ignored(self, parent_ref, file_name):
-        # Add parent_ref to be able to filter on size if needed
-        ignore = False
-        # Office temp file
-        # http://support.microsoft.com/kb/211632
-        if file_name.startswith("~") and file_name.endswith(".tmp"):
-            return True
-        # Emacs auto save file
-        # http://www.emacswiki.org/emacs/AutoSave
-        if file_name.startswith("#") and file_name.endswith("#") and len(file_name) > 2:
-            return True
-        for suffix in self.ignored_suffixes:
-            if file_name.endswith(suffix):
-                ignore = True
-                break
-        for prefix in self.ignored_prefixes:
-            if file_name.startswith(prefix):
-                ignore = True
-                break
-        if ignore:
-            return True
+    @register()
+    def ignore_non_existant(self, parent, name, **kwargs):
+        # 'self' here represents the context where the function is called and is used to facilitate its work; use
+        # 'duck-typing' to check for the right context.
+        # skip if called with a context which cannot compute the absolute path, e.g. missing,
+        # not derived from LocalClient, etc.
+        if self is None or not hasattr(self, '_abspath'):
+            return False
+        path = self._abspath(os.path.join(parent, name))
+        return not os.path.exists(path)
+
+    @register(apply_to_parent=True)
+    def ignore_hidden(self, parent, name, **kwargs):
         if AbstractOSIntegration.is_windows():
-            # NXDRIVE-465
-            ref = self.get_children_ref(parent_ref, file_name)
+            # 'self' here represents the context where the function is called and is used to facilitate its work; use
+            # 'duck-typing' to check for the right context.
+            # skip if called with a context which cannot compute the absolute path, e.g. missing,
+            # not derived from LocalClient, etc.
+            if self is None or not hasattr(self, '_abspath') or not hasattr(self, 'get_children_ref'):
+                return False
+            # NXDRIVE 465
+            ref = self.get_children_ref(parent, name)
             path = self._abspath(ref)
             if not os.path.exists(path):
                 return False
+
             import win32con
             import win32api
+
             attrs = win32api.GetFileAttributes(path)
             if attrs & win32con.FILE_ATTRIBUTE_SYSTEM == win32con.FILE_ATTRIBUTE_SYSTEM:
                 return True
             if attrs & win32con.FILE_ATTRIBUTE_HIDDEN == win32con.FILE_ATTRIBUTE_HIDDEN:
                 return True
         return False
+
+    def manipulate_guest_filter(self, ignore_guest):
+        if ignore_guest:
+            remove_ignore_filter("ignore_guest_folder")
+        else:
+            func = getattr(self, "ignore_guest_folder", None)
+            if func:
+                add_ignore_filter(func)
+
+    def is_ignored(self, parent_ref, file_name, ignore_guest=False):
+        self.manipulate_guest_filter(ignore_guest)
+        return base_is_ignored(self, parent_ref, file_name)
 
     def get_children_ref(self, parent_ref, name):
         if parent_ref == u'/':

--- a/nuxeo-drive-client/nxdrive/client/remote_document_client.py
+++ b/nuxeo-drive-client/nxdrive/client/remote_document_client.py
@@ -8,6 +8,7 @@ import os
 import urllib2
 from nxdrive.client.common import DEFAULT_REPOSITORY_NAME
 from nxdrive.client.common import safe_filename
+from nxdrive.client.common import base_is_ignored
 from nxdrive.logging_config import get_logger
 from nxdrive.client.common import NotFound
 from nxdrive.client.base_automation_client import BaseAutomationClient
@@ -325,30 +326,13 @@ class RemoteDocumentClient(BaseAutomationClient):
             digestAlgorithm, digest, self.repository, doc['type'], version, doc['state'], has_blob, filename,
             lock_owner, lock_created, permissions)
 
-    def _filtered_results(self, entries, fetch_parent_uid=True,
-                          parent_uid=None):
+    def _filtered_results(self, entries, fetch_parent_uid=True, parent_uid=None):
+        infos = [self._doc_to_info(d, fetch_parent_uid=fetch_parent_uid, parent_uid=parent_uid) for d in entries]
         # Filter out filenames that would be ignored by the file system client
-        # so as to be consistent.
-        filtered = []
-        for info in [self._doc_to_info(d, fetch_parent_uid=fetch_parent_uid,
-                                       parent_uid=parent_uid)
-                     for d in entries]:
-            ignore = False
-
-            for suffix in self.ignored_suffixes:
-                if info.name.endswith(suffix):
-                    ignore = True
-                    break
-
-            for prefix in self.ignored_prefixes:
-                if info.name.startswith(prefix):
-                    ignore = True
-                    break
-
-            if not ignore:
-                filtered.append(info)
-
-        return filtered
+        # so as to be consistent
+        # TODO use the parent path (instead of None) to also filter by the parent directory name, e.g.
+        # ignore files in a hidden folder
+        return [info for info in infos if not base_is_ignored(None, None, info.name)]
 
     #
     # Generic Automation features reused from nuxeolib

--- a/nuxeo-drive-client/nxdrive/tests/test_ignore.py
+++ b/nuxeo-drive-client/nxdrive/tests/test_ignore.py
@@ -1,0 +1,79 @@
+'''
+Created on 28 Jul 2016
+
+@author: constantinm
+'''
+
+import tempfile
+import os
+import shutil
+from unittest import TestCase
+from nxdrive.osi import AbstractOSIntegration
+from nxdrive.client.local_client import LocalClient
+
+
+class TestIgnoreFiles(TestCase):
+
+    def setUp(self):
+        super(TestIgnoreFiles, self).setUp()
+        self.basedir = tempfile.mkdtemp(u'nxdrive')
+        self.local_client = LocalClient(base_folder=self.basedir)
+        self.local_client.make_file(u'/', u"#myfile#")
+        self.local_client.make_file(u'/', u"Thumbs.db")
+        self.local_client.make_file(u'/', u"desktop.ini")
+        self.local_client.make_file(u'/', u"readme.txt")
+        self.local_client.make_file(u'/', u"test.lock")
+        self.local_client.make_file(u'/', u"test.swp")
+        self.local_client.make_file(u'/', u"~bar.tmp")
+        self.local_client.make_file(u'/', u"system.bk~")
+        self.local_client.make_file(u'/', u"~$info.doc")
+        self.local_client.make_file(u'/', u".update.sh")
+        self.local_client.make_folder(u'/', u"mydir")
+        self.local_client.make_file(u'/mydir', u"advise.txt")
+        self.local_client.make_folder(u'/', u".yourdir")
+        self.local_client.make_file(u'/.yourdir', u"proposal.pdf")
+        if AbstractOSIntegration.is_windows():
+            import win32con
+            import win32api
+            self.local_client.make_file(u'/', u"hidden-readme.txt")
+            win32api.SetFileAttributes(u"/hidden-readme.txt", win32con.FILE_ATTRIBUTE_HIIDEN)
+            self.local_client.make_folder(u'/', u"hidden-dir")
+            win32api.SetFileAttributes(u"/hidden-dir", win32con.FILE_ATTRIBUTE_HIIDEN)
+            self.local_client.make_file(u'/hidden-dir', u"nothidden.xsl")
+
+    def tearDown(self):
+        if os.path.exists(self.basedir):
+            shutil.rmtree(self.basedir, ignore_errors=True)
+
+    def test_ignored_files(self):
+        self.assertTrue(self.local_client.is_ignored(u'/', u"#myfile#"), "#myfile# should have been ignored")
+        self.assertTrue(self.local_client.is_ignored(u'/', u"Thumbs.db"), "Thumbs.db should have been ignored")
+        self.assertTrue(self.local_client.is_ignored(u'/', u"desktop.ini"), "desktop.ini should have been ignored")
+        self.assertFalse(self.local_client.is_ignored(u'/', u"readme.txt"), "readme.txt should not have been ignored")
+        self.assertTrue(self.local_client.is_ignored(u'/', u"test.lock"), "test.lock should have been ignored")
+        self.assertTrue(self.local_client.is_ignored(u'/', u"test.swp"), "test.swp should have been ignored")
+        self.assertTrue(self.local_client.is_ignored(u'/', u"~bar.tmp"), "~bar.tmp should have been ignored")
+        self.assertTrue(self.local_client.is_ignored(u'/', u"system.bk~"), "system.bk~ should have been ignored")
+        self.assertTrue(self.local_client.is_ignored(u'/', u"~$info.doc"), "~$info.doc should have been ignored")
+        self.assertTrue(self.local_client.is_ignored(u'/', u".update.sh"), ".update.sh should have been ignored")
+        self.assertFalse(self.local_client.is_ignored(u'/mydir', u"advise.txt"),
+                         "advise.txt should have not been ignored")
+        self.assertTrue(self.local_client.is_ignored(u'/.yourdir', u"proposal.pdf"),
+                        "proposal.pdf should have been ignored")
+
+    def test_update_prefixes_and_suffixes(self):
+        self.local_client = LocalClient(base_folder=self.basedir, ignored_prefixes=('.',), ignored_suffixes=('.tmp',))
+        self.assertTrue(self.local_client.is_ignored(u'/', u"#myfile#"), "#myfile# should have been ignored")
+        self.assertFalse(self.local_client.is_ignored(u'/', u"Thumbs.db"), "Thumbs.db should not have been ignored")
+        self.assertFalse(self.local_client.is_ignored(u'/', u"desktop.ini"), "desktop.ini should not have been ignored")
+        self.assertFalse(self.local_client.is_ignored(u'/', u"readme.txt"), "readme.txt should not have been ignored")
+        self.assertFalse(self.local_client.is_ignored(u'/', u"test.lock"), "test.lock should not have been ignored")
+        self.assertFalse(self.local_client.is_ignored(u'/', u"test.swp"), "test.swp should not have been ignored")
+        self.assertTrue(self.local_client.is_ignored(u'/', u"~bar.tmp"), "~bar.tmp should have been ignored")
+        self.assertFalse(self.local_client.is_ignored(u'/', u"system.bk~"), "system.bk~ should not have been ignored")
+        self.assertFalse(self.local_client.is_ignored(u'/', u"~$info.doc"), "~$info.doc should not have been ignored")
+        self.assertTrue(self.local_client.is_ignored(u'/', u".update.sh"), ".update.sh should have been ignored")
+        self.assertFalse(self.local_client.is_ignored(u'/mydir', u"advise.txt"),
+                         "advise.txt should have not been ignored")
+        self.assertTrue(self.local_client.is_ignored(u'/.yourdir', u"proposal.pdf"),
+                         "proposal.pdf should have been ignored")


### PR DESCRIPTION
refactor is_ignore for local files which should not sync, including files inside an 'ignored' folder.
Also, now both local client and remote document client use the same prefixes and suffixes.