### PR TITLE
NXDRIVE- 956: Uniformize actions on local deletion of read-only documents

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -4,6 +4,7 @@ Release date: `2017-??-??`
 ### Core
 - [NXDRIVE-731](https://jira.nuxeo.com/browse/NXDRIVE-731): Remove nuxeo-jsf-ui package dependency
 - [NXDRIVE-836](https://jira.nuxeo.com/browse/NXDRIVE-836): Bad behaviors with read-only documents on Windows
+- [NXDRIVE-956](https://jira.nuxeo.com/browse/NXDRIVE-956): Uniformize actions on local deletion of read-only documents
 - [NXDRIVE-957](https://jira.nuxeo.com/browse/NXDRIVE-957): Update process from 2.5.0 to 2.5.1 is broken
 
 ### GUI:
@@ -14,6 +15,7 @@ Release date: `2017-??-??`
 #### Minor changes
 - Account: Unset read-only when overwriting local folder
 - Tools: Updated `changelog.py` from 1.2.3 to 1.2.4
+- Tests: Use `QT_PATH` and `MINGW_PATH` envars on Windows
 - Packaging: Updated `Js2Py` from 0.44 to 0.50
 - Packaging: Updated `Send2Trash` from 1.3.0 to 1.4.1
 - Packaging: Updated `pytest` from 3.1.3 to 3.2.1

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -87,6 +87,8 @@ If an envar is specifying a version, this means that the specified version of th
 
 ### Optional Envars
 
+- `QT_PATH` is the **Qt binaries path**, i.e. `C:\Qt\4.8.7\bin`.
+- `MINGW_PATH` is the **MinGW binaries path** to use, i.e. `C:\mingw32\bin`.
 - `WORKSPACE_DRIVE` is the **absolute path to Drive sources**, i.e. `$WORKSPACE/sources`. If not defined, it will be set to `$WORKSPACE/sources` or `$WORKSPACE/nuxeo-drive` if folder exists else `$WORKSPACE`.
 - `CXFREEZE_VERSION` is the **cx_Freeze version** to use, i.e. `4.3.3`.
 - `SIP_VERSION` is the **SIP version** to use, i.e. `4.19`.

--- a/ftest/itests.xml
+++ b/ftest/itests.xml
@@ -15,8 +15,9 @@
 
   <!-- Configure nuxeo-drive marketplace package installation -->
   <property name="nuxeo.drive.mp.filename" value="nuxeo-drive.zip" />
+  <!-- nuxeo-jsf-ui is needed to test server URL guesser -->
   <!-- nuxeo-platform-importer is needed to test mass import -->
-  <property name="mp.install" value="file:${out.dir}/${nuxeo.drive.mp.filename},nuxeo-platform-importer" />
+  <property name="mp.install" value="file:${out.dir}/nuxeo-marketplace-jsf-ui.zip,${out.dir}/${nuxeo.drive.mp.filename},nuxeo-platform-importer" />
 
   <target name="fetch-nuxeo-drive-mp">
     <exec executable="python" failonerror="true">
@@ -27,6 +28,12 @@
       <arg value="--url=${nuxeo.drive.mp.url}" />
       <arg value="--marketplace-filename=${nuxeo.drive.mp.filename}" />
     </exec>
+  </target>
+
+  <target name="prepare-environment" depends="_init,prepare-db,prepare-tomcat">
+    <copy tofile="${out.dir}/nuxeo-marketplace-jsf-ui.zip">
+      <artifact:file key="org.nuxeo.ecm.distribution:nuxeo-marketplace-jsf-ui::zip" />
+    </copy>
   </target>
 
   <target name="run-drive-tests">

--- a/ftest/pom-8.10.xml
+++ b/ftest/pom-8.10.xml
@@ -31,6 +31,13 @@
       <type>zip</type>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.nuxeo.ecm.distribution</groupId>
+      <artifactId>nuxeo-marketplace-jsf-ui</artifactId>
+      <version>${nuxeo.tested.version}</version>
+      <type>zip</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/ftest/pom.xml
+++ b/ftest/pom.xml
@@ -31,6 +31,13 @@
       <type>zip</type>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.nuxeo.ecm.distribution</groupId>
+      <artifactId>nuxeo-marketplace-jsf-ui</artifactId>
+      <version>${nuxeo.tested.version}</version>
+      <type>zip</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/nuxeo-drive-client/nxdrive/engine/processor.py
+++ b/nuxeo-drive-client/nxdrive/engine/processor.py
@@ -641,8 +641,7 @@ class Processor(EngineWorker):
     def _synchronize_locally_deleted(self, doc_pair, local_client, remote_client):
         if not doc_pair.remote_ref:
             self._dao.remove_state(doc_pair)
-            if local_client.duplication_enabled():
-                self._search_for_dedup(doc_pair)
+            self._search_for_dedup(doc_pair)
             return
 
         if doc_pair.remote_can_delete:
@@ -674,8 +673,7 @@ class Processor(EngineWorker):
         # A file has been moved locally, and an error occurs when tried to
         # move on the server
         remote_info = None
-        if local_client.duplication_enabled():
-            self._search_for_dedup(doc_pair, doc_pair.remote_name)
+        self._search_for_dedup(doc_pair, doc_pair.remote_name)
 
         if doc_pair.local_name != doc_pair.remote_name:
             try:

--- a/nuxeo-drive-client/nxdrive/engine/watcher/local_watcher.py
+++ b/nuxeo-drive-client/nxdrive/engine/watcher/local_watcher.py
@@ -728,20 +728,9 @@ class LocalWatcher(EngineWorker):
     def _handle_watchdog_event_on_known_acquired_pair(self, doc_pair, evt, rel_path):
         if evt.event_type == 'deleted':
             if self._windows:
-                if not doc_pair.remote_can_delete:
-                    log.debug('Deleting a read-only document: %r', doc_pair)
-                    log.debug(
-                        'The %s will be downloaded again in the next scan',
-                        ('file' if doc_pair.folderish
-                         else 'folder and its content'))
-                    self._dao.remove_state(doc_pair)
-                    self._dao.add_path_to_scan(doc_pair.remote_parent_path)
-                    self._engine.deleteReadonly.emit(doc_pair.local_name)
-                    return
-
                 # Delay on Windows the delete event
-                self._win_lock.acquire()
                 log.debug('Add pair to delete events: %r', doc_pair)
+                self._win_lock.acquire()
                 try:
                     self._delete_events[doc_pair.remote_ref] = current_milli_time(), doc_pair
                 finally:

--- a/nuxeo-drive-client/tests/test_local_move_and_rename.py
+++ b/nuxeo-drive-client/tests/test_local_move_and_rename.py
@@ -747,8 +747,7 @@ class TestLocalMoveAndRename(UnitTestCase):
         self.assertFalse(local_client.exists(u'/Original Folder 1'))
 
         self.wait_sync(wait_for_async=True)
-        count = 10 if AbstractOSIntegration.is_windows() else 6
-        self.assertEqual(self.engine_1.get_dao().get_sync_count(), count)
+        self.assertEqual(self.engine_1.get_dao().get_sync_count(), 6)
 
         # Check remote folder and its children have not been deleted
         folder_1_remote_info = remote_client.get_info(u'/Original Folder 1')

--- a/nuxeo-drive-client/tests/test_permission_hierarchy.py
+++ b/nuxeo-drive-client/tests/test_permission_hierarchy.py
@@ -253,12 +253,8 @@ class TestPermissionHierarchy(UnitTestCase):
                        wait_for_engine_2=True)
 
         # Local checks
-        if AbstractOSIntegration.is_windows():
-            self.assertTrue(self.local_client_2.exists(
-                root + 'ReadFolder/file_ro.txt'))
-        else:
-            self.assertFalse(self.local_client_2.exists(
-                root + 'ReadFolder/file_ro.txt'))
+        self.assertFalse(self.local_client_2.exists(
+            root + 'ReadFolder/file_ro.txt'))
         self.assertFalse(self.local_client_2.exists(
             root + 'WriteFolder/file_ro.txt'))
         self.assertTrue(self.local_client_2.exists(
@@ -268,8 +264,7 @@ class TestPermissionHierarchy(UnitTestCase):
             'Now a fresh read-write doc.')
 
         # Remote checks
-        count = int(AbstractOSIntegration.is_windows())
-        self.assertEqual(len(self.user1.get_children_info(readonly)), count)
+        self.assertEqual(len(self.user1.get_children_info(readonly)), 0)
         children = self.user1.get_children_info(readwrite)
         self.assertEqual(len(children), 1)
         self.assertEqual(children[0].filename, 'file_rw.txt')

--- a/tools/windows/deploy_jenkins_slave.ps1
+++ b/tools/windows/deploy_jenkins_slave.ps1
@@ -78,6 +78,12 @@ function check_vars {
 	if (-Not ($Env:CXFREEZE_VERSION)) {
 		$Env:CXFREEZE_VERSION = "4.3.3"  # XXX: CXFREEZE_VERSION
 	}
+	if (-Not ($Env:QT_PATH)) {
+		$Env:QT_PATH = "C:\Qt\4.8.7\bin"
+	}
+	if (-Not ($Env:MINGW_PATH)) {
+		$Env:MINGW_PATH = "C:\mingw32\bin"
+	}
 	$Env:STORAGE_DIR = (New-Item -ItemType Directory -Force -Path "$($Env:WORKSPACE)\deploy-dir").FullName
 	$Env:PYTHON_DIR = "$Env:STORAGE_DIR\drive-$Env:PYTHON_DRIVE_VERSION-python"
 
@@ -89,6 +95,11 @@ function check_vars {
 	echo "    WORKSPACE_DRIVE      = $Env:WORKSPACE_DRIVE"
 	echo "    STORAGE_DIR          = $Env:STORAGE_DIR"
 	echo "    PYTHON_DIR           = $Env:PYTHON_DIR"
+	echo "    QT_PATH              = $Env:QT_PATH"
+	echo "    MINGW_PATH           = $Env:MINGW_PATH"
+
+	# Adjust the PATH for compilation tools
+	$Env:Path = "$Env:QT_PATH;$Env:MINGW_PATH"
 
 	Set-Location "$Env:WORKSPACE_DRIVE"
 
@@ -351,9 +362,6 @@ function unzip($filename, $dest_dir) {
 }
 
 function main {
-	# Adjust the PATH for compilation tools
-	$env:Path = "C:\Qt\4.8.7\bin;C:\mingw32\bin"
-
 	# Launch operations
 	check_vars
 	install_python


### PR DESCRIPTION
Introduced with NXDRIVE-836, actions taken on local deletion of read-only documents was not the same on Unix and Windows. This patch fixes that behavior.

Also:
  - On Windows, use `QT_PATH` and `MINGW_PATH` envars to facilitate tests.