### PR TITLE
NXDRIVE-756: Fix test_synchronize_special_filenames on Windows

### DIFF
--- a/nuxeo-drive-client/nxdrive/client/local_client.py
+++ b/nuxeo-drive-client/nxdrive/client/local_client.py
@@ -418,10 +418,9 @@ class LocalClient(BaseClient):
         os_path = self._abspath(ref)
         if not os.path.exists(os_path):
             if raise_if_missing:
-                raise NotFound("Could not found file '%s' under '%s'" % (
-                ref, self.base_folder))
-            else:
-                return None
+                err = 'Could not find file into {!r}: ref={!r}, os_path={!r}'
+                raise NotFound(err.format(self.base_folder, ref, os_path))
+            return None
         folderish = os.path.isdir(os_path)
         stat_info = os.stat(os_path)
         if folderish:
@@ -534,9 +533,10 @@ class LocalClient(BaseClient):
                 child_ref = self.get_children_ref(ref, child_name)
                 try:
                     result.append(self.get_info(child_ref))
-                except (OSError, NotFound):
+                except (OSError, NotFound) as e:
                     # the child file has been deleted in the mean time or while
                     # reading some of its attributes
+                    log.exception(e)
                     pass
 
         return result

--- a/nuxeo-drive-client/tests/test_synchronization.py
+++ b/nuxeo-drive-client/tests/test_synchronization.py
@@ -2,7 +2,6 @@ import time
 import urllib2
 import socket
 
-from unittest import skipIf
 from tests.common import TEST_WORKSPACE_PATH
 from tests.common import OS_STAT_MTIME_RESOLUTION
 from tests.common_unit_test import UnitTestCase
@@ -597,8 +596,6 @@ class TestSynchronization(UnitTestCase):
         self.assertEqual(sorted_states[2].local_name, 'Folder in readonly folder')
         self.assertEqual(sorted_states[2].pair_state, 'unsynchronized')
 
-    @skipIf(AbstractOSIntegration.is_windows(),
-            'TODO: NXDRIVE-756')
     def test_synchronize_special_filenames(self):
         local = self.local_client_1
         remote = self.remote_document_client_1

--- a/nuxeo-drive-client/tests/test_synchronization.py
+++ b/nuxeo-drive-client/tests/test_synchronization.py
@@ -602,41 +602,41 @@ class TestSynchronization(UnitTestCase):
         self.engine_1.start()
 
         # Create a remote folder with a weird name
-        folder = remote.make_folder(self.workspace, u'Folder with forbidden chars: / \\ * < > ? "')
+        folder = remote.make_folder(self.workspace, u'Folder with chars: / \\ * < > ? "')
 
         self.wait_sync(wait_for_async=True)
         folder_names = [i.name for i in local.get_children_info('/')]
-        self.assertEqual(folder_names, [u'Folder with forbidden chars- - - - - - - -'])
+        self.assertEqual(folder_names, [u'Folder with chars- - - - - - - -'])
 
         # Create a remote file with a weird name
-        file_ = remote.make_file(folder, u'File with forbidden chars: / \\ * < > ? "', content="some content",
+        file_ = remote.make_file(folder, u'File with chars: / \\ * < > ? "', content="some content",
                                  doc_type='Note')
 
         self.wait_sync(wait_for_async=True)
         file_names = [i.name for i in local.get_children_info(local.get_children_info('/')[0].path)]
-        self.assertEqual(file_names, [u'File with forbidden chars- - - - - - - -.txt'])
+        self.assertEqual(file_names, [u'File with chars- - - - - - - -.txt'])
 
         # Update a remote file with a weird name (NXDRIVE-286)
         remote.update(file_, properties={'note:note': 'new content'})
         self.wait_sync(wait_for_async=True, enforce_errors=False)
         self.assertEqual(local.get_content(
-            u'/Folder with forbidden chars- - - - - - - -/File with forbidden chars- - - - - - - -.txt'), "new content")
-        file_state = self.get_dao_state_from_engine_1(u'/Folder with forbidden chars- - - - - - - -' +
-                                                      u'/File with forbidden chars- - - - - - - -.txt')
+            u'/Folder with chars- - - - - - - -/File with chars- - - - - - - -.txt'), "new content")
+        file_state = self.get_dao_state_from_engine_1(u'/Folder with chars- - - - - - - -' +
+                                                      u'/File with chars- - - - - - - -.txt')
         self.assertEqual(file_state.pair_state, 'synchronized')
         self.assertEqual(file_state.local_digest, file_state.remote_digest)
 
         # Update note title with a weird name
-        remote.update(file_, properties={'dc:title': u'File with forbidden chars: / \\ * < > ? " - 2'})
+        remote.update(file_, properties={'dc:title': u'File with chars: / \\ * < > ? " - 2'})
         self.wait_sync(wait_for_async=True, enforce_errors=False)
         file_names = [i.name for i in local.get_children_info(local.get_children_info('/')[0].path)]
-        self.assertEqual(file_names, [u'File with forbidden chars- - - - - - - - - 2.txt'])
+        self.assertEqual(file_names, [u'File with chars- - - - - - - - - 2.txt'])
 
         # Update note title changing the case (NXRIVE-532)
-        remote.update(file_, properties={'dc:title': u'file with forbidden chars: / \\ * < > ? " - 2'})
+        remote.update(file_, properties={'dc:title': u'file with chars: / \\ * < > ? " - 2'})
         self.wait_sync(wait_for_async=True, enforce_errors=False)
         file_names = [i.name for i in local.get_children_info(local.get_children_info('/')[0].path)]
-        self.assertEqual(file_names, [u'file with forbidden chars- - - - - - - - - 2.txt'])
+        self.assertEqual(file_names, [u'file with chars- - - - - - - - - 2.txt'])
 
     def test_synchronize_error_remote(self):
         from urllib2 import HTTPError


### PR DESCRIPTION
The cause was that the path + file name was >260 characters in the last `remote.update()` operation.
As this test uses the `WindowsLocalClient`, the prefix for long path (`\\?\`) was removed.
And so, the test failed because it could not find the path anymore.