### PR TITLE
NXDRIVE-712: Conflict detection during multiple backups (saves) in a short time interval

### DIFF
--- a/nuxeo-drive-client/nxdrive/client/common.py
+++ b/nuxeo-drive-client/nxdrive/client/common.py
@@ -82,20 +82,21 @@ DEFAULT_REPOSITORY_NAME = 'default'
 
 DEFAULT_IGNORED_PREFIXES = tuple({
     '.',  # hidden Unix files
+    'Icon\r',  # macOS icon
+    'Thumbs.db',  # Windows Thumbnails files
+    'desktop.ini',  # Windows icon
     '~$',  # Windows lock files
-    'Thumbs.db',  # Thumbnails files
-    'Icon\r',  # Mac Icon
-    'desktop.ini',  # Icon for windows
 })
 
 DEFAULT_IGNORED_SUFFIXES = tuple({
-    '~',  # editor buffers
-    '.swp',  # vim swap files
-    '.lock',  # some process use file locks
     '.LOCK',  # other locks
-    '.part',  # partially downloaded files by browsers
     '.crdownload',  # partially downloaded files by browsers
+    '.lock',  # some process use file locks
+    '.part',  # partially downloaded files by browsers
     '.partial',  # partially downloaded files by browsers
+    '.swp',  # vim swap files
+    '.tmp',  # temporary files (MS Office and others)
+    '~',  # editor buffers
 })
 
 # Default buffer size for file upload / download and digest computation

--- a/nuxeo-drive-client/nxdrive/client/local_client.py
+++ b/nuxeo-drive-client/nxdrive/client/local_client.py
@@ -480,17 +480,20 @@ class LocalClient(BaseClient):
             return True
 
         if AbstractOSIntegration.is_windows():
-            # NXDRIVE-465
+            # NXDRIVE-465: ignore hidden files on Windows
             ref = self.get_children_ref(parent_ref, file_name)
             path = self.abspath(ref)
+            is_system = win32con.FILE_ATTRIBUTE_SYSTEM
+            is_hidden = win32con.FILE_ATTRIBUTE_HIDDEN
             try:
                 attrs = win32api.GetFileAttributes(path)
             except win32file.error, (errno, errctx, errmsg):
                 return False
-            if attrs & win32con.FILE_ATTRIBUTE_SYSTEM == win32con.FILE_ATTRIBUTE_SYSTEM:
+            if attrs & is_system == is_system:
                 return True
-            if attrs & win32con.FILE_ATTRIBUTE_HIDDEN == win32con.FILE_ATTRIBUTE_HIDDEN:
+            if attrs & is_hidden == is_hidden:
                 return True
+
         # NXDRIVE-655: need to check every parent if they are ignored
         result = False
         path = parent_ref

--- a/nuxeo-drive-client/nxdrive/engine/processor.py
+++ b/nuxeo-drive-client/nxdrive/engine/processor.py
@@ -363,7 +363,7 @@ class Processor(EngineWorker):
                 )
                 self._dao.update_last_transfer(doc_pair.id, "upload")
                 self._update_speed_metrics()
-                self._dao.update_remote_state(doc_pair, fs_item_info, versionned=False, no_digest=True)
+                self._dao.update_remote_state(doc_pair, fs_item_info, versionned=False)
                 # TODO refresh_client
             else:
                 log.debug("Skip update of remote document '%s' as it is readonly.", doc_pair.local_name)
@@ -383,7 +383,7 @@ class Processor(EngineWorker):
                 return
         if fs_item_info is None:
             fs_item_info = remote_client.get_info(doc_pair.remote_ref)
-            self._dao.update_remote_state(doc_pair, fs_item_info, versionned=False, no_digest=True)
+            self._dao.update_remote_state(doc_pair, fs_item_info, versionned=False)
         self._synchronize_if_not_remotely_dirty(doc_pair, local_client, remote_client, remote_info=fs_item_info)
 
     def _get_normal_state_from_remote_ref(self, ref):
@@ -555,8 +555,7 @@ class Processor(EngineWorker):
                     pass
                 self._dao.update_remote_state(doc_pair, fs_item_info,
                                               remote_parent_path=remote_parent_path,
-                                              versionned=False, queue=False,
-                                              no_digest=True)
+                                              versionned=False, queue=False)
             finally:
                 self._dao.release_lock()
             log.trace("Put remote_ref in %s", remote_ref)
@@ -663,7 +662,7 @@ class Processor(EngineWorker):
                                                  parent_pair.remote_ref)
                 self._dao.update_remote_state(doc_pair, remote_info,
                                               remote_parent_path=parent_path,
-                                              versionned=False, no_digest=True)
+                                              versionned=False)
             else:
                 # Move it back
                 self._handle_failed_remote_move(doc_pair, doc_pair)


### PR DESCRIPTION
The partial revert keeps the method signature even if `no_digest` is not used anymore. We will wait 2-3 months and see if bugs come before deciding to remove it.

The other part of the patch filter `ignored_suffixes` "at the root", which is a good thing.