### PR TITLE
fix-NXDRIVE-646-NXDRIVE-647-wait-sync-after-rebind

### DIFF
--- a/nuxeo-drive-client/tests/test_local_move_folders.py
+++ b/nuxeo-drive-client/tests/test_local_move_folders.py
@@ -185,10 +185,9 @@ class TestLocalMoveFolders(UnitTestCase):
         if unbind:
             self.send_bind_engine(1)
             self.wait_bind_engine(1)
-            self.wait_remote_scan()
         else:
             self.engine_1.start()
-            self.wait_sync(wait_for_async=True)
+        self.wait_sync(wait_for_async=True)
 
         # Check that nothing has changed
         self.assertEqual(len(remote.get_children_info(self.workspace)), 1)

--- a/nuxeo-drive-client/tests/test_shared_folders.py
+++ b/nuxeo-drive-client/tests/test_shared_folders.py
@@ -146,10 +146,9 @@ class TestSharedFolders(UnitTestCase):
         if unbind:
             self.send_bind_engine(1)
             self.wait_bind_engine(1)
-            self.wait_remote_scan()
         else:
             self.engine_1.start()
-            self.wait_sync()
+        self.wait_sync()
 
         # Check client side
         self.assertTrue(local_1.exists('/Folder01'))


### PR DESCRIPTION
Should fix the random bug observed in test_local_changes_while_unbinded, see https://qa.nuxeo.org/jenkins/view/Drive/job/Drive/job/FT-drive/job/task-NXDRIVE-808-try-no-random-bugs-bypass/7/consoleFull.