### PR TITLE
NXDRIVE-963: Crash when deleting an account

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -4,6 +4,9 @@ Release date: `2017-??-??`
 ### Core
 - [NXDRIVE-990](https://jira.nuxeo.com/browse/NXDRIVE-990): "Other docs" folder is deleted after disconnect and reconnect with same user
 
+#### Minor changes
+- GUI: Add more versions informations in About (Python, Qt, WebKit and SIP)
+
 
 # 2.5.4
 Release date: `2017-09-16`

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -4,6 +4,9 @@ Release date: `2017-??-??`
 ### Core
 - [NXDRIVE-990](https://jira.nuxeo.com/browse/NXDRIVE-990): "Other docs" folder is deleted after disconnect and reconnect with same user
 
+### GUI
+- [NXDRIVE-963](https://jira.nuxeo.com/browse/NXDRIVE-963): Crash when deleting an account
+
 #### Minor changes
 - GUI: Add more versions informations in About (Python, Qt, WebKit and SIP)
 

--- a/nuxeo-drive-client/nxdrive/client/base_automation_client.py
+++ b/nuxeo-drive-client/nxdrive/client/base_automation_client.py
@@ -567,7 +567,7 @@ class BaseAutomationClient(BaseClient):
             'deviceId': self.device_id,
             'applicationName': self.application_name,
             'permission': TOKEN_PERMISSION,
-            'revoke': 'true' if revoke else 'false',
+            'revoke': str(revoke).lower(),
         }
         device_description = DEVICE_DESCRIPTIONS.get(sys.platform)
         if device_description:

--- a/nuxeo-drive-client/nxdrive/data/ui5/css/ndrive.css
+++ b/nuxeo-drive-client/nxdrive/data/ui5/css/ndrive.css
@@ -280,7 +280,7 @@ a, a:link {
   font-size: 1.1em;
   margin-bottom: 30px; }
 
-#about-view .info p:first-child {
+#about-view .info p:first-child span {
   font-weight: bold;
   margin-bottom: 5px; }
 

--- a/nuxeo-drive-client/nxdrive/data/ui5/js/ndrive-settings.js
+++ b/nuxeo-drive-client/nxdrive/data/ui5/js/ndrive-settings.js
@@ -1,6 +1,7 @@
 var SettingsController = function($scope, $interval, $translate) {
 	DriveController.call(this, $scope, $translate);
 	self = this;
+	$scope.metrics = angular.fromJson(drive.get_infos());
 	$scope.accounts = [];
 	$scope.section = ""
 	$scope.local_folder = "";

--- a/nuxeo-drive-client/nxdrive/data/ui5/templates/settings-about.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/templates/settings-about.html
@@ -1,17 +1,21 @@
-<div id="about-view">
+<div id="about-view" xmlns="http://www.w3.org/1999/html">
 	<div class="info">
-	  <p><img src="imgs/nuxeo_drive_icon_48.png" /> Nuxeo Drive {{ version }}</p>
-	  <p>
-	    <img src="imgs/github.png" />
-	    <a href="" ng-click="open_local('https://github.com/nuxeo/nuxeo-drive')">https://github.com/nuxeo/nuxeo-drive</a>
-	  </p>
-	  <p>
-	    <img src="imgs/update.png" />
-	    <a href="" ng-click="open_local(update_url)">{{ update_url }}</a>
-	  </p>
+		<p>
+			<img src="imgs/nuxeo_drive_icon_48.png" />
+			<span>Nuxeo Drive {{ version }}</span>
+			<small>[Python {{ metrics.python_version }}, Qt {{ metrics.qt_version }}, PyQt {{ metrics.pyqt_version }}, WebKit {{ metrics.webkit_version }}, SIP {{ metrics.sip_version }}]</small>
+		</p>
+		<p>
+			<img src="imgs/github.png" />
+			<a href="" ng-click="open_local('https://github.com/nuxeo/nuxeo-drive')">https://github.com/nuxeo/nuxeo-drive</a>
+		</p>
+		<p>
+			<img src="imgs/update.png" />
+			<a href="" ng-click="open_local(update_url)">{{ update_url }}</a>
+		</p>
 	</div>
 	<div class="license">
-	  <div translate>LICENSE</div>
-	  <pre ng-include="'GPL.txt'"></pre>
+		<div translate>LICENSE</div>
+		<pre ng-include="'GPL.txt'"></pre>
 	</div>
 </div>

--- a/nuxeo-drive-client/nxdrive/data/ui5/templates/settings-about.html
+++ b/nuxeo-drive-client/nxdrive/data/ui5/templates/settings-about.html
@@ -1,4 +1,4 @@
-<div id="about-view" xmlns="http://www.w3.org/1999/html">
+<div id="about-view">
 	<div class="info">
 		<p>
 			<img src="imgs/nuxeo_drive_icon_48.png" />

--- a/nuxeo-drive-client/nxdrive/wui/settings.py
+++ b/nuxeo-drive-client/nxdrive/wui/settings.py
@@ -41,6 +41,7 @@ class WebSettingsApi(WebDriveApi):
         self._new_local_folder = ''
         self._account_creation_error = ''
         self._token_update_error = ''
+        self.__unbinding = False
 
     @QtCore.pyqtSlot(result=str)
     def get_default_section(self):
@@ -56,11 +57,16 @@ class WebSettingsApi(WebDriveApi):
 
     @QtCore.pyqtSlot(str, result=QtCore.QObject)
     def unbind_server_async(self, uid):
-        return Promise(self.unbind_server, uid)
+        if not self.__unbinding:
+            return Promise(self.unbind_server, uid)
 
     @QtCore.pyqtSlot(str, result=str)
     def unbind_server(self, uid):
-        self._manager.unbind_engine(str(uid))
+        self.__unbinding = True
+        try:
+            self._manager.unbind_engine(str(uid))
+        finally:
+            self.__unbinding = False
         return ''
 
     @QtCore.pyqtSlot(str)

--- a/nuxeo-drive-client/nxdrive/wui/settings.py
+++ b/nuxeo-drive-client/nxdrive/wui/settings.py
@@ -74,7 +74,6 @@ class WebSettingsApi(WebDriveApi):
         parts = urlparse.urlsplit(guess_server_url(unicode(url)))
         url = urlparse.urlunsplit(
             (parts.scheme, parts.netloc, parts.path, '', parts.fragment))
-        log.debug('URL: %r', url)
 
         # On first time login convert QString(having special characters) to str
         if isinstance(local_folder, QtCore.QString):


### PR DESCRIPTION
A simple check on the current action (here: unbinding) to prevent several calls to `unbind_server()`.