### PR TITLE
NXDRIVE-862: Infinite loop when renaming a folder from lower case to upper case on Windows

### DIFF
--- a/nuxeo-drive-client/nxdrive/__init__.py
+++ b/nuxeo-drive-client/nxdrive/__init__.py
@@ -7,4 +7,4 @@ To declare a beta, use this schema:
     - X.Y.ZbN i.e. "2.4.5b1"
 """
 
-__version__ = '2.4.6'
+__version__ = '2.4.7'

--- a/nuxeo-drive-client/nxdrive/engine/watcher/local_watcher.py
+++ b/nuxeo-drive-client/nxdrive/engine/watcher/local_watcher.py
@@ -359,9 +359,9 @@ class LocalWatcher(EngineWorker):
                         log.debug("Found potential moved file %s[%s]", child_info.path, remote_id)
                         doc_pair = self._dao.get_normal_state_from_remote(remote_id)
                         if doc_pair is not None and self.client.exists(doc_pair.local_path):
-                            if (not self.client.is_case_sensitive() and\
-                                            doc_pair.local_path.lower() == child_info.path.lower()):
-                                log.debug("Case renaming on a case insensitive filesystem, update info and ignore: %r",
+                            if (not self.client.is_case_sensitive()
+                                    and doc_pair.local_path.lower() == child_info.path.lower()):
+                                log.debug('Case renaming on a case insensitive filesystem, update info and ignore: %r',
                                                 doc_pair)
                                 if doc_pair.local_name in children:
                                     del children[doc_pair.local_name]
@@ -811,7 +811,7 @@ class LocalWatcher(EngineWorker):
             parent_path = os.path.dirname(src_path)
             parent_rel_path = self.client.get_path(parent_path)
             # Don't care about ignored file, unless it is moved
-            if self.client.is_ignored(parent_rel_path, file_name) and evt.event_type != 'moved':
+            if evt.event_type != 'moved' and self.client.is_ignored(parent_rel_path, file_name):
                 return
             if self.client.is_temp_file(file_name):
                 return
@@ -971,7 +971,7 @@ class DriveFSEventHandler(PatternMatchingEventHandler):
 
     def on_any_event(self, event):
         self.counter += 1
-        log.trace("Queueing watchdog: %r", event)
+        log.trace('Queueing watchdog: %r', event)
         self.watcher._watchdog_queue.put(event)
 
 
@@ -1033,7 +1033,7 @@ def normalize_event_filename(filename, action=True):
         try:
             filename = win32api.GetLongPathName(filename)
         except (win32api.error, UnicodeEncodeError) as e:
-            log.error('Long path conversion error: %s for %r', e, filename)
+            log.exception('Long path conversion error for %r', filename)
 
     if action and filename != normalized and os.path.exists(filename):
         log.debug('Forcing normalization: %r -> %r', filename, normalized)

--- a/nuxeo-drive-client/tests/mac_local_client.py
+++ b/nuxeo-drive-client/tests/mac_local_client.py
@@ -13,13 +13,8 @@ if sys.platform == 'darwin':
 
 
 class MacLocalClient(LocalClient):
-    def __init__(self, base_folder, digest_func='md5', ignored_prefixes=None,
-                 ignored_suffixes=None, check_suspended=None,
-                 case_sensitive=None, disable_duplication=True):
-        super(MacLocalClient, self).__init__(base_folder, digest_func,
-                                             ignored_prefixes, ignored_suffixes,
-                                             check_suspended, case_sensitive,
-                                             disable_duplication)
+    def __init__(self, base_folder, **kwargs):
+        super(MacLocalClient, self).__init__(base_folder, **kwargs)
         self.fm = Cocoa.NSFileManager.defaultManager()
 
     def copy(self, srcref, dstref):
@@ -73,4 +68,4 @@ class MacLocalClient(LocalClient):
     @staticmethod
     def _process_result(result):
         if not result[0]:
-            raise IOError(result[1].decode('utf-8', 'ignore'))
+            raise IOError(result[1].decode('utf-8', 'ignore'), locals())

--- a/nuxeo-drive-client/tests/test_encoding.py
+++ b/nuxeo-drive-client/tests/test_encoding.py
@@ -5,6 +5,7 @@ from nxdrive.client.local_client import FileInfo
 from nxdrive.osi import AbstractOSIntegration
 from tests.common_unit_test import UnitTestCase
 
+
 class TestEncoding(UnitTestCase):
 
     def setUp(self):

--- a/nuxeo-drive-client/tests/test_engine_dao.py
+++ b/nuxeo-drive-client/tests/test_engine_dao.py
@@ -6,7 +6,6 @@ Created on 31 mars 2015
 import unittest
 import os
 import sys
-import nxdrive
 from nxdrive.engine.dao.sqlite import EngineDAO
 from nxdrive.engine.engine import Engine
 import tempfile

--- a/nuxeo-drive-client/tests/test_group_changes.py
+++ b/nuxeo-drive-client/tests/test_group_changes.py
@@ -1,6 +1,8 @@
-from tests.common import log
-from tests.common_unit_test import UnitTestCase
 from nxdrive.client import RemoteDocumentClient
+from nxdrive.logging_config import get_logger
+from tests.common_unit_test import UnitTestCase
+
+log = get_logger(__name__)
 
 
 class TestGroupChanges(UnitTestCase):

--- a/nuxeo-drive-client/tests/test_local_client.py
+++ b/nuxeo-drive-client/tests/test_local_client.py
@@ -120,6 +120,15 @@ class StubLocalClient(object):
         with self.assertRaises(NotFound):
             self.local_client_1.get_info('/Something Missing')
 
+    def test_case_sensitivity(self):
+        local = self.local_client_1
+        sensitive = local.is_case_sensitive()
+        log.debug('OS is case sensitive: %r', sensitive)
+
+        local.make_file('/', 'abc.txt')
+        local.make_file('/', 'ABC.txt')
+        self.assertEqual(len(local.get_children_info('/')), sensitive + 1)
+
     def test_get_children_info(self):
         folder_1 = self.local_client_1.make_folder('/', 'Folder 1')
         folder_2 = self.local_client_1.make_folder('/', 'Folder 2')

--- a/nuxeo-drive-client/tests/test_local_client.py
+++ b/nuxeo-drive-client/tests/test_local_client.py
@@ -4,17 +4,20 @@ See win_local_client.py and mac_local_client.py for more informations.
 
 See NXDRIVE-742.
 """
-from time import sleep
-
 import hashlib
 import os
+from time import sleep
 from unittest import skipIf
 
 from nxdrive.client import LocalClient, NotFound
 from nxdrive.client.common import DuplicationDisabledError
+from nxdrive.logging_config import get_logger
 from nxdrive.osi import AbstractOSIntegration
 from tests.common import EMPTY_DIGEST, SOME_TEXT_CONTENT, SOME_TEXT_DIGEST
 from tests.common_unit_test import UnitTestCase
+
+log = get_logger(__name__)
+
 
 class StubLocalClient(object):
     """

--- a/nuxeo-drive-client/tests/test_local_create_folders.py
+++ b/nuxeo-drive-client/tests/test_local_create_folders.py
@@ -1,9 +1,12 @@
-from common_unit_test import UnitTestCase
-from tests.common_unit_test import log
-from tests.common_unit_test import FILE_CONTENT
 import os
-import sys
 import shutil
+import sys
+
+from common_unit_test import UnitTestCase
+from nxdrive.logging_config import get_logger
+from tests.common_unit_test import FILE_CONTENT
+
+log = get_logger(__name__)
 
 
 class TestLocalCreateFolders(UnitTestCase):

--- a/nuxeo-drive-client/tests/test_local_move_folders.py
+++ b/nuxeo-drive-client/tests/test_local_move_folders.py
@@ -1,8 +1,10 @@
 import os
 import shutil
 
+from nxdrive.logging_config import get_logger
 from tests.common_unit_test import UnitTestCase
-from tests.common_unit_test import log
+
+log = get_logger(__name__)
 
 
 class TestLocalMoveFolders(UnitTestCase):

--- a/nuxeo-drive-client/tests/test_local_paste.py
+++ b/nuxeo-drive-client/tests/test_local_paste.py
@@ -1,9 +1,12 @@
-from common_unit_test import UnitTestCase
-from tests.common_unit_test import log
-from tests.common_unit_test import FILE_CONTENT
 import os
 import shutil
 import tempfile
+
+from common_unit_test import UnitTestCase
+from nxdrive.logging_config import get_logger
+from tests.common_unit_test import FILE_CONTENT
+
+log = get_logger(__name__)
 TEST_TIMEOUT = 60
 
 

--- a/nuxeo-drive-client/tests/test_local_share_move_folders.py
+++ b/nuxeo-drive-client/tests/test_local_share_move_folders.py
@@ -1,10 +1,13 @@
 import os
 import shutil
-from mock import patch
-from nxdrive.engine.watcher.remote_watcher import RemoteWatcher
-from tests.common_unit_test import UnitTestCase
-from tests.common_unit_test import log
 
+from mock import patch
+
+from nxdrive.engine.watcher.remote_watcher import RemoteWatcher
+from nxdrive.logging_config import get_logger
+from tests.common_unit_test import UnitTestCase
+
+log = get_logger(__name__)
 wait_for_security_update = False
 src = None
 dst = None

--- a/nuxeo-drive-client/tests/test_long_path.py
+++ b/nuxeo-drive-client/tests/test_long_path.py
@@ -5,16 +5,18 @@ Created on Dec 22, 2016
 @author: dgraja
 
 '''
+import os
 import sys
 
-import os
-
+from nxdrive.logging_config import get_logger
 from nxdrive.utils import safe_long_path
-from tests.common import log
 from tests.common_unit_test import UnitTestCase
 
 if sys.platform == 'win32':
     import win32api
+
+
+log = get_logger(__name__)
 
 # Number of chars in path c://.../Nuxeo.. is approx 96 chars
 FOLDER_A = 'A' * 90

--- a/nuxeo-drive-client/tests/test_report.py
+++ b/nuxeo-drive-client/tests/test_report.py
@@ -1,12 +1,17 @@
 # coding: utf-8
 import os
 import tempfile
-from mock import Mock
 from unittest import TestCase
 
+from mock import Mock
+
+from nxdrive.logging_config import get_logger
 from nxdrive.manager import Manager
 from nxdrive.report import Report
-from tests.common import clean_dir, log
+from tests.common import clean_dir
+
+
+log = get_logger(__name__)
 
 
 class ReportTest(TestCase):

--- a/nuxeo-drive-client/tests/test_volume.py
+++ b/nuxeo-drive-client/tests/test_volume.py
@@ -6,8 +6,10 @@ from math import floor, log10
 from unittest import SkipTest, skipIf
 
 from common_unit_test import UnitTestCase
+from nxdrive.logging_config import get_logger
 from tests.common import TEST_WORKSPACE_PATH
-from tests.common_unit_test import log
+
+log = get_logger(__name__)
 
 
 class VolumeTestCase(UnitTestCase):

--- a/nuxeo-drive-client/tests/win_local_client.py
+++ b/nuxeo-drive-client/tests/win_local_client.py
@@ -17,22 +17,15 @@ from tests.common import log
 
 
 class WindowsLocalClient(LocalClient):
-    def __init__(self, base_folder, digest_func='md5', ignored_prefixes=None,
-                 ignored_suffixes=None, check_suspended=None,
-                 case_sensitive=None, disable_duplication=True):
-        super(WindowsLocalClient, self).__init__(base_folder, digest_func,
-                                                 ignored_prefixes,
-                                                 ignored_suffixes,
-                                                 check_suspended,
-                                                 case_sensitive,
-                                                 disable_duplication)
+    def __init__(self, base_folder, **kwargs):
+        super(WindowsLocalClient, self).__init__(base_folder, **kwargs)
 
     def delete_final(self, ref):
         path = self.abspath(ref)
         res = shell.SHFileOperation((0, shellcon.FO_DELETE, path, None,
                                      shellcon.FOF_NOCONFIRMATION, None, None))
         if res[0] != 0:
-            raise IOError(res)
+            raise IOError(res, locals())
 
     def move(self, ref, new_parent_ref, name=None):
         path = self.abspath(ref)
@@ -42,10 +35,9 @@ class WindowsLocalClient(LocalClient):
         res = shell.SHFileOperation((0, shellcon.FO_MOVE, path, new_path,
                                      shellcon.FOF_NOCONFIRMATION, None, None))
         if res[0] != 0:
-            raise IOError(res)
+            raise IOError(res, locals())
 
     def duplicate_file(self, ref):
-        # return super(WindowsLocalClient, self).duplicate_file(ref)
         parent = os.path.dirname(ref)
         name = os.path.basename(ref)
         locker = self.unlock_ref(parent, False)
@@ -56,7 +48,7 @@ class WindowsLocalClient(LocalClient):
                                          shellcon.FOF_NOCONFIRMATION, None,
                                          None))
             if res[0] != 0:
-                raise IOError(res)
+                raise IOError(res, locals())
             if parent == u"/":
                 return u"/" + name
             return parent + u"/" + name
@@ -78,7 +70,7 @@ class WindowsLocalClient(LocalClient):
         res = shell.SHFileOperation((0, shellcon.FO_RENAME, path, new_path,
                                      shellcon.FOF_NOCONFIRMATION, None, None))
         if res[0] != 0:
-            raise IOError(res)
+            raise IOError(res, locals())
 
     def delete(self, ref):
         path = self.abspath(ref)
@@ -87,4 +79,4 @@ class WindowsLocalClient(LocalClient):
                                      shellcon.FOF_NOCONFIRMATION | shellcon.FOF_ALLOWUNDO,
                                      None, None))
         if res[0] != 0:
-            raise IOError(res)
+            raise IOError(res, locals())

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,5 @@
 mock==2.0.0;python_version=='2.7'
 pytest==3.0.7;python_version=='2.7'
 pytest-sugar==0.8.0;python_version=='2.7' and sys_platform!='win32'
+pytest-timeout==1.2.0;python_version=='2.7'
 yappi==0.98;python_version=='2.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-appdirs
-setuptools
+appdirs==1.4.3;python_version=='2.7'
 argparse==1.4.0;python_version=='2.7'
 esky==0.9.9;python_version=='2.7'
 faulthandler==2.4;python_version=='2.7'
@@ -10,5 +9,6 @@ pycrypto==2.6.1;python_version=='2.7'
 pypac==0.2.1;python_version=='2.7'
 python-dateutil==2.6.0;python_version=='2.7'
 Send2Trash==1.3.0;python_version=='2.7'
+setuptools==36.0.1;python_version=='2.7'
 universal-analytics-python==0.2.4;python_version=='2.7'
 watchdog==0.8.3;python_version=='2.7'


### PR DESCRIPTION
The bug was "sioux", I put explanations in the code, see [L1034](https://github.com/nuxeo/nuxeo-drive/compare/wip-fix-NXDRIVE-862-inifinite-loop-rename-lower-upper?expand=1#diff-5fe7966eb71c8010411fa6038b861511R1034).

For the test, we need a new module named "pytest-timeout", added in "requirements-tests.txt", to be able to kill the test on infinite loop.

Also:
    - I setted versions on each and every external module to have complete reproductible builds.
    - Refactored arguments of `LocalClient` and splitted `LocalClient.remove_remote_id()` into specific smaller methods to de-complexifying the code, step by step.
    - Cleanup, as usual.