### PR TITLE
NXDRIVE-866: Fix startup on macOS

### DIFF
--- a/nuxeo-drive-client/nxdrive/commandline.py
+++ b/nuxeo-drive-client/nxdrive/commandline.py
@@ -100,11 +100,14 @@ class CliHandler(object):
                   "NXDRIVE_HOME/logs/nxaudit.logs")
         )
         common_parser.add_argument(
-            "--locale",
+            '--locale',
+            default='en',
+            choices=('de', 'en', 'es', 'fr', 'jp'),
             help="Select the default language"
         )
         common_parser.add_argument(
-            "--force-locale",
+            '--force-locale',
+            choices=('de', 'en', 'es', 'fr', 'jp'),
             help="Force the language"
         )
         common_parser.add_argument(

--- a/nuxeo-drive-client/nxdrive/engine/tracker.py
+++ b/nuxeo-drive-client/nxdrive/engine/tracker.py
@@ -27,8 +27,13 @@ class Tracker(Worker):
                                          user_agent=self._user_agent)
         self._tracker.set('appName', 'NuxeoDrive')
         self._tracker.set('appVersion', self._manager.get_version())
-        self._tracker.set('language', self.current_locale)
         self._tracker.set('encoding', sys.getfilesystemencoding())
+        try:
+            self._tracker.set('language', self.current_locale)
+        except TypeError:
+            # TODO: On macOS, locale.getdefaultlocale() returns (None, None)
+            # TODO: when built with Esky.
+            pass
         self._manager.started.connect(self._send_stats)
 
         # Send stat every hour

--- a/nuxeo-drive-client/nxdrive/manager.py
+++ b/nuxeo-drive-client/nxdrive/manager.py
@@ -912,7 +912,12 @@ class Manager(QtCore.QObject):
         self.refresh_update_status()
 
     def get_tracking(self):
-        return self._dao.get_config("tracking", "1") == "1"
+        """
+        Avoid sending statistics when testing or if the user does not allow it.
+        """
+
+        return (self._dao.get_config('tracking', '1') == '1'
+                and not os.environ.get('WORKSPACE'))
 
     def set_tracking(self, value):
         self._dao.update_config("tracking", value)

--- a/tools/jenkins/packages.groovy
+++ b/tools/jenkins/packages.groovy
@@ -106,7 +106,7 @@ for (x in slaves) {
                             bat 'powershell ".\\tools\\windows\\deploy_jenkins_slave.ps1" -build'
                             archive 'dist/*.msi, dist/*.zip'
                         }
-                        currentBuild.description = "Python ${params.PYTHON_DRIVE_VERSION}<br/>${params.BRANCH_NAME}"
+                        currentBuild.description = "Python ${params.PYTHON_DRIVE_VERSION}, Qt ${params.PYQT_VERSION}<br/>${params.BRANCH_NAME}"
                     }
                 }
             }

--- a/tools/osx/deploy_jenkins_slave.sh
+++ b/tools/osx/deploy_jenkins_slave.sh
@@ -70,7 +70,8 @@ create_package() {
     rm -rf "${src_folder_tmp}" "${dmg_tmp}"
 
     echo ">>> [DMG ${app_version}] Zipping application bundle to make it available as an update"
-    zip -r "${output_dir}/${update_pkg_name}.zip" "${pkg_path}"
+    cd "${output_dir}"
+    zip -r "${update_pkg_name}.zip" "${bundle_name}"
 }
 
 fix_version() {


### PR DESCRIPTION
Curiously, when Drive is built with Esky, as usual, `locale.getdefaultlocale()` returns `(None, None)`.
Don't know what is the cause, but for now we just bypass the error.