### PR TITLE
NXDRIVE-742: Add native LocalClient tests to simulate Drive operations

### DIFF
--- a/nuxeo-drive-client/tests/mac_local_client.py
+++ b/nuxeo-drive-client/tests/mac_local_client.py
@@ -1,69 +1,76 @@
-from nxdrive.client.local_client import LocalClient
-'''
-Intent of this file is to use OSX File Manager to make FS operation
-'''
+"""
+Intent of this file is to use OSX File Manager to make FS operations to simulate
+user actions.
+"""
+import sys
 
 import os
-import sys
+
+from nxdrive.client.local_client import LocalClient
+
 if sys.platform == 'darwin':
     import Cocoa
 
 
 class MacLocalClient(LocalClient):
+    def __init__(self, base_folder, digest_func='md5', ignored_prefixes=None,
+                 ignored_suffixes=None, check_suspended=None,
+                 case_sensitive=None, disable_duplication=False):
+        super(MacLocalClient, self).__init__(base_folder, digest_func,
+                                             ignored_prefixes, ignored_suffixes,
+                                             check_suspended, case_sensitive,
+                                             disable_duplication)
+        self.fm = Cocoa.NSFileManager.defaultManager()
 
-       def __init__(self, base_folder, digest_func='md5', ignored_prefixes=None,
-                        ignored_suffixes=None, check_suspended=None, case_sensitive=None, disable_duplication=False):
-            super(MacLocalClient, self).__init__(base_folder, digest_func, ignored_prefixes, ignored_suffixes,
-                                                 check_suspended, case_sensitive, disable_duplication)
-            self.fm = Cocoa.NSFileManager.defaultManager()
+    def copy(self, srcref, dstref):
+        src = self._abspath(srcref)
+        dst = self._abspath(dstref)
+        path, name = os.path.split(src)
+        if not os.path.exists(dst) and not os.path.exists(os.path.dirname(dst)):
+            raise ValueError('parent destination directory %s does not exist',
+                             os.path.dirname(dst))
+        if os.path.isdir(src) and os.path.exists(dst) and os.path.isfile(dst):
+            raise ValueError('cannnot copy directory %s to a file %s', src, dst)
+        if os.path.exists(dst) and os.path.isdir(dst):
+            dst = os.path.join(dst, name)
 
-       def copy(self, srcref, dstref):
-            src = self._abspath(srcref)
-            dst = self._abspath(dstref)
-            path, name = os.path.split(src)
-            if not os.path.exists(dst) and not os.path.exists(os.path.dirname(dst)):
-                raise ValueError('parent destination directory %s does not exist', os.path.dirname(dst))
-            if os.path.isdir(src) and os.path.exists(dst) and os.path.isfile(dst):
-                raise ValueError('cannnot copy directory %s to a file %s', src, dst)
-            if os.path.exists(dst) and os.path.isdir(dst):
-                dst = os.path.join(dst, name)
+        error = None
+        result = self.fm.copyItemAtPath_toPath_error_(src, dst, error)
+        self._process_result(result)
 
-            error = None
-            result = self.fm.copyItemAtPath_toPath_error_(src, dst, error)
-            self._process_result(result)
+    def move(self, srcref, parentref, name=None):
+        src = self._abspath(srcref)
+        parent = self._abspath(parentref)
+        path, srcname = os.path.split(src)
 
-       def move(self, srcref, parentref, name=None):
-            src = self._abspath(srcref)
-            parent = self._abspath(parentref)
-            path, srcname = os.path.split(src)
+        if name:
+            srcname = name
+        dst = os.path.join(parent, srcname)
 
-            if name:
-                srcname = name
-            dst = os.path.join(parent, srcname)
+        error = None
+        result = self.fm.moveItemAtPath_toPath_error_(src, dst, error)
+        self._process_result(result)
 
-            error = None
-            result = self.fm.moveItemAtPath_toPath_error_(src, dst, error)
-            self._process_result(result)
+    def duplicate_file(self, srcref):
+        parent = os.path.dirname(srcref)
+        name = os.path.basename(srcref)
+        os_path, name = self._abspath_deduped(parent, name)
+        dstref = os.path.join(parent, name)
+        self.copy(srcref, dstref)
+        return dstref
 
-       def duplicate_file(self, srcref):
-            parent = os.path.dirname(srcref)
-            name = os.path.basename(srcref)
-            os_path, name = self._abspath_deduped(parent, name)
-            dstref = os.path.join(parent, name)
-            self.copy(srcref, dstref)
-            return dstref
+    def rename(self, srcref, to_name):
+        parent = os.path.dirname(srcref)
+        dstref = os.path.join(parent)
+        self.move(srcref, dstref, name=to_name)
 
-       def rename(self, srcref, to_name):
-            parent = os.path.dirname(srcref)
-            dstref = os.path.join(parent)
-            self.move(srcref, dstref, name=to_name)
+    def delete(self, ref):
+        path = self._abspath(ref)
+        error = None
+        result = self.fm.removeItemAtPath_error_(path, error)
+        self._process_result(result)
 
-       def delete(self, ref):
-            path = self._abspath(ref)
-            error = None
-            result = self.fm.removeItemAtPath_error_(path, error)
-            self._process_result(result)
-
-       def _process_result(self, result):
-            if not result[0]:
-                raise IOError(result[1])
+    @staticmethod
+    def _process_result(result):
+        if not result[0]:
+            raise IOError(result[1])

--- a/nuxeo-drive-client/tests/test_local_client.py
+++ b/nuxeo-drive-client/tests/test_local_client.py
@@ -1,19 +1,30 @@
+"""
+Test LocalClient with native FS operations and specific OS ones.
+See win_local_client.py and mac_local_client.py for more informations.
+"""
 from time import sleep
 
 import hashlib
 import os
+from unittest import skipIf
 
-from nxdrive.client import NotFound
+from nxdrive.client import LocalClient, NotFound
+from nxdrive.osi import AbstractOSIntegration
 from tests.common import EMPTY_DIGEST, SOME_TEXT_CONTENT, SOME_TEXT_DIGEST
 from tests.common_unit_test import UnitTestCase
 
+try:
+    from exceptions import WindowsError
+except ImportError:
+    WindowsError = IOError
 
-class TestLocalClient(UnitTestCase):
 
-    def setUp(self):
-        super(TestLocalClient, self).setUp()
-        self.engine_1.start()
-        self.wait_sync()
+class StubLocalClient(object):
+    """ All tests goes here. If you need to implement a special behavior for
+        one OS, override the test method in the class TestLocalClientSimulation.
+        Check TestLocalClientSimulation.test_complex_filenames() for a real
+        world example.
+    """
 
     def test_make_documents(self):
         doc_1 = self.local_client_1.make_file('/', 'Document 1.txt')
@@ -28,7 +39,8 @@ class TestLocalClient(UnitTestCase):
         doc_2 = self.local_client_1.make_file('/', 'Document 2.txt',
                                               content=SOME_TEXT_CONTENT)
         self.assertTrue(self.local_client_1.exists(doc_2))
-        self.assertEqual(self.local_client_1.get_content(doc_2), SOME_TEXT_CONTENT)
+        self.assertEqual(self.local_client_1.get_content(doc_2),
+                         SOME_TEXT_CONTENT)
         doc_2_info = self.local_client_1.get_info(doc_2)
         self.assertEqual(doc_2_info.name, 'Document 2.txt')
         self.assertEqual(doc_2_info.path, doc_2)
@@ -55,7 +67,8 @@ class TestLocalClient(UnitTestCase):
 
     def test_get_info_invalid_date(self):
         doc_1 = self.local_client_1.make_file('/', 'Document 1.txt')
-        os.utime(self.local_client_1._abspath(os.path.join('/', 'Document 1.txt')), (0, 999999999999999))
+        os.utime(self.local_client_1._abspath(
+                os.path.join('/', 'Document 1.txt')), (0, 999999999999999))
         doc_1_info = self.local_client_1.get_info(doc_1)
         self.assertEqual(doc_1_info.name, 'Document 1.txt')
         self.assertEqual(doc_1_info.path, doc_1)
@@ -95,7 +108,8 @@ class TestLocalClient(UnitTestCase):
         file_2 = self.local_client_1.make_file(folder_1, invalid_filename)
         file_2 = self.local_client_1.get_info(file_2)
         self.assertEqual(file_2.name, escaped_filename)
-        self.assertEqual(file_2.path, folder_1_info.path + u'/' + escaped_filename)
+        self.assertEqual(
+                file_2.path, folder_1_info.path + u'/' + escaped_filename)
 
     def test_missing_file(self):
         with self.assertRaises(NotFound):
@@ -111,14 +125,15 @@ class TestLocalClient(UnitTestCase):
         self.local_client_1.make_file(folder_1, 'File 2.txt', content=b'bar\n')
 
         # ignored files
-        self.local_client_1.make_file('/', '.File 2.txt', content=b'baz\n')
-        self.local_client_1.make_file('/', '~$File 2.txt', content=b'baz\n')
-        self.local_client_1.make_file('/', 'File 2.txt~', content=b'baz\n')
-        self.local_client_1.make_file('/', 'File 2.txt.swp', content=b'baz\n')
-        self.local_client_1.make_file('/', 'File 2.txt.lock', content=b'baz\n')
-        self.local_client_1.make_file('/', 'File 2.txt.LOCK', content=b'baz\n')
-        self.local_client_1.make_file('/', 'File 2.txt.part', content=b'baz\n')
-        self.local_client_1.make_file('/', '.File 2.txt.nxpart', content=b'baz\n')
+        data = b'baz\n'
+        self.local_client_1.make_file('/', '.File 2.txt', content=data)
+        self.local_client_1.make_file('/', '~$File 2.txt', content=data)
+        self.local_client_1.make_file('/', 'File 2.txt~', content=data)
+        self.local_client_1.make_file('/', 'File 2.txt.swp', content=data)
+        self.local_client_1.make_file('/', 'File 2.txt.lock', content=data)
+        self.local_client_1.make_file('/', 'File 2.txt.LOCK', content=data)
+        self.local_client_1.make_file('/', 'File 2.txt.part', content=data)
+        self.local_client_1.make_file('/', '.File 2.txt.nxpart', content=data)
 
         workspace_children = self.local_client_1.get_children_info('/')
         self.assertEqual(len(workspace_children), 3)
@@ -127,7 +142,8 @@ class TestLocalClient(UnitTestCase):
         self.assertEqual(workspace_children[2].path, folder_2)
 
     def test_deep_folders(self):
-        # Check that local client can workaround the default windows MAX_PATH limit
+        # Check that local client can workaround the default >indows
+        # MAX_PATH limit
         folder = '/'
         for _i in range(30):
             folder = self.local_client_1.make_folder(folder, '0123456789')
@@ -147,11 +163,13 @@ class TestLocalClient(UnitTestCase):
         deep_child_info = deep_children[0]
         self.assertEqual(deep_file_info.name, deep_child_info.name)
         self.assertEqual(deep_file_info.path, deep_child_info.path)
-        self.assertEqual(deep_file_info.get_digest(), deep_child_info.get_digest())
+        self.assertEqual(deep_file_info.get_digest(),
+                         deep_child_info.get_digest())
 
         # Update the file content
         self.local_client_1.update_content(deep_file, b'New Content.')
-        self.assertEqual(self.local_client_1.get_content(deep_file), b'New Content.')
+        self.assertEqual(self.local_client_1.get_content(deep_file),
+                         b'New Content.')
 
         # Delete the folder
         self.local_client_1.delete(folder)
@@ -163,7 +181,8 @@ class TestLocalClient(UnitTestCase):
         self.assertFalse(self.local_client_1.exists('/0123456789'))
 
     def test_get_new_file(self):
-        path, os_path, name = self.local_client_1.get_new_file('/', 'Document 1.txt')
+        path, os_path, name = self.local_client_1.get_new_file('/',
+                                                               'Document 1.txt')
         self.assertEqual(path, '/Document 1.txt')
         self.assertTrue(os_path.endswith(os.path.join(self.workspace_title,
                                                       'Document 1.txt')))
@@ -183,25 +202,94 @@ class TestLocalClient(UnitTestCase):
         self.assertTrue(mtime == int(os.path.getmtime(path)))
 
     def test_get_path(self):
-        abs_path = os.path.join(self.local_nxdrive_folder_1, self.workspace_title, 'Test doc.txt')
-        self.assertEqual(self.local_client_1.get_path(abs_path), '/Test doc.txt')
+        abs_path = os.path.join(self.local_nxdrive_folder_1,
+                                self.workspace_title,
+                                'Test doc.txt')
+        self.assertEqual(self.local_client_1.get_path(abs_path),
+                         '/Test doc.txt')
 
     def test_is_equal_digests(self):
         content = b'joe'
-        local_path = self.local_client_1.make_file('/', 'File.txt', content=content)
+        local_path = self.local_client_1.make_file('/', 'File.txt',
+                                                   content=content)
         local_digest = hashlib.md5(content).hexdigest()
         # Equal digests
-        self.assertTrue(self.local_client_1.is_equal_digests(local_digest, local_digest, local_path))
+        self.assertTrue(self.local_client_1.is_equal_digests(local_digest,
+                                                             local_digest,
+                                                             local_path))
+
         # Different digests with same digest algorithm
         other_content = b'jack'
         remote_digest = hashlib.md5(other_content).hexdigest()
         self.assertNotEqual(local_digest, remote_digest)
-        self.assertFalse(self.local_client_1.is_equal_digests(local_digest, remote_digest, local_path))
+        self.assertFalse(self.local_client_1.is_equal_digests(local_digest,
+                                                              remote_digest,
+                                                              local_path))
+
         # Different digests with different digest algorithms but same content
         remote_digest = hashlib.sha1(content).hexdigest()
         self.assertNotEqual(local_digest, remote_digest)
-        self.assertTrue(self.local_client_1.is_equal_digests(local_digest, remote_digest, local_path))
-        # Different digests with different digest algorithms and different content
+        self.assertTrue(self.local_client_1.is_equal_digests(local_digest,
+                                                             remote_digest,
+                                                             local_path))
+
+        # Different digests with different digest algorithms and different
+        # content
         remote_digest = hashlib.sha1(other_content).hexdigest()
         self.assertNotEqual(local_digest, remote_digest)
-        self.assertFalse(self.local_client_1.is_equal_digests(local_digest, remote_digest, local_path))
+        self.assertFalse(self.local_client_1.is_equal_digests(local_digest,
+                                                              remote_digest,
+                                                              local_path))
+
+
+class TestLocalClientNative(StubLocalClient, UnitTestCase):
+    """ Test LocalClient using native python commands to make FS operations.
+        This will simulate Drive actions.
+    """
+
+    def setUp(self):
+        super(TestLocalClientNative, self).setUp()
+        self.engine_1.start()
+        self.wait_sync()
+
+    def get_local_client(self, path):
+        return LocalClient(path)
+
+
+@skipIf(AbstractOSIntegration.is_linux(),
+        'GNU/Linux uses native LocalClient.')
+class TestLocalClientSimulation(StubLocalClient, UnitTestCase):
+    """ Test LocalClient using OS specific commands to make FS operations.
+        This will simulate user actions on:
+            - Explorer (Windows)
+            - File Manager (macOS)
+    """
+
+    def setUp(self):
+        super(TestLocalClientSimulation, self).setUp()
+        self.engine_1.start()
+        self.wait_sync()
+
+    def test_complex_filenames(self):
+        """ It should fail on Windows:
+            Explorer cannot find the directory as the path is way to long.
+        """
+
+        if AbstractOSIntegration.is_windows():
+            # IOError: [Errno 2] No such file or directory
+            with self.assertRaises(IOError):
+                super(TestLocalClientSimulation, self).test_complex_filenames()
+        else:
+            super(TestLocalClientSimulation, self).test_complex_filenames()
+
+    def test_deep_folders(self):
+        """ It should fail on Windows:
+            Explorer cannot deal with very long paths.
+        """
+
+        if AbstractOSIntegration.is_windows():
+            # WindowsError: [Error 206] The filename or extension is too long
+            with self.assertRaises(WindowsError):
+                super(TestLocalClientSimulation, self).test_deep_folders()
+        else:
+            super(TestLocalClientSimulation, self).test_deep_folders()

--- a/nuxeo-drive-client/tests/win_local_client.py
+++ b/nuxeo-drive-client/tests/win_local_client.py
@@ -1,25 +1,35 @@
-'''
-Intent of this file is ...
+"""
+Intent of this file is to use Explorer operations to make FS to simulate user
+actions.
 
 https://msdn.microsoft.com/en-us/library/windows/desktop/bb775771(v=vs.85).aspx
 Using SHFileOperation as the MSDN advise to use it for multithread
 
-IFileOperation can only be applied in a single-threaded apartment (STA) situation. It cannot be used for a multithreaded apartment (MTA) situation. For MTA, you still must use SHFileOperation.
-'''
-from nxdrive.client.local_client import LocalClient
-from win32com.shell import shell, shellcon
+IFileOperation can only be applied in a single-threaded apartment (STA)
+situation. It cannot be used for a multithreaded apartment (MTA) situation.
+For MTA, you still must use SHFileOperation.
+"""
 import os
+from win32com.shell import shell, shellcon
+
+from nxdrive.client.local_client import LocalClient
 
 
 class WindowsLocalClient(LocalClient):
     def __init__(self, base_folder, digest_func='md5', ignored_prefixes=None,
-                    ignored_suffixes=None, check_suspended=None, case_sensitive=None, disable_duplication=False):
-        super(WindowsLocalClient, self).__init__(base_folder, digest_func, ignored_prefixes, ignored_suffixes,
-                                            check_suspended, case_sensitive, disable_duplication)
+                 ignored_suffixes=None, check_suspended=None,
+                 case_sensitive=None, disable_duplication=False):
+        super(WindowsLocalClient, self).__init__(base_folder, digest_func,
+                                                 ignored_prefixes,
+                                                 ignored_suffixes,
+                                                 check_suspended,
+                                                 case_sensitive,
+                                                 disable_duplication)
 
     def delete_final(self, ref):
         path = self._abspath(ref)
-        res = shell.SHFileOperation((0, shellcon.FO_DELETE, path, None, shellcon.FOF_NOCONFIRMATION, None, None))
+        res = shell.SHFileOperation((0, shellcon.FO_DELETE, path, None,
+                                     shellcon.FOF_NOCONFIRMATION, None, None))
         if res[0] != 0:
             raise IOError(res)
 
@@ -28,20 +38,23 @@ class WindowsLocalClient(LocalClient):
         if name is None:
             name = os.path.basename(path)
         new_path = os.path.join(self._abspath(new_parent_ref), name)
-        res = shell.SHFileOperation((0, shellcon.FO_MOVE, path, new_path, shellcon.FOF_NOCONFIRMATION, None, None))
+        res = shell.SHFileOperation((0, shellcon.FO_MOVE, path, new_path,
+                                     shellcon.FOF_NOCONFIRMATION, None, None))
         if res[0] != 0:
             raise IOError(res)
 
     def duplicate_file(self, ref):
-        #return super(WindowsLocalClient, self).duplicate_file(ref)
+        # return super(WindowsLocalClient, self).duplicate_file(ref)
         parent = os.path.dirname(ref)
         name = os.path.basename(ref)
         locker = self.unlock_ref(parent, False)
         os_path, name = self._abspath_deduped(parent, name)
         try:
             res = shell.SHFileOperation((0, shellcon.FO_COPY, os_path,
-                                   self._abspath(ref), shellcon.FOF_NOCONFIRMATION, None, None))
-            if      res[0] != 0:
+                                         self._abspath(ref),
+                                         shellcon.FOF_NOCONFIRMATION, None,
+                                         None))
+            if res[0] != 0:
                 raise IOError(res)
             if parent == u"/":
                 return u"/" + name
@@ -56,7 +69,8 @@ class WindowsLocalClient(LocalClient):
     def rename(self, ref, to_name):
         path = self._abspath(ref)
         new_path = os.path.join(os.path.dirname(path), to_name)
-        res = shell.SHFileOperation((0, shellcon.FO_RENAME, path, new_path, shellcon.FOF_NOCONFIRMATION, None, None))
+        res = shell.SHFileOperation((0, shellcon.FO_RENAME, path, new_path,
+                                     shellcon.FOF_NOCONFIRMATION, None, None))
         if res[0] != 0:
             raise IOError(res)
 
@@ -64,6 +78,7 @@ class WindowsLocalClient(LocalClient):
         path = self._abspath(ref)
         # FOF_ALLOWUNDO send to Trash
         res = shell.SHFileOperation((0, shellcon.FO_DELETE, path, None,
-                                     shellcon.FOF_NOCONFIRMATION|shellcon.FOF_ALLOWUNDO, None, None))
+                                     shellcon.FOF_NOCONFIRMATION | shellcon.FOF_ALLOWUNDO,
+                                     None, None))
         if res[0] != 0:
             raise IOError(res)


### PR DESCRIPTION
Also:
    - Optimize imports
    - Several PEP8 fixes

Real changes starts at ligne 245 in test_local_client.py. I renamed the class `TestLocalClient` to `StubLocalClient` and added two classes that inherit of it. Tests are declared into that class.

Then to test OS specific operations (like Explorer or OSX File Manager), the class `TestLocalClientSimulation` overrides few test methods to explicitely fail when needed. And the class `TestLocalClientNative` uses the native/normal `LocalClient` as Drive would do to test Drive operations.

Finally GNU/Linux does not need to test specific behaviors because it uses native LocalClient by default.