### PR TITLE
NXDRIVE-918: Ignore .bak files

### DIFF
--- a/nuxeo-drive-client/nxdrive/client/common.py
+++ b/nuxeo-drive-client/nxdrive/client/common.py
@@ -91,6 +91,7 @@ DEFAULT_IGNORED_PREFIXES = tuple({
 
 DEFAULT_IGNORED_SUFFIXES = tuple({
     '.LOCK',  # other locks
+    '.bak',  # temporary backup files
     '.crdownload',  # partially downloaded files by browsers
     '.lock',  # some process use file locks
     '.part',  # partially downloaded files by browsers


### PR DESCRIPTION
It will be usefull for every one and we need it for OTEIS right know.