### PR TITLE
NXDRIVE-337: Add shorcut support for windows 10

### DIFF
--- a/nuxeo-drive-client/nxdrive/engine/engine.py
+++ b/nuxeo-drive-client/nxdrive/engine/engine.py
@@ -367,6 +367,8 @@ class Engine(QObject):
     def unbind(self):
         self.stop()
         try:
+            # Unregister the favorite link for Nuxeo Drive upon disconnecting.
+            self._manager.get_osi().unregister_folder_link(self._manager._get_default_nuxeo_drive_name())
             # Dont fail if not possible to remove token
             doc_client = self.get_remote_doc_client()
             doc_client.revoke_token()
@@ -795,6 +797,8 @@ class Engine(QObject):
             # If the top level state for the server binding doesn't exist,
             # create the local folder and the top level state.
             self._check_root()
+            self._manager.get_osi().register_folder_link(self._local_folder,
+                                                             self._manager._get_default_nuxeo_drive_name())
 
     def _check_fs(self, path):
         if not self._manager.get_osi().is_partition_supported(path):

--- a/nuxeo-drive-client/nxdrive/engine/engine.py
+++ b/nuxeo-drive-client/nxdrive/engine/engine.py
@@ -368,7 +368,7 @@ class Engine(QObject):
         self.stop()
         try:
             # Unregister the favorite link for Nuxeo Drive upon disconnecting.
-            self._manager.get_osi().unregister_folder_link(self._manager._get_default_nuxeo_drive_name())
+            self._manager.get_osi().unregister_folder_link(self._manager._get_default_nuxeo_drive_name(), self._uid)
             # Dont fail if not possible to remove token
             doc_client = self.get_remote_doc_client()
             doc_client.revoke_token()
@@ -797,7 +797,7 @@ class Engine(QObject):
             # If the top level state for the server binding doesn't exist,
             # create the local folder and the top level state.
             self._check_root()
-            self._manager.get_osi().register_folder_link(self._local_folder,
+            self._manager.get_osi().register_folder_link(self._local_folder, self._uid, 
                                                              self._manager._get_default_nuxeo_drive_name())
 
     def _check_fs(self, path):

--- a/nuxeo-drive-client/nxdrive/osi/darwin/darwin.py
+++ b/nuxeo-drive-client/nxdrive/osi/darwin/darwin.py
@@ -164,7 +164,7 @@ class DarwinIntegration(AbstractOSIntegration):
                 pass
         return result
 
-    def register_folder_link(self, folder_path, name=None):
+    def register_folder_link(self, folder_path, engine_id, name=None):
         try:
             from LaunchServices import LSSharedFileListInsertItemURL
             from LaunchServices import kLSSharedFileListItemBeforeFirst
@@ -196,7 +196,7 @@ class DarwinIntegration(AbstractOSIntegration):
         if item is not None:
             log.debug("Registered new favorite in Finder for: %s", folder_path)
 
-    def unregister_folder_link(self, name):
+    def unregister_folder_link(self, name, engine_id):
         try:
             from LaunchServices import LSSharedFileListItemRemove
         except ImportError:

--- a/nuxeo-drive-client/nxdrive/osi/windows/windows.py
+++ b/nuxeo-drive-client/nxdrive/osi/windows/windows.py
@@ -226,8 +226,8 @@ class WindowsIntegration(AbstractOSIntegration):
     def unregister_protocol_handlers(self):
         app_name = self._manager.get_appname()
         reg = _winreg.ConnectRegistry(None, _winreg.HKEY_CURRENT_USER)
-        self._recursive_delete(reg, 'Software\\', app_name)
-        self._recursive_delete(reg, 'Software\\Classes\\', 'nxdrive')
+        self._recursive_delete(reg, 'Software', app_name)
+        self._recursive_delete(reg, 'Software\\Classes', 'nxdrive')
 
     def register_contextual_menu(self):
         # TODO: better understand why / how this works.


### PR DESCRIPTION
Added support for windows 10, Pin to the navigation
Note: Python 2.7.11 is required to platform.release() API, which is used to determine the Windows version.
