### PR TITLE
NXDRIVE-158: Allow configuring ignored prefixes and suffixes in the local configuration

### DIFF
--- a/nuxeo-drive-client/nxdrive/__init__.py
+++ b/nuxeo-drive-client/nxdrive/__init__.py
@@ -7,4 +7,4 @@ To declare a beta, use this schema:
     - X.Y.ZbN i.e. "2.4.5b1"
 """
 
-__version__ = '2.4.0'
+__version__ = '2.4.1'

--- a/nuxeo-drive-client/nxdrive/client/common.py
+++ b/nuxeo-drive-client/nxdrive/client/common.py
@@ -66,21 +66,23 @@ class NotFound(Exception):
 
 DEFAULT_REPOSITORY_NAME = 'default'
 
-DEFAULT_IGNORED_PREFIXES = [
+DEFAULT_IGNORED_PREFIXES = tuple({
     '.',  # hidden Unix files
     '~$',  # Windows lock files
     'Thumbs.db',  # Thumbnails files
     'Icon\r',  # Mac Icon
     'desktop.ini',  # Icon for windows
-]
+})
 
-DEFAULT_IGNORED_SUFFIXES = [
+DEFAULT_IGNORED_SUFFIXES = tuple({
     '~',  # editor buffers
     '.swp',  # vim swap files
     '.lock',  # some process use file locks
     '.LOCK',  # other locks
-    '.part', '.crdownload', '.partial',  # partially downloaded files by browsers
-]
+    '.part',  # partially downloaded files by browsers
+    '.crdownload',  # partially downloaded files by browsers
+    '.partial',  # partially downloaded files by browsers
+})
 
 # Default buffer size for file upload / download and digest computation
 FILE_BUFFER_SIZE = 1024 ** 2

--- a/nuxeo-drive-client/nxdrive/client/remote_document_client.py
+++ b/nuxeo-drive-client/nxdrive/client/remote_document_client.py
@@ -339,20 +339,12 @@ class RemoteDocumentClient(BaseAutomationClient):
         for info in [self._doc_to_info(d, fetch_parent_uid=fetch_parent_uid,
                                        parent_uid=parent_uid)
                      for d in entries]:
-            ignore = False
 
-            for suffix in self.ignored_suffixes:
-                if info.name.endswith(suffix):
-                    ignore = True
-                    break
+            if (info.name.endswith(self.ignored_suffixes)
+                    or info.name.startswith(self.ignored_prefixes)):
+                continue
 
-            for prefix in self.ignored_prefixes:
-                if info.name.startswith(prefix):
-                    ignore = True
-                    break
-
-            if not ignore:
-                filtered.append(info)
+            filtered.append(info)
 
         return filtered
 

--- a/nuxeo-drive-client/nxdrive/commandline.py
+++ b/nuxeo-drive-client/nxdrive/commandline.py
@@ -1,23 +1,22 @@
-"""Utilities to operate Nuxeo Drive from the command line"""
+# coding: utf-8
+""" Utilities to operate Nuxeo Drive from the command line. """
+import argparse
 import os
 import sys
-import argparse
-from getpass import getpass
-import traceback
 import threading
+import traceback
+from getpass import getpass
+
+from nxdrive import __version__
+from nxdrive.client.common import DEFAULT_REPOSITORY_NAME
+from nxdrive.logging_config import configure, get_logger
+from nxdrive.osi import AbstractOSIntegration
+from nxdrive.utils import default_nuxeo_drive_folder, normalized_path
+
 try:
-    import ipdb
-    debugger = ipdb
+    import ipdb as pdb
 except ImportError:
     import pdb
-    debugger = pdb
-
-from nxdrive.client.common import DEFAULT_REPOSITORY_NAME
-from nxdrive.utils import default_nuxeo_drive_folder, normalized_path
-from nxdrive.logging_config import configure
-from nxdrive.logging_config import get_logger
-from nxdrive.osi import AbstractOSIntegration
-from nxdrive import __version__
 
 
 DEFAULT_NX_DRIVE_FOLDER = default_nuxeo_drive_folder()
@@ -343,8 +342,7 @@ class CliHandler(object):
 
             def info(etype, value, tb):
                 traceback.print_exception(etype, value, tb)
-                print
-                debugger.pm()
+                pdb.pm()
 
             sys.excepthook = info
 
@@ -413,10 +411,10 @@ class CliHandler(object):
             self.manager.dispose_db()
             import shutil
             shutil.rmtree(self.manager.nxdrive_home)
-        except Exception, e:
+        except Exception as e:
             # Exit with 0 signal to not block the uninstall
-            print e
-            sys.exit(0)
+            print(e)
+            exit(0)
 
     def handle(self, argv):
         """Parse options, setup logs and manager and dispatch execution."""
@@ -426,7 +424,7 @@ class CliHandler(object):
         # 'launch' is the default command if None is provided
         command = options.command = getattr(options, 'command', 'launch')
 
-        if command != 'test' and command != 'uninstall':
+        if command != 'uninstall':
             # Configure the logging framework, except for the tests as they
             # configure their own.
             # Don't need uninstall logs either for now.
@@ -445,7 +443,7 @@ class CliHandler(object):
 
         # Find the command to execute based on the
         handler = getattr(self, command, None)
-        if handler is None:
+        if not handler:
             raise NotImplementedError(
                 'No handler implemented for command ' + options.command)
 
@@ -455,10 +453,9 @@ class CliHandler(object):
             if options.debug:
                 # Make it possible to use the postmortem debugger
                 raise
-            else:
-                msg = e.msg if hasattr(e, 'msg') else e
-                self.log.error("Error executing '%s': %s", command, msg,
-                          exc_info=True)
+            msg = e.msg if hasattr(e, 'msg') else e
+            self.log.error("Error executing '%s': %s", command, msg,
+                           exc_info=True)
 
     def get_manager(self, options):
         from nxdrive.manager import Manager
@@ -468,9 +465,8 @@ class CliHandler(object):
         if console:
             from nxdrive.console import ConsoleApplication
             return ConsoleApplication(self.manager, options)
-        else:
-            from nxdrive.wui.application import Application
-            return Application(self.manager, options)
+        from nxdrive.wui.application import Application
+        return Application(self.manager, options)
 
     def launch(self, options=None, console=False):
         """Launch the Qt app in the main thread and sync in another thread."""
@@ -529,8 +525,8 @@ class CliHandler(object):
         if options.local_folder is None or options.local_folder == "":
             options.local_folder = DEFAULT_NX_DRIVE_FOLDER
         self.manager.bind_server(options.local_folder, options.nuxeo_url,
-                                    options.username, password, start_engine=False,
-                                    check_credentials=check_credentials)
+                                 options.username, password, start_engine=False,
+                                 check_credentials=check_credentials)
         return 0
 
     def unbind_server(self, options):
@@ -634,4 +630,4 @@ def main(argv=None):
     return CliHandler().handle(argv)
 
 if __name__ == "__main__":
-    sys.exit(main())
+    exit(main())

--- a/nuxeo-drive-client/nxdrive/commandline.py
+++ b/nuxeo-drive-client/nxdrive/commandline.py
@@ -366,7 +366,7 @@ class CliHandler(object):
         user_ini = os.path.expanduser(os.path.join(self.default_home, config_name))
         if os.path.exists(user_ini):
             configs.append(user_ini)
-        if len(configs) > 0:
+        if configs:
             config.read(configs)
         if config.has_option(ConfigParser.DEFAULTSECT, 'env'):
             env = config.get(ConfigParser.DEFAULTSECT, 'env')
@@ -374,8 +374,14 @@ class CliHandler(object):
             for item in config.items(env):
                 if item[0] == 'env':
                     continue
-                args[item[0].replace('-', '_')] = item[1]
-            if len(args):
+                value = item[1]
+                if value == '':
+                    continue
+                if '\n' in item[1]:
+                    # Treat multiline option as a set
+                    value = set(item[1].split())
+                args[item[0].replace('-', '_')] = value
+            if args:
                 parser.set_defaults(**args)
         else:
             parser.set_defaults(**AbstractOSIntegration.get(None).get_system_configuration())

--- a/nuxeo-drive-client/nxdrive/direct_edit.py
+++ b/nuxeo-drive-client/nxdrive/direct_edit.py
@@ -40,13 +40,7 @@ class DirectEdit(Worker):
     directEditReadonly = pyqtSignal(object)
     directEditLocked = pyqtSignal(object, object, object)
 
-    '''
-    classdocs
-    '''
     def __init__(self, manager, folder, url):
-        '''
-        Constructor
-        '''
         super(DirectEdit, self).__init__()
         self._test = False
         self._manager = manager
@@ -56,7 +50,7 @@ class DirectEdit(Worker):
         self._metrics = dict()
         self._metrics['edit_files'] = 0
         self._observer = None
-        if type(folder) == str:
+        if isinstance(folder, bytes):
             folder = unicode(folder)
         self._folder = folder
         self._local_client = LocalClient(
@@ -120,7 +114,8 @@ class DirectEdit(Worker):
         if info.get('item_id') is not None:
             self.edit(info['server_url'], info['item_id'])
         else:
-            self.edit(info['server_url'], info['doc_id'], user=info['user'], download_url=info['download_url'])
+            self.edit(info['server_url'], info['doc_id'], user=info['user'],
+                      download_url=info['download_url'])
 
     def _cleanup(self):
         log.debug("Cleanup DirectEdit folder")
@@ -133,22 +128,24 @@ class DirectEdit(Worker):
                 if len(children) > 1:
                     log.warn("Cannot clean this document: %s", child.path)
                     continue
-                if (len(children) == 0):
+                if not children:
                     # Cleaning the folder it is empty
-                    shutil.rmtree(self._local_client.abspath(child.path), ignore_errors=True)
+                    shutil.rmtree(self._local_client.abspath(child.path),
+                                  ignore_errors=True)
                     continue
                 ref = children[0].path
                 try:
                     _,  _, _, digest_algorithm, digest = self._extract_edit_info(ref)
                 except NotFound:
                     # Engine is not known anymore
-                    shutil.rmtree(self._local_client.abspath(child.path), ignore_errors=True)
+                    shutil.rmtree(self._local_client.abspath(child.path),
+                                  ignore_errors=True)
                     continue
                 try:
                     # Don't update if digest are the same
                     info = self._local_client.get_info(ref)
                     current_digest = info.get_digest(digest_func=digest_algorithm)
-                    if (current_digest != digest):
+                    if current_digest != digest:
                         log.warn("Document has been modified and not synchronized, readd to upload queue")
                         self._upload_queue.put(ref)
                         continue
@@ -156,7 +153,8 @@ class DirectEdit(Worker):
                     log.debug(e)
                     continue
                 # Place for handle reopened of interrupted Edit
-                shutil.rmtree(self._local_client.abspath(child.path), ignore_errors=True)
+                shutil.rmtree(self._local_client.abspath(child.path),
+                              ignore_errors=True)
         if not os.path.exists(self._folder):
             os.mkdir(self._folder)
 
@@ -214,7 +212,9 @@ class DirectEdit(Worker):
         else:
             log.debug('Downloading file %r', info.filename)
             if url is not None:
-                remote_client.do_get(url, file_out=file_out, digest=info.digest, digest_algorithm=info.digest_algorithm)
+                remote_client.do_get(url, file_out=file_out,
+                                     digest=info.digest,
+                                     digest_algorithm=info.digest_algorithm)
             else:
                 remote_client.get_blob(info, file_out=file_out)
         return file_out
@@ -231,10 +231,7 @@ class DirectEdit(Worker):
         engine = self._get_engine(server_url, user=user)
         if engine is None:
             values = dict()
-            if user is None:
-                values['user'] = 'None'
-            else:
-                values['user'] = user
+            values['user'] = str(user)
             values['server'] = server_url
             log.warn("No engine found for server_url=%s, user=%s, doc_id=%s", server_url, user, doc_id)
             self._display_modal("DIRECT_EDIT_CANT_FIND_ENGINE", values)
@@ -346,7 +343,7 @@ class DirectEdit(Worker):
     def _handle_queues(self):
         uploaded = False
         # Lock any documents
-        while (not self._lock_queue.empty()):
+        while not self._lock_queue.empty():
             try:
                 item = self._lock_queue.get_nowait()
                 ref = item[0]
@@ -381,11 +378,11 @@ class DirectEdit(Worker):
                 self.directEditLockError.emit(item[1], os.path.basename(ref), uid)
         # Unqueue any errors
         item = self._error_queue.get()
-        while (item is not None):
+        while item:
             self._upload_queue.put(item.get())
             item = self._error_queue.get()
         # Handle the upload queue
-        while (not self._upload_queue.empty()):
+        while not self._upload_queue.empty():
             try:
                 ref = self._upload_queue.get_nowait()
                 log.trace('Handling DirectEdit queue ref: %r', ref)
@@ -428,7 +425,7 @@ class DirectEdit(Worker):
         if uploaded:
             log.debug('Emitting directEditUploadCompleted')
             self.directEditUploadCompleted.emit()
-        while (not self._watchdog_queue.empty()):
+        while not self._watchdog_queue.empty():
             evt = self._watchdog_queue.get()
             self.handle_watchdog_event(evt)
 
@@ -449,7 +446,7 @@ class DirectEdit(Worker):
             self.handle_url()
             if self._test:
                 log.trace("DirectEdit Entering main loop: continue:%r pause:%r running:%r", self._continue, self._pause, self._running)
-            while (1):
+            while True:
                 self._interact()
                 if self._test:
                     log.trace("DirectEdit post interact: continue:%r pause:%r running:%r", self._continue, self._pause, self._running)

--- a/nuxeo-drive-client/nxdrive/direct_edit.py
+++ b/nuxeo-drive-client/nxdrive/direct_edit.py
@@ -59,7 +59,11 @@ class DirectEdit(Worker):
         if type(folder) == str:
             folder = unicode(folder)
         self._folder = folder
-        self._local_client = LocalClient(self._folder)
+        self._local_client = LocalClient(
+            self._folder,
+            ignored_prefixes=manager.ignored_prefixes,
+            ignored_suffixes=manager.ignored_suffixes,
+        )
         self._upload_queue = Queue()
         self._lock_queue = Queue()
         self._error_queue = BlacklistQueue()

--- a/nuxeo-drive-client/nxdrive/engine/engine.py
+++ b/nuxeo-drive-client/nxdrive/engine/engine.py
@@ -837,7 +837,12 @@ class Engine(QObject):
                     thread.worker.quit()
 
     def get_local_client(self):
-        client = LocalClient(self._local_folder, case_sensitive=self._case_sensitive)
+        client = LocalClient(
+            self._local_folder,
+            case_sensitive=self._case_sensitive,
+            ignored_prefixes=self._manager.ignored_prefixes,
+            ignored_suffixes=self._manager.ignored_suffixes,
+        )
         if self._case_sensitive is None and os.path.exists(self._local_folder):
             self._case_sensitive = client.is_case_sensitive()
         return client

--- a/nuxeo-drive-client/nxdrive/manager.py
+++ b/nuxeo-drive-client/nxdrive/manager.py
@@ -250,9 +250,6 @@ class ProxySettings(object):
 
 
 class Manager(QtCore.QObject):
-    '''
-    classdocs
-    '''
     proxyUpdated = QtCore.pyqtSignal(object)
     clientUpdated = QtCore.pyqtSignal(object, object)
     engineNotFound = QtCore.pyqtSignal(object)
@@ -271,9 +268,6 @@ class Manager(QtCore.QObject):
         return Manager._singleton
 
     def __init__(self, options):
-        '''
-        Constructor
-        '''
         if Manager._singleton is not None:
             raise Exception("Only one instance of Manager can be create")
         Manager._singleton = self
@@ -327,7 +321,7 @@ class Manager(QtCore.QObject):
         if options.log_level_file is not None:
             # Set the log_level_file option
             handler = self._get_file_log_handler()
-            if handler is not None:
+            if handler:
                 handler.setLevel(options.log_level_file)
                 # Store it in the database
                 self._dao.update_config("log_level_file", str(handler.level))
@@ -337,7 +331,7 @@ class Manager(QtCore.QObject):
 
         # Add auto lock on edit
         res = self._dao.get_config("direct_edit_auto_lock")
-        if res is None:
+        if not res:
             self._dao.update_config("direct_edit_auto_lock", "1")
 
         # Persist update URL infos
@@ -382,7 +376,7 @@ class Manager(QtCore.QObject):
         self._pause = self.is_debug()
         self.device_id = self._dao.get_config("device_id")
         self.updated = False  # self.update_version()
-        if self.device_id is None:
+        if not self.device_id:
             self.generate_device_id()
 
         self.load()
@@ -561,7 +555,7 @@ class Manager(QtCore.QObject):
         self._dao = ManagerDAO(self._get_db())
 
     def _create_updater(self, update_check_delay):
-        if (update_check_delay == 0):
+        if update_check_delay == 0:
             log.info("Update check delay is 0, disabling autoupdate")
             self._app_updater = FakeUpdater()
             return self._app_updater
@@ -703,9 +697,9 @@ class Manager(QtCore.QObject):
         in_error = dict()
         self._engines = dict()
         for engine in self._engine_definitions:
-            if not engine.engine in self._engine_types:
+            if engine.engine not in self._engine_types:
                 log.warn("Can't find engine %s anymore", engine.engine)
-                if not engine.engine in in_error:
+                if engine.engine not in in_error:
                     in_error[engine.engine] = True
                     self.engineNotFound.emit(engine)
             self._engines[engine.uid] = self._engine_types[engine.engine](self, engine,
@@ -717,7 +711,7 @@ class Manager(QtCore.QObject):
         return 'Nuxeo Drive'
 
     def _force_autoupdate(self):
-        if (self._app_updater.get_next_poll() > 60 and self._app_updater.get_last_poll() > 1800):
+        if self._app_updater.get_next_poll() > 60 and self._app_updater.get_last_poll() > 1800:
             self._app_updater.force_poll()
 
     def get_default_nuxeo_drive_folder(self):
@@ -777,9 +771,9 @@ class Manager(QtCore.QObject):
     def _increment_local_folder(self, basefolder, name):
         nuxeo_drive_folder = os.path.join(basefolder, name)
         num = 2
-        while (not self.check_local_folder_available(nuxeo_drive_folder)):
+        while not self.check_local_folder_available(nuxeo_drive_folder):
             nuxeo_drive_folder = os.path.join(basefolder, name + " " + str(num))
-            num = num + 1
+            num += 1
             if num > 10:
                 return ""
         return nuxeo_drive_folder
@@ -1099,7 +1093,7 @@ class Manager(QtCore.QObject):
             other = engine.local_folder
             if not other.endswith('/'):
                 other = other + '/'
-            if (other.startswith(local_folder) or local_folder.startswith(other)):
+            if other.startswith(local_folder) or local_folder.startswith(other):
                 return False
         return True
 
@@ -1122,7 +1116,7 @@ class Manager(QtCore.QObject):
                 log.debug("Engine type has been specified in the url: %s will be used", engine_type)
         if not self.check_local_folder_available(local_folder):
             raise FolderAlreadyUsed()
-        if not engine_type in self._engine_types:
+        if engine_type not in self._engine_types:
             raise EngineTypeMissing()
         if self._engines is None:
             self.load()

--- a/nuxeo-drive-client/tests/common_unit_test.py
+++ b/nuxeo-drive-client/tests/common_unit_test.py
@@ -17,6 +17,7 @@ from mock import Mock
 
 from nxdrive import __version__
 from nxdrive.client import LocalClient, RemoteDocumentClient, RemoteFileSystemClient, RestAPIClient
+from nxdrive.client.common import DEFAULT_IGNORED_PREFIXES, DEFAULT_IGNORED_SUFFIXES
 from nxdrive.logging_config import get_logger
 from nxdrive.manager import Manager
 from nxdrive.osi import AbstractOSIntegration
@@ -339,6 +340,8 @@ class UnitTestCase(SimpleUnitTestCase):
         options.update_site_url = None
         options.beta_update_site_url = None
         options.autolock_interval = 30
+        options.ignored_prefixes = DEFAULT_IGNORED_PREFIXES
+        options.ignored_suffixes = DEFAULT_IGNORED_SUFFIXES
         options.nxdrive_home = self.nxdrive_conf_folder_1
         self.manager_1 = Manager(options)
         self.connected = False

--- a/nuxeo-drive-client/tests/test_local_client.py
+++ b/nuxeo-drive-client/tests/test_local_client.py
@@ -145,7 +145,7 @@ class StubLocalClient(object):
         self.assertEqual(workspace_children[2].path, folder_2)
 
     def test_deep_folders(self):
-        # Check that local client can workaround the default >indows
+        # Check that local client can workaround the default Windows
         # MAX_PATH limit
         folder = '/'
         for _i in range(30):
@@ -159,7 +159,7 @@ class StubLocalClient(object):
         deep_file = self.local_client_1.make_file(folder, 'File.txt',
                                                   content=b'Some Content.')
 
-        # Check the consistency of  get_children_info and get_info
+        # Check the consistency of get_children_info and get_info
         deep_file_info = self.local_client_1.get_info(deep_file)
         deep_children = self.local_client_1.get_children_info(folder)
         self.assertEqual(len(deep_children), 1)


### PR DESCRIPTION
To define custom prefixes/suffixes, use this kind of `config.ini`:

    [DEFAULT]
    env=custom

    [custom]
    ignored-prefixes =
        IGNOREME-
        IGNOREME-
        no_release-

    ignored-suffixes = .bak

Custom prefixes/suffixes will be appended to the default ones.