### PR TITLE
Remove use of deprecated and insecure os.tempnam()

### DIFF
--- a/nuxeo-drive-client/nxdrive/client/local_client.py
+++ b/nuxeo-drive-client/nxdrive/client/local_client.py
@@ -689,8 +689,9 @@ class LocalClient(BaseClient):
             if (old_name != new_name and old_name.lower() == new_name.lower()
                 and not self.is_case_sensitive()):
                 # Must use a temp rename as FS is not case sensitive
-                temp_path = os.tempnam(self._abspath(parent),
-                                       LocalClient.CASE_RENAME_PREFIX + old_name + '_')
+                prefix = LocalClient.CASE_RENAME_PREFIX + old_name + '_'
+                _, temp_path = tempfile.mkstemp(dir=self._abspath(parent),
+                                                prefix=prefix)
                 if AbstractOSIntegration.is_windows():
                     import ctypes
                     ctypes.windll.kernel32.SetFileAttributesW(


### PR DESCRIPTION
[tempnam](https://docs.python.org/2/library/os.html#os.tempnam) is deprecated and insecure by design. [mkstemp](https://docs.python.org/2/library/tempfile.html#tempfile.mkstemp) seems the best alternative.