### PR TITLE
Revert "NXDRIVE-702: fix use of deprecated and insecure os.tempnam()"

### DIFF
--- a/nuxeo-drive-client/nxdrive/client/local_client.py
+++ b/nuxeo-drive-client/nxdrive/client/local_client.py
@@ -689,9 +689,8 @@ class LocalClient(BaseClient):
             if (old_name != new_name and old_name.lower() == new_name.lower()
                 and not self.is_case_sensitive()):
                 # Must use a temp rename as FS is not case sensitive
-                prefix = LocalClient.CASE_RENAME_PREFIX + old_name + '_'
-                _, temp_path = tempfile.mkstemp(dir=self._abspath(parent),
-                                                prefix=prefix)
+                temp_path = os.tempnam(self._abspath(parent),
+                                       LocalClient.CASE_RENAME_PREFIX + old_name + '_')
                 if AbstractOSIntegration.is_windows():
                     import ctypes
                     ctypes.windll.kernel32.SetFileAttributesW(


### PR DESCRIPTION
NXDRIVE-707: Windows: bug test_synchronize_special_filenames (sync timeout)

Explanation: `os.tempnam` returns a string with a possible available temporary path, `tempfile.mkstemp` creates and opens a temporary file. As the file is opened in memory, Windows has issue with that.
Concerning the security issue with `os.tempnam`, it should be good as we just need a temporary name.