### PR TITLE
NXDRIVE-929: Cleanup JavaScript/HTML code

### DIFF
--- a/nuxeo-drive-client/nxdrive/data/ui5/activity.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/activity.html
@@ -7,8 +7,8 @@
 <script src="js/jquery-2.1.3.min.js"></script>
 <script src="js/bootstrap.min.js"></script>
 <script src="i18n.js"></script>
-<link rel="stylesheet" href="css/bootstrap.min.css"></link>
-<link rel="stylesheet" href="css/ndrive.css"></link>
+<link rel="stylesheet" href="css/bootstrap.min.css"/>
+<link rel="stylesheet" href="css/ndrive.css"/>
 <script>
 	app = drive_module("DriveActivity");
 	app.controller("DriveActivityCtl", function($scope, $interval) {

--- a/nuxeo-drive-client/nxdrive/data/ui5/activity.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/activity.html
@@ -21,7 +21,7 @@
 </script>
 </head>
 <body style="overflow: hidden;" ng-app="DriveActivity" ng-controller="DriveActivityCtl">
-	<div drive-include="getTemplate('activity-content')">
+	<div drive-include="activity-content">
 	</div>
 </body>
 </html>

--- a/nuxeo-drive-client/nxdrive/data/ui5/conflicts.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/conflicts.html
@@ -8,8 +8,8 @@
 <script src="js/bootstrap.min.js"></script>
 <script src="i18n.js"></script>
 <script src="js/ndrive-conflicts.js"></script>
-<link rel="stylesheet" href="css/bootstrap.min.css"></link>
-<link rel="stylesheet" href="css/ndrive.css"></link>
+<link rel="stylesheet" href="css/bootstrap.min.css"/>
+<link rel="stylesheet" href="css/ndrive.css"/>
 <script>
 	drive.resize(550, 600);
 	app = drive_module("DriveConflicts");

--- a/nuxeo-drive-client/nxdrive/data/ui5/conflicts.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/conflicts.html
@@ -17,7 +17,7 @@
 </script>
 </head>
 <body style="overflow: auto;visibility: visible;" ng-app="DriveConflicts" ng-controller="DriveConflictsCtl">
-	<div drive-include="getTemplate('conflicts-content')">
+	<div drive-include="conflicts-content">
 	</div>
 </body>
 </html>

--- a/nuxeo-drive-client/nxdrive/data/ui5/debug.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/debug.html
@@ -7,8 +7,8 @@
 <script src="js/jquery-2.1.3.min.js"></script>
 <script src="js/bootstrap.min.js"></script>
 <script src="i18n.js"></script>
-<link rel="stylesheet" href="css/bootstrap.min.css"></link>
-<link rel="stylesheet" href="css/ndrive.css"></link>
+<link rel="stylesheet" href="css/bootstrap.min.css"/>
+<link rel="stylesheet" href="css/ndrive.css"/>
 <script>
 	if (typeof(drive) != "undefined") {
 		drive.resize(1200,715);

--- a/nuxeo-drive-client/nxdrive/data/ui5/debug.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/debug.html
@@ -177,7 +177,7 @@
 </style>
 </head>
 <body ng-app="DriveDebug" ng-controller="DriveDebugCtl">
-	<div drive-include="getTemplate('debug-content')">
+	<div drive-include="debug-content">
 	</div>
 </body>
 </html>

--- a/nuxeo-drive-client/nxdrive/data/ui5/js/ndrive-conflicts.js
+++ b/nuxeo-drive-client/nxdrive/data/ui5/js/ndrive-conflicts.js
@@ -57,7 +57,7 @@ ConflictsController.prototype.updateErrors = function($scope) {
 	}
 	$scope.errors = errors;
 
-	for (ignore in ignoreds) {
+	for (var ignore in ignoreds) {
 		if (reasons.indexOf(ignoreds[ignore].last_error) < 0) {
 			ignoreds[ignore].ignore_reason = "IGNORE_REASON_UNKNOWN";
 		} else {

--- a/nuxeo-drive-client/nxdrive/data/ui5/js/ndrive-conflicts.js
+++ b/nuxeo-drive-client/nxdrive/data/ui5/js/ndrive-conflicts.js
@@ -71,7 +71,7 @@ ConflictsController.prototype.updateConflicts = function($scope, $interval) {
 	$scope.conflicts = angular.fromJson(drive.get_conflicts());
 	for (var i=0; i<$scope.conflicts.length; i++) {
 		if ($scope.conflicts[i].last_error == "DUPLICATING") {
-			setTimeout( function() {
+			setTimeout(function() {
 				self.updateConflicts($scope, $interval);
 				$scope.$apply();
 			}, 1000);

--- a/nuxeo-drive-client/nxdrive/data/ui5/js/ndrive-settings.js
+++ b/nuxeo-drive-client/nxdrive/data/ui5/js/ndrive-settings.js
@@ -119,7 +119,7 @@ var SettingsController = function($scope, $interval, $translate) {
 	}
 	$scope.reinitMsgs();
 	$scope.unbindServer = function($event) {
-		button = angular.element($event.currentTarget);
+		var button = angular.element($event.currentTarget);
 		$scope.currentConfirm = button;
 		if (button.hasClass("btn-danger")) {
 			button.html('<span class="glyphicon glyphicon-refresh glyphicon-refresh-animate" aria-hidden="true"></span>&nbsp;' + $translate.instant("DISCONNECTING"))
@@ -143,8 +143,8 @@ var SettingsController = function($scope, $interval, $translate) {
 	$scope.changeSection = function(section) {
 		if (section.length > 9 &&
 				section.substr(0,8) == "Accounts") {
-			uid = section.substr(9, section.length);
-			for (i = 0; i < $scope.engines.length; i++) {
+			var uid = section.substr(9, section.length);
+			for (var i = 0; i < $scope.engines.length; i++) {
 				if ($scope.engines[i].uid == uid) {
 					$scope.changeAccount($scope.engines[i]);
 				}
@@ -169,13 +169,13 @@ var SettingsController = function($scope, $interval, $translate) {
 	}
 	$scope.reinitNewAccount();
 	$scope.changeSection(drive.get_default_section());
-	newLocalFolder = drive.get_new_local_folder();
+	var newLocalFolder = drive.get_new_local_folder();
 	if ($scope.engines.length > 0) {
 		if ($scope.currentAccount == "") {
 			if (newLocalFolder == "") {
 				$scope.changeAccount($scope.engines[0]);
 			} else {
-				for (i = 0; i < $scope.engines.length; i++) {
+				for (var i = 0; i < $scope.engines.length; i++) {
 					if ($scope.engines[i].local_folder == newLocalFolder) {
 						$scope.changeAccount($scope.engines[i]);
 						break;
@@ -191,12 +191,12 @@ var SettingsController = function($scope, $interval, $translate) {
 		$scope.setSuccessMessage($translate.instant("CONNECTION_SUCCESS"));
 		drive.set_new_local_folder("");
 	} else {
-		accountCreationError = drive.get_account_creation_error();
+		var accountCreationError = drive.get_account_creation_error();
 		if (accountCreationError != "") {
 			$scope.setErrorMessage($translate.instant(accountCreationError));
 			drive.set_account_creation_error("");
 		}
-		tokenUpdateError = drive.get_token_update_error();
+		var tokenUpdateError = drive.get_token_update_error();
 		if(tokenUpdateError != "") {
 			$scope.tokenUpdateError = tokenUpdateError;
 			drive.set_token_update_error("");
@@ -227,13 +227,13 @@ SettingsController.prototype.reinitNewAccount = function ($scope) {
 SettingsController.prototype.bindServer = function($scope, $translate) {
 	$scope.currentAction = "CONNECTING";
 	$scope.reinitMsgs();
-	local_folder = $scope.currentAccount.local_folder;
+	var local_folder = $scope.currentAccount.local_folder;
 	when (drive.bind_server($scope.currentAccount.local_folder, $scope.currentAccount.server_url, $scope.currentAccount.username, $scope.password, $scope.currentAccount.name)).then( function(res) {
 		if (res == "") {
 			$scope.password = "";
 			$scope.engines = angular.fromJson(drive.get_engines());
 			$scope.reinitNewAccount();
-			for (i = 0; i < $scope.engines.length; i++) {
+			for (var i = 0; i < $scope.engines.length; i++) {
 				if ($scope.engines[i].local_folder == local_folder) {
 					$scope.changeAccount($scope.engines[i]);
 					break;
@@ -263,7 +263,7 @@ SettingsController.prototype.webAuthentication = function($scope, $translate) {
 }
 SettingsController.prototype.updateToken = function($scope, $translate) {
 	$scope.reinitMsgs();
-	res = drive.web_update_token($scope.currentAccount.uid);
+	var res = drive.web_update_token($scope.currentAccount.uid);
 	if (res != "") {
 		$scope.setErrorMessage($translate.instant(res));
 	}

--- a/nuxeo-drive-client/nxdrive/data/ui5/js/ndrive.js
+++ b/nuxeo-drive-client/nxdrive/data/ui5/js/ndrive.js
@@ -64,7 +64,7 @@ if (tracker != "") {
 	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	})(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
 	ga('create', tracker, 'auto');
 	ga('send', 'pageview');

--- a/nuxeo-drive-client/nxdrive/data/ui5/js/ndrive.js
+++ b/nuxeo-drive-client/nxdrive/data/ui5/js/ndrive.js
@@ -2,26 +2,26 @@
 String.prototype.endsWith = function(suffix) {
     return this.indexOf(suffix, this.length - suffix.length) !== -1;
 };
-_promises = [];
-promise_success = function(uid, result) {
+var _promises = [];
+var promise_success = function(uid, result) {
 	if (_promises[uid] == undefined || _promises[uid]._success_callback == undefined) {
 		return;
 	}
 	_promises[uid]._success_callback(result);
 	delete _promises[uid];
 }
-promise_error = function(uid, err) {
+var promise_error = function(uid, err) {
 	if (_promises[uid] == undefined || _promises[uid]._error_callback == undefined) {
 		return;
 	}
 	_promises[uid]._error_callback(err);
 	delete _promises[uid];
 }
-when = function(result) {
+var when = function(result) {
 	return {
 		then: function(callback, error_callback) {
 			if (result && result['_promise_success'] !== undefined && result['_promise_error'] !== undefined) {
-				uid = result['_promise_uid']();
+				var uid = result['_promise_uid']();
 				if (_promises[uid] == undefined) {
 					_promises[uid] = self
 				}
@@ -37,7 +37,7 @@ when = function(result) {
 	};
 }
 function drive_module(name) {
-	app = angular.module(name, ['pascalprecht.translate']);
+	var app = angular.module(name, ['pascalprecht.translate']);
 	app.directive('driveInclude', function($http, $templateCache, $compile) {
 	    return function(scope, element, attrs) {
 	        $http.get(scope.getTemplate(attrs.driveInclude), { cache: $templateCache }).success(
@@ -59,7 +59,7 @@ function drive_module(name) {
 	});
 	return app;
 }
-tracker = drive.get_tracker_id();
+var tracker = drive.get_tracker_id();
 if (tracker != "") {
 	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -71,7 +71,7 @@ if (tracker != "") {
 }
 
 // Default controller
-DriveController = function($scope, $translate) {
+var DriveController = function($scope, $translate) {
 	// Map default drive API
 	self = this;
 	$scope.currentAction = "";

--- a/nuxeo-drive-client/nxdrive/data/ui5/js/ndrive.js
+++ b/nuxeo-drive-client/nxdrive/data/ui5/js/ndrive.js
@@ -40,18 +40,17 @@ function drive_module(name) {
 	app = angular.module(name, ['pascalprecht.translate']);
 	app.directive('driveInclude', function($http, $templateCache, $compile) {
 	    return function(scope, element, attrs) {
-	    	// Not nicest way
-	        var templatePath = eval("scope."+attrs.driveInclude);
-	        $http.get(templatePath, { cache: $templateCache }).success(function(response) {
+	        $http.get(scope.getTemplate(attrs.driveInclude), { cache: $templateCache }).success(
+	        function(response) {
 	            var contents = element.html(response).contents();
 	            $compile(contents)(scope);
 	        });
 	    };
 	});
 	app.config(function ($translateProvider) {
-		languages = angular.fromJson(drive.get_languages());
-		for (i=0; i<languages.length; i++) {
-			$translateProvider.translations(languages[i][0], eval("LABELS." + languages[i][0]));
+		var languages = angular.fromJson(drive.get_languages());
+		for (var i=0; i<languages.length; i++) {
+			$translateProvider.translations(languages[i][0], LABELS[languages[i][0]]);
 		}
 		$translateProvider.preferredLanguage(drive.locale());
 	});

--- a/nuxeo-drive-client/nxdrive/data/ui5/modal.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/modal.html
@@ -8,8 +8,8 @@
 <script src="js/bootstrap.min.js"></script>
 <script src="i18n.js"></script>
 <script src="js/ndrive-modal.js"></script>
-<link rel="stylesheet" href="css/bootstrap.min.css"></link>
-<link rel="stylesheet" href="css/ndrive.css"></link>
+<link rel="stylesheet" href="css/bootstrap.min.css"/>
+<link rel="stylesheet" href="css/ndrive.css"/>
 <script>
 	resize = function() {
 		if ($("#content").height() < 5) {

--- a/nuxeo-drive-client/nxdrive/data/ui5/network_error.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/network_error.html
@@ -30,7 +30,7 @@
 		<img src="imgs/network.png" />
 		<h1>{{error.simple_label | translate}}</h1>
 		<h3>{{error.label | translate}}</h3>
-		<button type="button" style="margin-top: 20px;" class="btn btn-default btn-primary" onclick="drive.retry();"><span class="glyphicon glyphicon-refresh" aria-hidden="true"></span>&nbsp;<span translate>NETWORK_ERROR_RETRY</span></button>
+		<button type="button" style="margin-top: 20px;" class="btn btn-default btn-primary" onclick="drive.retry();"><span class="glyphicon glyphicon-refresh"></span>&nbsp;<span translate>NETWORK_ERROR_RETRY</span></button>
 	</div>
 </body>
 </html>

--- a/nuxeo-drive-client/nxdrive/data/ui5/network_error.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/network_error.html
@@ -8,8 +8,8 @@
 <script src="js/bootstrap.min.js"></script>
 <script src="i18n.js"></script>
 <script src="js/ndrive-network-error.js"></script>
-<link rel="stylesheet" href="css/bootstrap.min.css"></link>
-<link rel="stylesheet" href="css/ndrive.css"></link>
+<link rel="stylesheet" href="css/bootstrap.min.css"/>
+<link rel="stylesheet" href="css/ndrive.css"/>
 <script>
 	resize = function() {
 		if ($("#content").height() < 5) {

--- a/nuxeo-drive-client/nxdrive/data/ui5/settings.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/settings.html
@@ -8,8 +8,8 @@
 <script src="js/bootstrap.min.js"></script>
 <script src="i18n.js"></script>
 <script src="js/ndrive-settings.js"></script>
-<link rel="stylesheet" href="css/bootstrap.min.css"></link>
-<link rel="stylesheet" href="css/ndrive.css"></link>
+<link rel="stylesheet" href="css/bootstrap.min.css"/>
+<link rel="stylesheet" href="css/ndrive.css"/>
 <script>
 	if (typeof(drive) != "undefined") {
 		drive.resize(750, 450);

--- a/nuxeo-drive-client/nxdrive/data/ui5/settings.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/settings.html
@@ -19,7 +19,7 @@
 </script>
 </head>
 <body id="drive-settings" ng-app="DriveSettings" ng-controller="DriveSettingsCtl">
-	<div drive-include="getTemplate('settings-content')">
+	<div drive-include="settings-content">
 	</div>
 </body>
 </html>

--- a/nuxeo-drive-client/nxdrive/data/ui5/systray.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/systray.html
@@ -8,8 +8,8 @@
 <script src="js/bootstrap.min.js"></script>
 <script src="i18n.js"></script>
 <script src="js/ndrive-systray.js"></script>
-<link rel="stylesheet" href="css/bootstrap.min.css"></link>
-<link rel="stylesheet" href="css/ndrive.css"></link>
+<link rel="stylesheet" href="css/bootstrap.min.css"/>
+<link rel="stylesheet" href="css/ndrive.css"/>
 <script>
 	app = drive_module("DriveSystray");
 	app.controller("DriveSystrayCtl", SystrayController);

--- a/nuxeo-drive-client/nxdrive/data/ui5/systray.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/systray.html
@@ -16,7 +16,7 @@
 </script>
 </head>
 <body style="cursor: default;" ng-app="DriveSystray" ng-controller="DriveSystrayCtl">
-	<div drive-include="getTemplate('systray-content')">
+	<div drive-include="systray-content">
 	</div>
 </body>
 </html>

--- a/nuxeo-drive-client/nxdrive/data/ui5/templates/conflicts-content.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/templates/conflicts-content.html
@@ -63,7 +63,7 @@
 			<span style="color: #999; margin-bottom: 10px;" translate translate-values="{ date:'{{ pair.last_sync_date ? pair.last_sync_date : pair.last_remote_update }}'}">LAST_SYNCHRONIZED</span>
 			<div class="pull-right btn-group">
 				<button type="button" class="btn btn-danger" ng-click="retry_pair(pair.id)" translate>CONFLICT_RETRY</button>
-				<button type="button" style="height: 34px;" class="btn btn-danger dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+				<button type="button" style="height: 34px;" class="btn btn-danger dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
 					<span class="caret"></span>
 					<span class="sr-only">Toggle dropdown</span>
 				</button>

--- a/nuxeo-drive-client/nxdrive/data/ui5/templates/debug-content.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/templates/debug-content.html
@@ -7,16 +7,16 @@
       </a>
     </div>
     <ul class="nav navbar-nav">
-    	<li ng-show="!is_paused('engine')"><a href="#" ng-click="pause('engine')"><span class="glyphicon glyphicon-pause" aria-hidden="true"></span>&nbsp;Pause</a></li>
-    	<li ng-show="is_paused('engine')"><a href="#" ng-click="pause('engine')"><span class="glyphicon glyphicon-play" aria-hidden="true"></span>&nbsp;Resume</a></li>
+      <li ng-show="!is_paused('engine')"><a href="#" ng-click="pause('engine')"><span class="glyphicon glyphicon-pause"></span>&nbsp;Pause</a></li>
+      <li ng-show="is_paused('engine')"><a href="#" ng-click="pause('engine')"><span class="glyphicon glyphicon-play"></span>&nbsp;Resume</a></li>
     </ul>
   	<ul class="nav navbar-nav navbar-right">
-  		<li><a href="#" ng-click="pause('local_watcher')"><span ng-class="pause_class('local_watcher')" class="glyphicon" aria-hidden="true"></span>&nbsp;Local Watcher</a></li>
-  		<li><a href="#" ng-click="pause('remote_watcher')"><span ng-class="pause_class('remote_watcher')" class="glyphicon" aria-hidden="true"></span>&nbsp;Remote Watcher</a></li>
-        <li class="dropdown">
-          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false"><b>{{ engine.name }}</b><span class="caret"></span></a>
+      <li><a href="#" ng-click="pause('local_watcher')"><span ng-class="pause_class('local_watcher')" class="glyphicon"></span>&nbsp;Local Watcher</a></li>
+      <li><a href="#" ng-click="pause('remote_watcher')"><span ng-class="pause_class('remote_watcher')" class="glyphicon"></span>&nbsp;Remote Watcher</a></li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-expanded="false"><b>{{ engine.name }}</b><span class="caret"></span></a>
           <ul class="dropdown-menu" role="menu">
-            <li ng-repeat="engine in engines" ng-click="setEngine(engine)"><a href="#">{{ engine.name }}</a></li>
+             <li ng-repeat="engine in engines" ng-click="setEngine(engine)"><a href="#">{{ engine.name }}</a></li>
           </ul>
         </li>
       </ul>
@@ -36,7 +36,7 @@
 			<table class="table table-hover table-condensed">
 			<thead>
 				<tr>
-					<th><a href="#" ng-click="pause('local_folder_queue')"><span ng-class="pause_class('local_folder_queue')" class="glyphicon" aria-hidden="true"></span>&nbsp;Local Folders</a><span class="badge pull-right">{{ engine.queue.local_folder_queue }}</span></th>
+					<th><a href="#" ng-click="pause('local_folder_queue')"><span ng-class="pause_class('local_folder_queue')" class="glyphicon"></span>&nbsp;Local Folders</a><span class="badge pull-right">{{ engine.queue.local_folder_queue }}</span></th>
 				</tr>
 			</thead>
 			</table>
@@ -54,7 +54,7 @@
 			<table class="table table-hover">
 				<thead>
 					<tr>
-						<th><a href="#" ng-click="pause('local_file_queue')"><span ng-class="pause_class('local_file_queue')" class="glyphicon" aria-hidden="true"></span>&nbsp;Local Files</a><span class="badge pull-right">{{ engine.queue.local_file_queue }}</span></th>
+						<th><a href="#" ng-click="pause('local_file_queue')"><span ng-class="pause_class('local_file_queue')" class="glyphicon"></span>&nbsp;Local Files</a><span class="badge pull-right">{{ engine.queue.local_file_queue }}</span></th>
 					</tr>
 				</thead>
 			</table>
@@ -72,7 +72,7 @@
 			<table class="table table-hover">
 			<thead>
 				<tr>
-					<th><a href="#" ng-click="pause('remote_folder_queue')"><span ng-class="pause_class('remote_folder_queue')" class="glyphicon" aria-hidden="true"></span>&nbsp;Remote Folders</a><span class="badge pull-right">{{ engine.queue.remote_folder_queue }}</span></th>
+					<th><a href="#" ng-click="pause('remote_folder_queue')"><span ng-class="pause_class('remote_folder_queue')" class="glyphicon"></span>&nbsp;Remote Folders</a><span class="badge pull-right">{{ engine.queue.remote_folder_queue }}</span></th>
 				</tr>
 			</thead>
 			</table>
@@ -90,7 +90,7 @@
 			<table class="table table-hover">
 				<thead>
 					<tr>
-						<th><a href="#" ng-click="pause('remote_file_queue')"><span ng-class="pause_class('remote_file_queue')" class="glyphicon" aria-hidden="true"></span>&nbsp;Remote Files</a><span class="badge pull-right">{{ engine.queue.remote_file_queue }}</span></th>
+						<th><a href="#" ng-click="pause('remote_file_queue')"><span ng-class="pause_class('remote_file_queue')" class="glyphicon"></span>&nbsp;Remote Files</a><span class="badge pull-right">{{ engine.queue.remote_file_queue }}</span></th>
 					</tr>
 				</thead>
 			</table>
@@ -109,7 +109,7 @@
 		<table class="table table-hover table-condensed">
 		<thead>
 			<tr>
-				<th colspan="2"><a href="#" ng-click="refreshLogs()"><span class="glyphicon glyphicon-refresh" aria-hidden="true"></span>&nbsp;Logs</a></th>
+				<th colspan="2"><a href="#" ng-click="refreshLogs()"><span class="glyphicon glyphicon-refresh"></span>&nbsp;Logs</a></th>
 			</tr>
 		</thead>
 		</table>

--- a/nuxeo-drive-client/nxdrive/data/ui5/templates/debug-content.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/templates/debug-content.html
@@ -151,15 +151,15 @@
 	<div class="tab-pane" role="tabpanel" id="notifs">
 		<form>
 		  <div class="form-group">
-		    <label for="exampleInputEmail1">Title</label>
-		    <input type="text" class="form-control" ng-model="notification.title" id="exampleInputEmail1" placeholder="Title">
+		    <label for="notif-title">Title</label>
+		    <input class="form-control" ng-model="notification.title" id="notif-title" placeholder="Title">
 		  </div>
 		  <div class="form-group">
-		    <label for="exampleInputPassword1">Description</label>
-		    <input type="text" class="form-control" ng-model="notification.description" id="exampleInputPassword1" placeholder="Description">
+		    <label for="notif-desc">Description</label>
+		    <input class="form-control" ng-model="notification.description" id="notif-desc" placeholder="Description">
 		  </div>
 		  <div class="form-group">
-		    <label for="exampleInputFile">Level</label><br />
+		    <label>Level</label><br />
 		    <select  ng-model="notification.level">
 		    	<option value="danger">ERROR</option>
 		    	<option value="warning">WARNING</option>
@@ -167,8 +167,8 @@
 		    </select>
 		  </div>
 		  <div class="form-group">
-		    <label for="exampleInputFile">Action</label><br />
-		    <input type="text" ng-disabled="!notification.actionable" ng-model="notification.action" class="form-control" id="exampleInputPassword1" placeholder="Action">
+		    <label>Action</label><br />
+		    <input ng-disabled="!notification.actionable" ng-model="notification.action" class="form-control" placeholder="Action">
 		  </div>
 		  <div class="row">
 		  	<div class="col-xs-3">

--- a/nuxeo-drive-client/nxdrive/data/ui5/templates/settings-account.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/templates/settings-account.html
@@ -2,14 +2,14 @@
   <div class="form-group" ng-show="!currentAccount.initialized">
     <label for="name" class="col-sm-2 control-label" translate>NAME</label>
     <div class="col-sm-10">
-      <input type="text" class="form-control" id="name" placeholder="{{ 'ENGINE_NAME_PLACEHOLDER' | translate }}" ng-model="currentAccount.name">
+      <input class="form-control" id="name" placeholder="{{ 'ENGINE_NAME_PLACEHOLDER' | translate }}" ng-model="currentAccount.name">
     </div>
   </div>
   <div class="form-group">
     <label for="localFolder" class="col-sm-2 control-label" translate>ENGINE_FOLDER</label>
     <div class="col-sm-10">
     	<div class="input-group">
-      <input ng-disabled="currentAccount.initialized" type="text" class="form-control" id="localFolder" placeholder="{{ 'ENGINE_SELECT_FOLDER_PLACEHOLDER' | translate }}" ng-model="currentAccount.local_folder">
+      <input ng-disabled="currentAccount.initialized" class="form-control" id="localFolder" placeholder="{{ 'ENGINE_SELECT_FOLDER_PLACEHOLDER' | translate }}" ng-model="currentAccount.local_folder">
       <span class="input-group-addon" id="basic-addon2" ng-click="browse()" translate>ENGINE_FOLDER_BROWSE</span>
       </div>
     </div>
@@ -18,13 +18,13 @@
   <div class="form-group">
     <label for="serverURL" class="col-sm-2 control-label" translate>URL</label>
     <div class="col-sm-10">
-      <input ng-disabled="currentAccount.initialized" type="text" class="form-control" id="serverURL" placeholder="{{ 'ENGINE_URL_PLACEHOLDER' | translate }}" ng-model="currentAccount.server_url">
+      <input ng-disabled="currentAccount.initialized" class="form-control" id="serverURL" placeholder="{{ 'ENGINE_URL_PLACEHOLDER' | translate }}" ng-model="currentAccount.server_url">
     </div>
   </div>
   <div class="form-group" ng-show="!webAuthenticationAvailable || currentAccount.initialized">
     <label for="username" class="col-sm-2 control-label" translate>USERNAME</label>
     <div class="col-sm-10">
-      <input ng-disabled="currentAccount.initialized" type="text" class="form-control" id="username" placeholder="{{ 'ENGINE_USERNAME_PLACEHOLDER' | translate }}" ng-model="currentAccount.username">
+      <input ng-disabled="currentAccount.initialized" class="form-control" id="username" placeholder="{{ 'ENGINE_USERNAME_PLACEHOLDER' | translate }}" ng-model="currentAccount.username">
     </div>
   </div>
   <div class="form-group" ng-show="!webAuthenticationAvailable && !currentAccount.initialized">
@@ -42,7 +42,7 @@
 	      <input type="password" class="form-control" placeholder="{{ 'UPDATE_PASSWORD_PLACEHOLDER' | translate }}" ng-model="password">
 	      <span class="input-group-btn">
 	        <button class="btn btn-default" ng-click="update_password(currentAccount.uid, password)" type="button">
-              <span ng-show="update_password_error == 'CONNECTING'" class="glyphicon glyphicon-refresh glyphicon-refresh-animate" aria-hidden="true"></span>
+              <span ng-show="update_password_error == 'CONNECTING'" class="glyphicon glyphicon-refresh glyphicon-refresh-animate"></span>
               <span ng-disabled="update_password_error == 'CONNECTING'" translate>UPDATE_PASSWORD_BUTTON</span>
             </button>
 	      </span>
@@ -66,8 +66,8 @@
   <div class="form-group">
     <div class="col-sm-offset-2 col-sm-10">
       <button type="button" ng-blur="unbindBlur()" id="unbindButton" class="btn btn-default" ng-click="unbindServer($event)" ng-show="currentAccount.uid != null" translate>DISCONNECT</button>
-      <button type="button" class="btn btn-default btn-primary" ng-show="!webAuthenticationAvailable && !currentAccount.initialized" ng-disabled="!validForm() || currentAction != ''" ng-click="bindServer()"><span ng-show="currentAction == 'CONNECTING'" class="glyphicon glyphicon-refresh glyphicon-refresh-animate" aria-hidden="true"></span><span translate>CONNECT</span></button>
-      <button type="button" class="btn btn-default btn-primary" ng-show="webAuthenticationAvailable && !currentAccount.initialized" ng-disabled="!validForm() || currentAction != ''" ng-click="webAuthentication()"><span ng-show="currentAction == 'CONNECTING'" class="glyphicon glyphicon-refresh glyphicon-refresh-animate" aria-hidden="true"></span><span translate>CONNECT</span></button>
+      <button type="button" class="btn btn-default btn-primary" ng-show="!webAuthenticationAvailable && !currentAccount.initialized" ng-disabled="!validForm() || currentAction != ''" ng-click="bindServer()"><span ng-show="currentAction == 'CONNECTING'" class="glyphicon glyphicon-refresh glyphicon-refresh-animate"></span><span translate>CONNECT</span></button>
+      <button type="button" class="btn btn-default btn-primary" ng-show="webAuthenticationAvailable && !currentAccount.initialized" ng-disabled="!validForm() || currentAction != ''" ng-click="webAuthentication()"><span ng-show="currentAction == 'CONNECTING'" class="glyphicon glyphicon-refresh glyphicon-refresh-animate"></span><span translate>CONNECT</span></button>
       <button style="float:right;" title="{{ 'SELECT_SYNC_FOLDERS_DESCRIPTION' | translate }}" type="button" class="btn btn-default" ng-disabled="currentAccount.offline" ng-show="currentAccount.uid != null" ng-click="filters()" translate>SELECT_SYNC_FOLDERS</button>
       <button style="float:right;" type="button" class="btn btn-default" ng-show="currentAccount.uid != null && currentAccount.metrics.unsynchronized_files > 0" ng-click="show_conflicts(currentAccount.uid)" translate translate-values="currentAccount.metrics">IGNORES_SYSTRAY</button>
     </div>

--- a/nuxeo-drive-client/nxdrive/data/ui5/templates/settings-accounts.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/templates/settings-accounts.html
@@ -11,6 +11,6 @@
       </li>
     </ul>
   </div>
-  <div class="col-xs-9" drive-include="getTemplate('settings-account')">
+  <div class="col-xs-9" drive-include="settings-account">
   </div>
 </div>

--- a/nuxeo-drive-client/nxdrive/data/ui5/templates/settings-accounts.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/templates/settings-accounts.html
@@ -6,7 +6,7 @@
       </li>
       <li ng-class="getAccountClass(newAccount)">
         <a ng-click="changeAccount(newAccount)" href="" class="success">
-          <span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>&nbsp;<i translate>NEW_ENGINE</i>
+          <span class="glyphicon glyphicon-plus-sign"></span>&nbsp;<i translate>NEW_ENGINE</i>
         </a>
       </li>
     </ul>

--- a/nuxeo-drive-client/nxdrive/data/ui5/templates/settings-advanced.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/templates/settings-advanced.html
@@ -22,13 +22,13 @@
 	  <div class="form-group" ng-show="proxy.config == 'Automatic'">
 	    <label for="name" class="col-sm-2 control-label" translate>SCRIPT_ADDR</label>
 	    <div class="col-sm-8">
-	      <input type="text" class="form-control" id="name" placeholder="{{ PROXY_PAC_URL_PLACEHOLDER | translate}}" ng-model="proxy.pac_url">
+	      <input class="form-control" id="name" placeholder="{{ PROXY_PAC_URL_PLACEHOLDER | translate}}" ng-model="proxy.pac_url">
 	    </div>
 	  </div>
 	  <div class="form-group" ng-show="proxy.config == 'Manual'">
 	    <label for="name" class="col-sm-2 control-label" translate>HOST</label>
 	    <div class="col-sm-8">
-	      <input type="text" class="form-control" id="name" placeholder="{{ 'PROXY_HOST_PLACEHOLDER' | translate }}" ng-model="proxy.url">
+	      <input class="form-control" id="name" placeholder="{{ 'PROXY_HOST_PLACEHOLDER' | translate }}" ng-model="proxy.url">
 	    </div>
 	  </div>
 	  <div class="checkbox" ng-show="proxy.config == 'Manual'">
@@ -40,7 +40,7 @@
 	  <div class="form-group" ng-show="proxy.config == 'Manual' && proxy.authenticated">
 	    <label for="proxyUsername" class="col-sm-2 control-label" translate>USERNAME</label>
 	    <div class="col-sm-8">
-	      <input type="text" class="form-control" id="proxyUsername" placeholder="{{ 'PROXY_USERNAME_PLACEHOLDER' | translate }}" ng-model="proxy.username">
+	      <input class="form-control" id="proxyUsername" placeholder="{{ 'PROXY_USERNAME_PLACEHOLDER' | translate }}" ng-model="proxy.username">
 	    </div>
 	  </div>
 	  <div class="form-group" ng-show="proxy.config == 'Manual' && proxy.authenticated">
@@ -52,7 +52,7 @@
       <div class="alert alert-{{ message_type }}" role="alert" ng-show="message != ''">
   	 	{{ message }}
 	  </div>
-	  <button type="button" class="btn btn-default btn-primary" ng-click="saveProxy()" ng-disabled="currentAction == 'PROXY_APPLYING'"><span ng-show="currentAction == 'PROXY_APPLYING'" class="glyphicon glyphicon-refresh glyphicon-refresh-animate" aria-hidden="true"></span><span translate>APPLY</span></button>
+	  <button type="button" class="btn btn-default btn-primary" ng-click="saveProxy()" ng-disabled="currentAction == 'PROXY_APPLYING'"><span ng-show="currentAction == 'PROXY_APPLYING'" class="glyphicon glyphicon-refresh glyphicon-refresh-animate"></span><span translate>APPLY</span></button>
 
 	</form>
 </div>

--- a/nuxeo-drive-client/nxdrive/data/ui5/templates/settings-content.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/templates/settings-content.html
@@ -14,13 +14,13 @@
   </div>
 </nav>
 <div class="container-fluid" style="padding-top: 80px;">
-<div class="container" ng-show="section == 'General'" drive-include="getTemplate('settings-general')">
+<div class="container" ng-show="section == 'General'" drive-include="settings-general">
   
 </div>
-<div class="row" ng-show="section == 'Accounts'" drive-include="getTemplate('settings-accounts')">
+<div class="row" ng-show="section == 'Accounts'" drive-include="settings-accounts">
 </div>
-<div class="container" ng-show="section == 'Advanced'" drive-include="getTemplate('settings-advanced')">
+<div class="container" ng-show="section == 'Advanced'" drive-include="settings-advanced">
 </div>
-<div class="container" ng-show="section == 'About'" drive-include="getTemplate('settings-about')">
+<div class="container" ng-show="section == 'About'" drive-include="settings-about">
 </div>
 </div>

--- a/nuxeo-drive-client/nxdrive/data/ui5/templates/settings-content.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/templates/settings-content.html
@@ -6,10 +6,10 @@
       </a>
     </div>
     <ul class="nav navbar-nav">
-      <li ng-class="getSectionClass('General')"><a href="#" ng-click="changeSection('General')"><span class="glyphicon glyphicon-refresh" aria-hidden="true"></span>&nbsp;<span translate>SECTION_GENERAL</span></a></li>
-      <li ng-class="getSectionClass('Accounts')"><a href="#" ng-click="changeSection('Accounts')"><span class="glyphicon glyphicon-user" aria-hidden="true"></span>&nbsp;<span translate>SECTION_ACCOUNTS</span></a></li>
-      <li ng-class="getSectionClass('Advanced')"><a href="#" ng-click="changeSection('Advanced')"><span class="glyphicon glyphicon-wrench" aria-hidden="true"></span>&nbsp;<span translate>SECTION_ADVANCED</span></a></li>
-      <li ng-class="getSectionClass('About')"><a href="#" ng-click="changeSection('About')"><span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>&nbsp;<span translate>SECTION_ABOUT</span></a></li>
+      <li ng-class="getSectionClass('General')"><a href="#" ng-click="changeSection('General')"><span class="glyphicon glyphicon-refresh"></span>&nbsp;<span translate>SECTION_GENERAL</span></a></li>
+      <li ng-class="getSectionClass('Accounts')"><a href="#" ng-click="changeSection('Accounts')"><span class="glyphicon glyphicon-user"></span>&nbsp;<span translate>SECTION_ACCOUNTS</span></a></li>
+      <li ng-class="getSectionClass('Advanced')"><a href="#" ng-click="changeSection('Advanced')"><span class="glyphicon glyphicon-wrench"></span>&nbsp;<span translate>SECTION_ADVANCED</span></a></li>
+      <li ng-class="getSectionClass('About')"><a href="#" ng-click="changeSection('About')"><span class="glyphicon glyphicon-info-sign"></span>&nbsp;<span translate>SECTION_ABOUT</span></a></li>
     </ul>
   </div>
 </nav>

--- a/nuxeo-drive-client/nxdrive/data/ui5/templates/systray-bottom.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/templates/systray-bottom.html
@@ -9,6 +9,6 @@
     <span title="{{SYNCHRONIZATION_COMPLETED | translate }}" class="glyphicon glyphicon-ok"></span>
   </div>
   <div ng-show="!engine.paused && engine.syncing == 'syncing'">
-    <span title="{{SYNCHRONIZATION_IN_PROGRESS | translate }}" ng-show="engine.syncing_count > 0">({{engine.syncing_count}})</span>&nbsp;<img src="imgs/nuxeo_drive_icon_48.png" /></span>
+    <span title="{{SYNCHRONIZATION_IN_PROGRESS | translate }}" ng-show="engine.syncing_count > 0">({{engine.syncing_count}})</span>&nbsp;<img src="imgs/nuxeo_drive_icon_48.png" />
   </div>
 </div>

--- a/nuxeo-drive-client/nxdrive/data/ui5/templates/systray-bottom.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/templates/systray-bottom.html
@@ -1,4 +1,4 @@
-<div class="label notifications-container" style="position: absolute; padding:0px; left:0px; width: 100%; bottom: 40px; width: 100%;" drive-include="getTemplate('systray-notifications')">
+<div class="label notifications-container" style="position: absolute; padding:0px; left:0px; width: 100%; bottom: 40px; width: 100%;" drive-include="systray-notifications">
 	
   </div>
 <div class="sync-status">

--- a/nuxeo-drive-client/nxdrive/data/ui5/templates/systray-content.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/templates/systray-content.html
@@ -11,8 +11,8 @@
   </div>
 </div>
 <div id="systray" ng-show="bind">
-  <div id="systray-top" class="navbar navbar-fixed-top" drive-include="getTemplate('systray-top')"></div>
-  <div id="systray-bottom" class="navbar navbar-fixed-bottom" drive-include="getTemplate('systray-bottom')"></div>
+  <div id="systray-top" class="navbar navbar-fixed-top" drive-include="systray-top"></div>
+  <div id="systray-bottom" class="navbar navbar-fixed-bottom" drive-include="systray-bottom"></div>
   <div id="sub-menu">
     <span translate>RECENTLY_UPDATED</span>
     <a ng-click="open_local('/')" title="{{ 'OPEN_ROOT_FOLDER' | translate }}">
@@ -22,5 +22,5 @@
       <span class="glyphicon glyphicon-globe"></span>
     </a>
   </div>
-  <div class="list-group" drive-include="getTemplate('systray-files')"></div>
+  <div class="list-group" drive-include="systray-files"></div>
 </div>

--- a/nuxeo-drive-client/nxdrive/data/ui5/templates/systray-notifications.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/templates/systray-notifications.html
@@ -25,6 +25,6 @@
 <div ng-show="app_update[0] == 'updating'" class="notification notification-info">
 	<span translate translate_values="{ version:app_update[1] }">UPDATING_VERSION</span>
 	<div class="progress" style="height: 4px;">
-		<div class="progress-bar progress-bar-info" role="progressbar" aria-valuenow="{{ app_update[2] }}" aria-valuemin="0" aria-valuemax="100" style="width: {{ app_update[2] }}%" />
+		<div class="progress-bar progress-bar-info" role="progressbar" aria-valuenow="{{ app_update[2] }}" aria-valuemin="0" aria-valuemax="100" style="width: {{ app_update[2] }}%"></div>
 	</div>
 </div>


### PR DESCRIPTION
Fixes for several errors/warnings:
- HTML - Redundant default attribute
- JS - Variables should be declared explicitly
- JS - Remove use of eval()
- XML - Collapses empty tags
- Use HTTPS for Google Analytics script