### PR TITLE
NXDDRIVE-634: Update file move condition

### DIFF
--- a/nuxeo-drive-client/nxdrive/engine/processor.py
+++ b/nuxeo-drive-client/nxdrive/engine/processor.py
@@ -13,6 +13,7 @@ from nxdrive.engine.activity import Action
 from nxdrive.utils import current_milli_time, is_office_temp_file
 from PyQt4.QtCore import pyqtSignal
 from threading import Lock
+from urllib2 import HTTPError
 import os
 log = get_logger(__name__)
 
@@ -406,22 +407,25 @@ class Processor(EngineWorker):
             uid = remote_ref.split('#')[-1]
             info = remote_doc_client.get_info(uid, raise_if_missing=False, use_trash=False)
             if info:
-                if info.state == 'deleted':
-                    log.debug("Untrash from the client: %r", doc_pair)
-                    remote_doc_client.undelete(uid)
-                    remote_parent_path = parent_pair.remote_parent_path + '/' + parent_pair.remote_ref
-                    fs_item_info = remote_client.get_info(remote_ref)
-                    # Handle document move
-                    if not fs_item_info.path.startswith(remote_parent_path):
-                        fs_item_info = remote_client.move(fs_item_info.uid, parent_pair.remote_ref)
-                    # Handle document rename
-                    if fs_item_info.name != doc_pair.local_name:
-                        fs_item_info = remote_client.rename(fs_item_info.uid, doc_pair.local_name)
-                    self._dao.update_remote_state(doc_pair, fs_item_info, remote_parent_path=remote_parent_path, versionned=False)
-                    # Handle document modification - update the doc_pair
-                    doc_pair = self._dao.get_state_from_id(doc_pair.id)
-                    self._synchronize_locally_modified(doc_pair, local_client, remote_client)
-                    return
+                try:
+                    if info.state == 'deleted':
+                        log.debug("Untrash from the client: %r", doc_pair)
+                        remote_doc_client.undelete(uid)
+                        remote_parent_path = parent_pair.remote_parent_path + '/' + parent_pair.remote_ref
+                        fs_item_info = remote_client.get_info(remote_ref)
+                        # Handle document move
+                        if not parent_pair.remote_ref.endswith(info.parent_uid):
+                            fs_item_info = remote_client.move(fs_item_info.uid, parent_pair.remote_ref)
+                        # Handle document rename
+                        if fs_item_info.name != doc_pair.local_name:
+                            fs_item_info = remote_client.rename(fs_item_info.uid, doc_pair.local_name)
+                        self._dao.update_remote_state(doc_pair, fs_item_info, remote_parent_path=remote_parent_path, versionned=False)
+                        # Handle document modification - update the doc_pair
+                        doc_pair = self._dao.get_state_from_id(doc_pair.id)
+                        self._synchronize_locally_modified(doc_pair, local_client, remote_client)
+                        return
+                except HTTPError as e:
+                    log.error("Upload Document ignoring existing reference " + uid + "error "+ e.message)
                 log.trace("Compare parents: %r | %r", info.parent_uid, parent_pair.remote_ref)
                 # Document exists on the server
                 if parent_pair.remote_ref is not None and parent_pair.remote_ref.endswith(info.parent_uid)\

--- a/nuxeo-drive-client/nxdrive/tests/test_local_deletion.py
+++ b/nuxeo-drive-client/nxdrive/tests/test_local_deletion.py
@@ -55,6 +55,30 @@ class TestLocalDeletion(UnitTestCase):
         self.assertFalse(self.local_client_1.exists('/File_To_Delete.txt'))
         self.assertEqual(self.local_client_1.get_content('/File_To_Delete2.txt'), 'New content')
 
+    def test_move_untrash_file_on_parent(self):
+        file_path = '/ToDelete/File_To_Delete.txt'
+        self.local_client_1.make_folder('/', 'ToDelete')
+        self.local_client_1.make_file('/ToDelete', 'File_To_Delete.txt', 'This is a content')
+        self.wait_sync()
+        self.assertTrue(self.remote_document_client_1.exists(file_path))
+        old_info = self.remote_document_client_1.get_info(file_path, use_trash=True)
+        abs_path = self.local_client_1._abspath(file_path)
+        # Pretend we had trash the file
+        shutil.move(abs_path, os.path.join(self.local_test_folder_1, 'File_To_Delete.txt'))        
+        self.wait_sync(wait_for_async=True)
+        self.local_client_1.delete('/ToDelete')
+        self.wait_sync(wait_for_async=True)
+        self.assertFalse(self.remote_document_client_1.exists(file_path))
+        self.assertFalse(self.local_client_1.exists(file_path))
+        # See if it untrash or recreate
+        shutil.move(os.path.join(self.local_test_folder_1, 'File_To_Delete.txt'), self.local_client_1._abspath('/'))
+        self.wait_sync(wait_for_async=True)
+        new_info = self.remote_document_client_1.get_info(old_info.uid, use_trash=True)        
+        self.assertFalse('ToDelete' in new_info.path)
+        self.assertEqual(new_info.state, 'project')
+        self.assertTrue(self.local_client_1.exists('/File_To_Delete.txt'))
+        pass
+    
     def test_untrash_file_on_delete_parent(self):
         file_path = '/ToDelete/File_To_Delete.txt'
         self.local_client_1.make_folder('/', 'ToDelete')


### PR DESCRIPTION
1. Update the move detect condition.
2. When user has "Read Only" permission on source document, the undelete operation will throw exception. Catch exception and upload as new file. 
