### PR TITLE
NXDRIVE-571: Work on a local branch to allow git push

### DIFF
--- a/tools/jenkins/beta.groovy
+++ b/tools/jenkins/beta.groovy
@@ -20,7 +20,14 @@ node('IT') {
         env.DRY_RUN = params.DRY_RUN
 
         stage('Checkout') {
+            deleteDir()
             checkout scm
+            checkout([
+                $class: 'GitSCM', branches: [[name: '*/master']],
+                extensions: [
+                    [$class: 'CleanCheckout'],
+                    [$class: 'LocalBranch', localBranch: 'master']]
+            ])
         }
 
         stage('Create') {


### PR DESCRIPTION
I think this will fix the current problem:

    [Drive-beta] Running shell script
    + tools/release.sh --create
    >>> [beta 2.3.331] Creating the commit
    [detached HEAD c98220f5] Release 2.3.331
     1 file changed, 1 insertion(+), 1 deletion(-)
    error: src refspec master does not match any.
    error: failed to push some refs to 'https://github.com/nuxeo/nuxeo-drive.git'

Source: https://github.com/dalalv/jenkinsfiles/blob/master/jenkinsfile-push-to-git-repo