### PR TITLE
NXDRIVE-747: Insert the current path at the first place when building…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -409,7 +409,7 @@ class NuxeoDriveSetup(object):
             from esky.util import get_platform
 
             # build_exe does not seem to take the package_dir info into account
-            sys.path.append(attribs.get_path_append())
+            sys.path.insert(0, attribs.get_path_append())
 
             executables = [cx_Executable(script)]
             freeze_options = dict()


### PR DESCRIPTION
… executable

This was the cause of auto-update endless loop. If Nuxeo Drive was already
installed via pip on the system, the package builder was shipping that
Nuxeo Drive instead of the one from fresh sources.