### PR TITLE
NXDRIVE-767: Add time.sleep() average error test file

### DIFF
--- a/nuxeo-drive-client/tests/test_aaa.py
+++ b/nuxeo-drive-client/tests/test_aaa.py
@@ -1,0 +1,21 @@
+# coding: utf-8
+""" Simple tests that must be launched first. """
+
+from datetime import datetime
+from time import sleep
+
+
+def test_time_sleep(capsys):
+    """ Simple test to check accurancy of time.sleep(). """
+
+    def check_sleep(amount):
+        start = datetime.now()
+        sleep(amount)
+        end = datetime.now()
+        delta = end - start
+        return delta.seconds + delta.microseconds / 1000000.0
+
+    error = sum(abs(check_sleep(0.1) - 0.1) for _ in range(100)) * 10
+
+    with capsys.disabled():
+        print('check: time.sleep() average error is {:0.2}ms'.format(error))


### PR DESCRIPTION
With this commit, we will have a new line printed after test initializations:

    >>> Launching the tests suite
    Test session starts (platform: linux2, Python 2.7.13, pytest 3.0.6, pytest-sugar 0.8.0)
    run-last-failure: rerun last 1 failures first
    rootdir: nuxeo-drive, inifile: 
    plugins: sugar-0.8.0, cov-2.4.0
    check: time.sleep() average error is 0.22ms

To ensure failing tests with sync timeout are related or not to this function.