### PR TITLE
[WIP] NXDRIVE-711: fix system tray menu behavior

### DIFF
--- a/nuxeo-drive-client/nxdrive/tests/test_gui_systray.py
+++ b/nuxeo-drive-client/nxdrive/tests/test_gui_systray.py
@@ -1,0 +1,97 @@
+# coding: utf-8
+
+from tempfile import mkdtemp
+from unittest import SkipTest, TestCase
+
+from PyQt4.QtCore import Qt, QPoint
+from PyQt4.QtTest import QTest
+from mock import Mock
+
+from nxdrive.logging_config import configure, get_logger
+from nxdrive.manager import Manager
+from nxdrive.tests.common import clean_dir
+from nxdrive.wui.application import Application
+
+
+class SystemTrayMenu(TestCase):
+
+    # Delay, in msec, before and after each mouse action
+    delay = 100
+
+    @classmethod
+    def setUpClass(cls):
+
+        def configure_logger():
+            configure(console_level='TRACE',
+                      command_name='test',
+                      force_configure=True)
+
+        # Configure test logger
+        configure_logger()
+        cls.log = get_logger(__name__)
+
+        cls.folder = mkdtemp(u'-nxdrive-tests-gui-systray')
+        options = Mock()
+        options.debug = False
+        options.force_locale = None
+        options.proxy_server = None
+        options.log_level_file = None
+        options.update_site_url = None
+        options.beta_update_site_url = None
+        options.nxdrive_home = cls.folder
+
+        cls.manager = Manager(options)
+        cls.app = Application(cls.manager, options)
+
+        # Close the settings window, if opened (on fresh install)
+        try:
+            cls.app.uniqueDialogs['settings'].close()
+        except KeyError:
+            pass
+
+        QTest.qWait(1000)
+
+        cls.icon = cls.app._tray_icon
+        cls.menu = cls.app.tray_icon_menu
+
+    @classmethod
+    def tearDownClass(cls):
+        # Remove singleton
+        cls.manager.dispose_db()
+        Manager._singleton = None
+
+        clean_dir(cls.folder)
+
+    def test_0_icon_is_visible(self):
+        ''' Note: the method name starts with a "0" to be the first executed.
+            No system tray icon => no tests.
+        '''
+
+        self.log.debug('Systray icon should be visible')
+        self.assertTrue(self.icon.isVisible())
+
+        geo = self.icon.geometry()
+        self.log.trace('Systray icon (%s, %s) at position (%s, %s)', geo.width(), geo.height(), geo.x(), geo.y())
+        # Simple tests for this Qt5 bug: https://bugreports.qt.io/browse/QTBUG-32811
+        # If it fails here, we cannot do anything but upgrade Qt version (from the customer side)
+        self.assertTrue(geo.width() > 1)
+        self.assertTrue(geo.height() > 1)
+
+    def test_icon_click_left(self):
+        raise SkipTest('To debug: cannot trigger a mouse click on the icon ...')
+
+        self.log.debug('Left click on the icon should open the menu')
+        geo = self.icon.geometry()
+        pos = QPoint(geo.x() + geo.width() // 2, geo.y() + geo.height() // 2)
+        self.log.trace('Move mouse at position (%s, %s)', pos.x(), pos.y())
+        QTest.mouseMove(self.menu, pos=pos, delay=self.delay)
+
+        self.log.trace('Simulate left click on the icon')
+        QTest.mouseClick(self.menu.dialog, Qt.LeftButton, pos=pos, delay=self.delay)
+
+        QTest.qWait(1000)
+        self.assertTrue(self.menu.isVisible())
+
+        self.log.debug('Another left click on the icon should close the menu')
+        # click!
+        self.assertFalse(self.menu.isVisible())

--- a/nuxeo-drive-client/nxdrive/wui/systray.py
+++ b/nuxeo-drive-client/nxdrive/wui/systray.py
@@ -1,291 +1,195 @@
+# coding: utf-8
 '''
 Created on 27 janv. 2015
 
 @author: Remi Cattiau
 '''
-from PyQt4 import QtGui, QtCore
+from PyQt4.QtCore import QRect, Qt, pyqtSlot
+from PyQt4.QtGui import QAction, QApplication, QCursor, QMenu, QSystemTrayIcon
+
 from nxdrive.logging_config import get_logger
+from nxdrive.osi import AbstractOSIntegration
 from nxdrive.wui.dialog import WebDialog, WebDriveApi
 from nxdrive.wui.translator import Translator
-from nxdrive.osi import AbstractOSIntegration
+
+try:
+    from nxdrive.osi.darwin.pyNotificationCenter import notify
+except ImportError:
+    pass
+
 log = get_logger(__name__)
 
 
-class DriveSystrayIcon(QtGui.QSystemTrayIcon):
+class DriveSystrayIcon(QSystemTrayIcon):
 
     def __init__(self):
         super(DriveSystrayIcon, self).__init__()
         self.activated.connect(self._show_popup)
 
-    def showMessage(self, title, message, icon=QtGui.QSystemTrayIcon.Information, timeout = 10000):
-        if AbstractOSIntegration.is_mac():
-            if AbstractOSIntegration.os_version_above("10.8"):
-                from nxdrive.osi.darwin.pyNotificationCenter import notify
-                # Use notification center
-                return notify(title, None, message)
-        return QtGui.QSystemTrayIcon.showMessage(self, title, message, icon, timeout)
+    def showMessage(self, title, message, icon=QSystemTrayIcon.Information, timeout=10000):
+        if AbstractOSIntegration.is_mac() and AbstractOSIntegration.os_version_above('10.8'):
+            # Use notification center
+            return notify(title, None, message)
+        return QSystemTrayIcon.showMessage(self, title, message, icon, timeout)
 
     def _show_popup(self, reason):
-        if reason == QtGui.QSystemTrayIcon.Trigger:
-            self.contextMenu().popup(QtGui.QCursor.pos())
+        if reason == QSystemTrayIcon.Trigger:
+            self.contextMenu().popup(QCursor.pos())
 
 
 class WebSystrayApi(WebDriveApi):
 
-    @QtCore.pyqtSlot(str)
+    menu = None
+
+    @pyqtSlot(str)
     def show_settings(self, page):
-        try:
-            super(WebSystrayApi, self).show_settings(page)
-            self._dialog.close()
-        except Exception as e:
-            log.exception(e)
+        self.get_dialog().hide()
+        super(WebSystrayApi, self).show_settings(page)
 
-    @QtCore.pyqtSlot(str)
+    @pyqtSlot(str)
     def show_conflicts_resolution(self, uid):
-        try:
-            super(WebSystrayApi, self).show_conflicts_resolution(uid)
-            self._dialog.close()
-        except Exception as e:
-            log.exception(e)
+        self.get_dialog().hide()
+        super(WebSystrayApi, self).show_conflicts_resolution(uid)
 
-    @QtCore.pyqtSlot(str, str)
+    @pyqtSlot(str, str)
     def show_metadata(self, uid, ref):
-        try:
-            super(WebSystrayApi, self).show_metadata(uid, ref)
-            self._dialog.close()
-        except Exception as e:
-            log.exception(e)
+        self.get_dialog().hide()
+        super(WebSystrayApi, self).show_metadata(uid, ref)
 
-    @QtCore.pyqtSlot(str, result=str)
+    @pyqtSlot(str, result=str)
     def open_remote(self, uid):
-        try:
-            res = super(WebSystrayApi, self).open_remote(uid)
-            self._dialog.close()
-            return res
-        except Exception as e:
-            log.exception(e)
-            return ""
+        self.get_dialog().hide()
+        return super(WebSystrayApi, self).open_remote(uid)
 
-    @QtCore.pyqtSlot(str, str, result=str)
+    @pyqtSlot(str, str, result=str)
     def open_local(self, uid, path):
-        try:
-            res = super(WebSystrayApi, self).open_local(uid, path)
-            self._dialog.close()
-            return res
-        except Exception as e:
-            log.exception(e)
-            return ""
+        self.get_dialog().hide()
+        return super(WebSystrayApi, self).open_local(uid, path)
 
-    @QtCore.pyqtSlot()
+    @pyqtSlot()
     def open_help(self):
-        try:
-            self._manager.open_help()
-            self._dialog.close()
-        except Exception as e:
-            log.exception(e)
+        self.get_dialog().hide()
+        self._manager.open_help()
 
-
-    @QtCore.pyqtSlot(str)
+    @pyqtSlot(str)
     def trigger_notification(self, id_):
-        try:
-            super(WebSystrayApi, self).trigger_notification(id_)
-            self._dialog.close()
-        except Exception as e:
-            log.exception(e)
+        self.get_dialog().hide()
+        super(WebSystrayApi, self).trigger_notification(id_)
 
-    @QtCore.pyqtSlot()
+    @pyqtSlot()
     def open_about(self):
-        try:
-            self._application.show_settings(section="About")
-            self._dialog.close()
-        except Exception as e:
-            log.exception(e)
+        self.get_dialog().hide()
+        self._application.show_settings(section='About')
 
-    @QtCore.pyqtSlot()
+    @pyqtSlot()
     def suspend(self):
-        try:
-            self._manager.suspend()
-            self._dialog.close()
-        except Exception as e:
-            log.exception(e)
+        self.get_dialog().close()
+        self._manager.suspend()
 
-    @QtCore.pyqtSlot(str, result=int)
+    @pyqtSlot(str, result=int)
     def get_syncing_items(self, uid):
-        try:
-            engine = self._get_engine(uid)
+        engine = self._get_engine(uid)
+        if engine:
             return engine.get_dao().get_syncing_count()
-        except Exception as e:
-            log.exception(e)
-            return 0
+        return 0
 
-    @QtCore.pyqtSlot()
+    @pyqtSlot()
     def resume(self):
-        try:
-            self._manager.resume()
-            self._dialog.close()
-        except Exception as e:
-            log.exception(e)
+        self.get_dialog().close()
+        self._manager.resume()
 
     def _create_advanced_menu(self):
-        menu = QtGui.QMenu()
-        menu.setFocusProxy(self._dialog)
+        menu = QMenu()
         if self._manager.is_paused():
-            menu.addAction(Translator.get("RESUME"), self.resume)
+            menu.addAction(Translator.get('RESUME'), self.resume)
         else:
-            menu.addAction(Translator.get("SUSPEND"), self.suspend)
+            menu.addAction(Translator.get('SUSPEND'), self.suspend)
         menu.addSeparator()
-        menu.addAction(Translator.get("SETTINGS"), self._application.show_settings)
+        menu.addAction(Translator.get('SETTINGS'), self._application.show_settings)
         menu.addSeparator()
-        menu.addAction(Translator.get("HELP"), self.open_help)
+        menu.addAction(Translator.get('HELP'), self.open_help)
         if self._manager.is_debug():
             menu.addSeparator()
-            menuDebug = self._application.create_debug_menu(menu)
-            debugAction = QtGui.QAction(Translator.get("DEBUG"), self)
-            debugAction.setMenu(menuDebug)
-            menu.addAction(debugAction)
+            menu_debug = self._application.create_debug_menu(menu)
+            debug_action = QAction(Translator.get('DEBUG'), self)
+            debug_action.setMenu(menu_debug)
+            menu.addAction(debug_action)
         menu.addSeparator()
-        menu.addAction(Translator.get("QUIT"), self._application.quit)
+        menu.addAction(Translator.get('QUIT'), self._application.quit)
         return menu
 
-    @QtCore.pyqtSlot()
+    @pyqtSlot()
     def advanced_systray(self):
-        try:
-            menu = self._create_advanced_menu()
-            menu.exec_(QtGui.QCursor.pos())
-        except Exception as e:
-            log.exception(e)
+        if not self.menu:
+            self.menu = self._create_advanced_menu()
+        self.menu.popup(QCursor.pos())
 
 
 class WebSystrayView(WebDialog):
-    DEFAULT_WIDTH = 300
-    DEFAULT_HEIGHT = 370
-    '''
-    classdocs
-    '''
+
+    default_width = 300
+    default_height = 370
+
     def __init__(self, application, icon):
-        '''
-        Constructor
-        '''
-        super(WebSystrayView, self).__init__(application, "systray.html", api=WebSystrayApi(application, self))
+
+        super(WebSystrayView, self).__init__(application, 'systray.html', api=WebSystrayApi(application, self))
         self._icon = icon
-        self._icon_geometry = None
-        self._view.setFocusProxy(self)
-        self.resize(WebSystrayView.DEFAULT_WIDTH, WebSystrayView.DEFAULT_HEIGHT)
-        self.setWindowFlags(QtCore.Qt.FramelessWindowHint | QtCore.Qt.WindowStaysOnTopHint | QtCore.Qt.Popup | QtCore.Qt.Dialog);
+        self.setWindowFlags(Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint | Qt.Popup)
+        self.move_and_replace()
+        # TODO center systray icon into the notification zone
 
-    def replace(self):
-        log.trace("Icon is %r", self._icon)
-        self._icon_geometry = rect = self._icon.geometry()
-        log.trace("IconRect is : %s,%s | %s,%s",rect.x(), rect.y(), rect.width(), rect.height())
-        from PyQt4.QtGui import QApplication, QCursor
-        from PyQt4.QtCore import QRect
-        desktop = QApplication.desktop()
-        log.trace("Screen id is %d", desktop.screenNumber(rect.topLeft()))
-        desk = desktop.screenGeometry(desktop.screenNumber(rect.topLeft()))
-        log.trace("ScreenRect is : %s,%s | %s,%s",desk.x(), desk.y(), desk.width(), desk.height())
-        pos = QCursor.pos()
-        log.trace("Cursor is : %s,%s",pos.x(), pos.y())
-        # Make our calculation on a offset screen to 0/0
-        rect = QRect(rect.x()-desk.x(), rect.y()-desk.y(), rect.width(), rect.height())
-        pos.setX(pos.x()-desk.x())
-        pos.setY(pos.y()-desk.y())
-        if not rect.contains(pos) or (rect.x() == 0 and rect.y() == 0):
-            # Avoid any modulo 0
-            if rect.width() == 0 or rect.height() == 0:
-                rect = QRect(pos.x(), pos.y(), rect.width(), rect.height())
-            else:
-                rect = QRect(pos.x()-pos.x()%rect.width(), pos.y()-pos.y()%rect.height(), rect.width(), rect.height())
-            log.trace("Adjusting X/Y to %d/%d", rect.x(), rect.y())
-            pos = rect
-            self._icon_geometry = QRect(rect.x()+desk.x(), rect.y()+desk.y(), rect.width(), rect.height())
-            log.trace("New rect is : %s,%s | %s,%s",pos.x(), pos.y(), pos.width(), pos.height())
-        x = rect.x() + rect.width() - self.width()
-        y = rect.y() - self.height()
-        # Prevent the systray to be hidden
-        if y < 0:
-            y = rect.y() + rect.height()
-        if x < 0:
-            x = rect.x()
-        # Use the offset again
-        x += desk.x()
-        y += desk.y()
-        log.trace("Move systray menu to %d/%d", x, y)
-        self.move(x, y)
+    def move_and_replace(self):
+        ''' Resize and move the sysem tray menu accordingly to the system tray icon position. '''
 
-    def show(self):
-        self.replace()
-        super(WebSystrayView, self).show()
-        if self.isVisible():
-            self.raise_()
-            self.activateWindow()
-            self.setFocus(QtCore.Qt.ActiveWindowFocusReason)
+        self.resize(self.default_width,
+                    self.default_height)  # TODO can we use these args on init?
 
-    def underMouse(self):
-        # The original result was different from this simple
-        return self.geometry().contains(QtGui.QCursor.pos())
+        rect = self._icon.geometry()
+        log.trace('Systray icon: %r', self._icon)
+        log.trace('Systray icon geometry: %r', rect)
 
-    def shouldHide(self):
-        log.trace("Geometry: %r", self.geometry())
-        log.trace("Cursor is: %r", QtGui.QCursor.pos())
-        log.trace("Icon: %r", self._icon)
-        log.trace("Icon geometry: %r", self._icon_geometry)
-        if not (self.underMouse() or (self._icon and self._icon.geometry().contains(QtGui.QCursor.pos()))
-                or (self._icon_geometry and self._icon_geometry.contains(QtGui.QCursor.pos()))):
-            log.trace('will close menu')
-            self.close()
-
-    def focusOutEvent(self, event):
-        if not (self.underMouse() or (self._icon and self._icon.geometry().contains(QtGui.QCursor.pos()))
-                or (self._icon_geometry and self._icon_geometry.contains(QtGui.QCursor.pos()))):
-            self.close()
-        super(WebSystrayView, self).focusOutEvent(event)
-
-    def resizeEvent(self, event):
-        super(WebSystrayView, self).resizeEvent(event)
-        self.replace()
-
-    @QtCore.pyqtSlot()
-    def close(self):
-        self._icon = None
-        try:
-            super(WebSystrayView, self).close()
-        except RuntimeError:
-            # This exception can happen here
-            # wrapped C/C++ object of type WebSystrayView has been deleted
-            pass
+        # Calculate coordinates of the box that will contain the systray menu
+        pos_x = max(0, rect.x() + rect.width() - self.width())
+        pos_y = rect.y() - self.height()
+        if pos_y < 0:
+            pos_y = rect.y() + rect.height()
+        log.trace('Move systray menu to (%d, %d)', pos_x, pos_y)
+        self.move(pos_x, pos_y)
+        log.trace('Systray menu geometry: %r', self.geometry())
 
 
-class WebSystray(QtGui.QMenu):
-    '''
-    classdocs
-    '''
+class WebSystray(QMenu):
+
     def __init__(self, application, systray_icon):
-        '''
-        Constructor
-        '''
         super(WebSystray, self).__init__()
-        self.aboutToShow.connect(self.onShow)
-        self.aboutToHide.connect(self.onHide)
+        self.aboutToShow.connect(self.on_show)
+        self.aboutToHide.connect(self.on_hide)
         self._application = application
         self._systray_icon = systray_icon
-        self.dlg = None
+        self.__dialog = None
 
-    @QtCore.pyqtSlot()
-    def dialogDeleted(self):
-        self.dlg = None
+    @property
+    def dialog(self):
+        if not self.__dialog:
+            self.__dialog = WebSystrayView(self._application, self._systray_icon)
+            self.__dialog.destroyed.connect(self.on_delete)
+            self.__dialog._icon = self._systray_icon
 
-    @QtCore.pyqtSlot()
-    def onHide(self):
-        if self.dlg:
-            self.dlg.shouldHide()
-
-    @QtCore.pyqtSlot()
-    def onShow(self):
-        log.trace("Show systray menu")
-        if self.dlg is None:
-            self.dlg = WebSystrayView(self._application, self._systray_icon)
             # Close systray when app is quitting
-            self._application.aboutToQuit.connect(self.dlg.close)
-            self.dlg.destroyed.connect(self.dialogDeleted)
-        self.dlg._icon = self._systray_icon
-        self.dlg.show()
+            self._application.aboutToQuit.connect(self.__dialog.close)
+        return self.__dialog
+
+    @pyqtSlot()
+    def on_delete(self):
+        self.__dialog = None
+
+    @pyqtSlot()
+    def on_hide(self):
+        if not self.dialog.geometry().contains(QCursor.pos()):
+            log.trace('Hide systray menu')
+            self.dialog.hide()
+
+    @pyqtSlot()
+    def on_show(self):
+        log.trace('Show systray menu')
+        self.dialog.show()


### PR DESCRIPTION
[WIP, do **not** merge]

Several points about this PR:

- Reordered imports, and use `from PyQt4.xxx import yyy` to facilitate future transition to Qt5.
- Removed several too broad `Exception` as they are catched at a higher level, and the code is more readable now
- Several modifications to be more PEP8 compliant
- Several small refactors: the menu seems more reactive
- The `replace` method has been greatly simplfied. The menu acts more like it should: its position is based on the icon position, not the cursor one.
- Add GUI tests for the first time (still need work)

I tried on GNU/Linux and Windows and changes don't break something.
Need tests on Mac.