### PR TITLE
NXDRIVE-881: Handle folder remote rename when doing full remote scan

### DIFF
--- a/nuxeo-drive-client/nxdrive/__init__.py
+++ b/nuxeo-drive-client/nxdrive/__init__.py
@@ -7,4 +7,4 @@ To declare a beta, use this schema:
     - X.Y.ZbN i.e. "2.4.5b1"
 """
 
-__version__ = '2.4.6b1'
+__version__ = '2.4.6'

--- a/nuxeo-drive-client/nxdrive/client/local_client.py
+++ b/nuxeo-drive-client/nxdrive/client/local_client.py
@@ -203,14 +203,14 @@ class LocalClient(BaseClient):
         log.trace('Removing xattr %s from %s', name, path)
         locker = self.unlock_path(path, False)
         if AbstractOSIntegration.is_windows():
-            pathAlt = path + ":" + name
+            path_alt = path + ':' + name
             try:
-                if os.path.exists(pathAlt):
-                    os.remove(pathAlt)
+                if os.path.exists(path_alt):
+                    os.remove(path_alt)
             except OSError as e:
                 if e.errno == os.errno.EACCES:
                     self.unset_path_readonly(path)
-                    os.remove(pathAlt)
+                    os.remove(path_alt)
                     self.set_path_readonly(path)
                 else:
                     raise e
@@ -351,12 +351,12 @@ class LocalClient(BaseClient):
         log.trace('Setting xattr %s with value %r on %r', name, remote_id, path)
         locker = self.unlock_path(path, False)
         if AbstractOSIntegration.is_windows():
-            pathAlt = path + ":" + name
+            path_alt = path + ':' + name
             try:
                 if not os.path.exists(path):
                     raise NotFound()
                 stat = os.stat(path)
-                with open(pathAlt, "w") as f:
+                with open(path_alt, 'w') as f:
                     f.write(remote_id)
                 # Avoid time modified change
                 os.utime(path, (stat.st_atime, stat.st_mtime))
@@ -364,7 +364,7 @@ class LocalClient(BaseClient):
                 # Should not happen
                 if e.errno == os.errno.EACCES:
                     self.unset_path_readonly(path)
-                    with open(pathAlt, "w") as f:
+                    with open(path_alt, 'w') as f:
                         f.write(remote_id)
                     self.set_path_readonly(path)
                 else:
@@ -515,9 +515,8 @@ class LocalClient(BaseClient):
         children = os.listdir(os_path)
 
         for child_name in sorted(children):
-            if self.is_ignored(ref, child_name):
-                continue
-            elif self.is_temp_file(child_name):
+            if (self.is_ignored(ref, child_name)
+                    or self.is_temp_file(child_name)):
                 continue
 
             child_ref = self.get_children_ref(ref, child_name)
@@ -736,7 +735,8 @@ class LocalClient(BaseClient):
     def abspath(self, ref):
         """Absolute path on the operating system"""
         if not ref.startswith(u'/'):
-            raise ValueError("LocalClient expects ref starting with '/'")
+            raise ValueError(
+                'LocalClient expects ref starting with "/"', locals())
         path_suffix = ref[1:].replace('/', os.path.sep)
         path = normalized_path(os.path.join(self.base_folder, path_suffix))
         return safe_long_path(path)

--- a/nuxeo-drive-client/nxdrive/engine/dao/sqlite.py
+++ b/nuxeo-drive-client/nxdrive/engine/dao/sqlite.py
@@ -92,7 +92,10 @@ class StateRow(sqlite3.Row):
                 ).format(name=type(self).__name__, cls=self)
 
     def __getattr__(self, name):
-        return self[name]
+        try:
+            return self[name]
+        except IndexError:
+            raise IndexError('No key with that name.', locals())
 
     def is_readonly(self):
         if self.folderish:

--- a/nuxeo-drive-client/nxdrive/engine/dao/sqlite.py
+++ b/nuxeo-drive-client/nxdrive/engine/dao/sqlite.py
@@ -1256,6 +1256,17 @@ class EngineDAO(ConfigurationDAO):
                 log.trace('Not updating remote state (not dirty) for row = %r with info = %r', row, info)
                 return
         log.trace('Updating remote state for row = %r with info = %r (force: %r)', row, info, force_update)
+
+        if (row.pair_state not in ('conflicted', 'remotely_created')
+                and row.folderish
+                and row.local_name
+                and row.local_name != info.name):
+            # We check the current pair_state to not interfer with conflicted
+            # documents (a move on both sides) nor with newly remotely
+            # created ones.
+            row.remote_state = 'modified'
+            row.pair_state = self._get_pair_state(row)
+
         if versionned:
             version = ', version=version+1'
             log.trace('Increasing version to %d for pair %r', row.version + 1, row)

--- a/nuxeo-drive-client/nxdrive/engine/processor.py
+++ b/nuxeo-drive-client/nxdrive/engine/processor.py
@@ -226,9 +226,9 @@ class Processor(EngineWorker):
                         doc_pair.remote_ref = None
 
                 # NXDRIVE-842: parent is in disabled duplication error
-                state = self._get_normal_state_from_remote_ref(
+                parent_pair = self._get_normal_state_from_remote_ref(
                     doc_pair.remote_parent_ref)
-                if state and state.last_error == 'DEDUP':
+                if parent_pair and parent_pair.last_error == 'DEDUP':
                     self._current_item = self._get_item()
                     continue
 
@@ -236,9 +236,14 @@ class Processor(EngineWorker):
                 if parent_path == '':
                     parent_path = "/"
                 if not local_client.exists(parent_path):
-                    self._dao.remove_state(doc_pair)
-                    self._current_item = self._get_item()
-                    continue
+                    if doc_pair.local_parent_path != parent_pair.local_path:
+                        # The parent folder has been renamed sooner
+                        # in the current synchronization
+                        doc_pair.local_parent_path = parent_pair.local_path
+                    else:
+                        self._dao.remove_state(doc_pair)
+                        self._current_item = self._get_item()
+                        continue
 
                 self._current_metrics = dict()
                 handler_name = '_synchronize_' + doc_pair.pair_state
@@ -1018,8 +1023,6 @@ class Processor(EngineWorker):
                             self._dao.synchronize_state(pair)
                     else:
                         self._dao.remove_state(target_pair)
-                    # Mark all local as unknown
-                    # self._mark_unknown_local_recursive(session, source_pair)
                 self._dao.synchronize_state(source_pair)
                 return True
             except Exception, e:

--- a/nuxeo-drive-client/nxdrive/engine/watcher/remote_watcher.py
+++ b/nuxeo-drive-client/nxdrive/engine/watcher/remote_watcher.py
@@ -632,7 +632,7 @@ class RemoteWatcher(EngineWorker):
                             consistent_new_info = new_info
                             if remote_parent_factory == COLLECTION_SYNC_ROOT_FACTORY_NAME:
                                 new_info_parent_uid = doc_pair.remote_parent_ref
-                                new_info_path = (doc_pair.remote_parent_path + '/' + remote_ref)
+                                new_info_path = doc_pair.remote_parent_path + '/' + remote_ref
                                 consistent_new_info = RemoteFileInfo(
                                     new_info.name, new_info.uid,
                                     new_info_parent_uid,
@@ -665,17 +665,16 @@ class RemoteWatcher(EngineWorker):
                             self._dao.update_remote_state(doc_pair, new_info, remote_parent_path=remote_parent_path,
                                                           force_update=lock_update)
                             if doc_pair.folderish:
-                                log.trace("Force scan recursive on %r : %d", doc_pair, (event_id == "securityUpdated"))
+                                log.trace('Force scan recursive on %r : %d', doc_pair, event_id == 'securityUpdated')
                                 self._force_remote_scan(doc_pair, consistent_new_info, remote_path=new_info.path,
-                                                        force_recursion=(event_id == "securityUpdated"),
-                                                        moved=(event_id == "documentMoved"))
+                                                        force_recursion=event_id == 'securityUpdated',
+                                                        moved=event_id == 'documentMoved')
                             if lock_update:
                                 doc_pair = self._dao.get_state_from_id(doc_pair.id)
                                 try:
                                     self._handle_readonly(self._local_client, doc_pair)
                                 except (OSError, IOError) as ex:
-                                    log.trace("Can't handle readonly for %r (%r)", doc_pair, ex)
-                                    pass
+                                    log.trace('Cannot handle readonly for %r (%r)', doc_pair, ex)
                     updated = True
                     refreshed.add(remote_ref)
 
@@ -685,7 +684,7 @@ class RemoteWatcher(EngineWorker):
                 parent_pairs = self._dao.get_states_from_remote(new_info.parent_uid)
                 for parent_pair in parent_pairs:
 
-                    child_pair, new_pair = (self._find_remote_child_match_or_create(parent_pair, new_info))
+                    child_pair, new_pair = self._find_remote_child_match_or_create(parent_pair, new_info)
                     if new_pair:
                         log.debug("Marked doc_pair '%s' as remote creation",
                                   child_pair.remote_name)

--- a/nuxeo-drive-client/nxdrive/engine/watcher/remote_watcher.py
+++ b/nuxeo-drive-client/nxdrive/engine/watcher/remote_watcher.py
@@ -172,16 +172,15 @@ class RemoteWatcher(EngineWorker):
             return True
         return False
 
-    def _do_scan_remote(self, doc_pair, remote_info, force_recursion=True, mark_unknown=True,
-                        moved=False):
+    def _do_scan_remote(self, doc_pair, remote_info, force_recursion=True, moved=False):
         if remote_info.can_scroll_descendants:
             log.debug('Performing scroll remote scan for %s (%s)', remote_info.name, remote_info.uid)
             self._scan_remote_scroll(doc_pair, remote_info, moved=moved)
         else:
             log.debug('Scroll scan not available, performing recursive remote scan for %s (%s)', remote_info.name,
                       remote_info.uid)
-            self._scan_remote_recursive(doc_pair, remote_info, force_recursion=force_recursion,
-                                        mark_unknown=mark_unknown)
+            self._scan_remote_recursive(doc_pair, remote_info,
+                                        force_recursion=force_recursion)
 
     def _scan_remote_scroll(self, doc_pair, remote_info, moved=False):
         """Perform a scroll scan of the bound remote folder looking for updates"""
@@ -267,7 +266,7 @@ class RemoteWatcher(EngineWorker):
         return delta.seconds * 1000 + delta.microseconds / 1000
 
     def _scan_remote_recursive(self, doc_pair, remote_info,
-                               force_recursion=True, mark_unknown=True):
+                               force_recursion=True):
         """Recursively scan the bound remote folder looking for updates
 
         If force_recursion is True, recursion is done even on
@@ -279,14 +278,6 @@ class RemoteWatcher(EngineWorker):
 
         # Check if synchronization thread was suspended
         self._interact()
-
-        # If a folderish pair state has been remotely updated,
-        # recursively unmark its local descendants as 'unsynchronized'
-        # by marking them as 'unknown'.
-        # This is needed to synchronize unsynchronized items back.
-        if mark_unknown:
-            # TODO Should be DAO method
-            log.trace("Skip remote scan as mark_unknown: %r", doc_pair)
 
         # Detect recently deleted children
         db_children = self._dao.get_remote_children(doc_pair.remote_ref)
@@ -316,7 +307,7 @@ class RemoteWatcher(EngineWorker):
 
         for folder in to_scan:
             # TODO Optimize by multithreading this too ?
-            self._do_scan_remote(folder[0], folder[1], force_recursion=force_recursion, mark_unknown=False)
+            self._do_scan_remote(folder[0], folder[1], force_recursion=force_recursion)
         self._dao.add_path_scanned(remote_parent_path)
 
     def _init_scan_remote(self, doc_pair, remote_info):


### PR DESCRIPTION
The previous fix was fixing this issue but failed elsewhere. So this is a new approach that passes all tests. I keeped the `mark_unknown` keyword removal from the previous patch, it seems to be useless now.

There are a couple of cleanup/fixes too, reported by SonarPython.