### PR TITLE
NXDRIVE-689: Handle long paths name on setup on Windows (#133)

### DIFF
--- a/nuxeo-drive-client/nxdrive/client/local_client.py
+++ b/nuxeo-drive-client/nxdrive/client/local_client.py
@@ -134,7 +134,8 @@ class LocalClient(BaseClient):
     def is_case_sensitive(self):
         if self._case_sensitive is None:
             lock = self.unlock_path(self.base_folder, unlock_parent=False)
-            path = tempfile.mkdtemp(prefix='.caseTest_', dir=self.base_folder)
+            path = tempfile.mkdtemp(prefix='.caseTest_',
+                                    dir=safe_long_path(self.base_folder))
             if os.path.exists(path.upper()):
                 self._case_sensitive = False
             else:


### PR DESCRIPTION
A rewrite of #133 to match with CI changes.