### PR TITLE
NXDRIVE-992: Rollback release tag on Drive-package job failure

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -14,6 +14,7 @@ Release date: `2017-??-??`
 
 #### Minor changes
 - GUI: Add more versions informations in About (Python, Qt, WebKit and SIP)
+- Jenkins: Better artifacts deployment on the server
 
 
 # 2.5.4

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -12,6 +12,9 @@ Release date: `2017-??-??`
 - [NXDRIVE-978](https://jira.nuxeo.com/browse/NXDRIVE-978): Wrong resume/suspend icon after pause and disconnect/reconnect
 - [NXDRIVE-982](https://jira.nuxeo.com/browse/NXDRIVE-982): After disconnect and connect, systray menu alignment is not proper
 
+### Packaging / Build
+- [NXDRIVE-992](https://jira.nuxeo.com/browse/NXDRIVE-992): Rollback release tag on Drive-package job failure
+
 #### Minor changes
 - GUI: Add more versions informations in About (Python, Qt, WebKit and SIP)
 - Jenkins: Better artifacts deployment on the server

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -32,14 +32,13 @@ release() {
 cp -vf ${path}/drive-tests/*${drive_version}* ${path}/drive
 
 # Create symbolic links of the latest packages
-ln -sfv ${dmg} ${path}/drive/latest/nuxeo-drive.dmg
-ln -sfv ${msi} ${path}/drive/latest/nuxeo-drive.msi
+ln -sfrv ${dmg} ${path}/drive/latest/nuxeo-drive.dmg
+ln -sfrv ${msi} ${path}/drive/latest/nuxeo-drive.msi
 
 # Create symbolic links of the latest packages for all supported versions of Nuxeo
-for nuxeo_version in 6.0 7.10 8.10 9.1-SNAPSHOT; do
-    mkdir -pv ${path}/drive/latest/\$nuxeo_version
-    ln -sfv ${dmg} ${path}/drive/latest/\$nuxeo_version/nuxeo-drive.dmg
-    ln -sfv ${msi} ${path}/drive/latest/\$nuxeo_version/nuxeo-drive.msi
+for folder in \$(find ${path}/drive/latest -maxdepth 1 -type d); do
+    ln -sfrv ${dmg} \$folder/nuxeo-drive.dmg
+    ln -sfrv ${msi} \$folder/nuxeo-drive.msi
 done
 EOF
 

--- a/tools/jenkins/beta.groovy
+++ b/tools/jenkins/beta.groovy
@@ -15,36 +15,44 @@ timestamps {
             def credential_id = '4691426b-aa51-428b-901d-4e851ee37b01'
             def release = ''
 
-            stage('Checkout') {
-                deleteDir()
-                git credentialsId: credential_id, url: 'ssh://git@github.com/nuxeo/nuxeo-drive.git'
-            }
-
-            stage('Create') {
-                sshagent([credential_id]) {
-                    sh 'tools/release.sh --create'
-                    archive 'draft.json'
-                }
-            }
-
-            stage('Trigger') {
-                // Trigger the Drive packages job to build executables and have artifacts
-                release = sh script: 'git tag -l "release-*" --sort=-taggerdate | head -n1', returnStdout: true
-                release = release.trim()
-                build job: 'Drive-packages', parameters: [
-                    [$class: 'StringParameterValue', name: 'BRANCH_NAME', value: 'refs/tags/' + release],
-                    [$class: 'BooleanParameterValue', name: 'CLEAN_WORKSPACE', value: true]]
-            }
-
-            stage('Publish') {
-                dir('dist') {
+            try {
+                stage('Checkout') {
                     deleteDir()
+                    git credentialsId: credential_id, url: 'ssh://git@github.com/nuxeo/nuxeo-drive.git'
                 }
+
+                stage('Create') {
+                    sshagent([credential_id]) {
+                        sh 'tools/release.sh --create'
+                        archive 'draft.json'
+                    }
+                }
+
+                stage('Trigger') {
+                    // Trigger the Drive packages job to build executables and have artifacts
+                    release = sh script: 'git tag -l "release-*" --sort=-taggerdate | head -n1', returnStdout: true
+                    release = release.trim()
+                    build job: 'Drive-packages', parameters: [
+                        [$class: 'StringParameterValue', name: 'BRANCH_NAME', value: 'refs/tags/' + release],
+                        [$class: 'BooleanParameterValue', name: 'CLEAN_WORKSPACE', value: true]]
+                }
+
+                stage('Publish') {
+                    dir('dist') {
+                        deleteDir()
+                    }
+                    sshagent([credential_id]) {
+                        sh 'tools/release.sh --publish'
+                    }
+                    release = release.replace('release-', '').trim()
+                    currentBuild.description = "Beta ${release}"
+                }
+            } catch(e) {
                 sshagent([credential_id]) {
-                    sh 'tools/release.sh --publish'
+                    sh 'tools/release.sh --cancel'
                 }
-                release = release.replace('release-', '').trim()
-                currentBuild.description = "Beta ${release}"
+                currentBuild.result = 'FAILURE'
+                throw e
             }
         }
     }

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -6,6 +6,16 @@
 # Warning: do not execute this script manually but from Jenkins.
 #
 
+cancel_beta() {
+    local drive_version
+
+    drive_version="$(python tools/changelog.py --drive-version)"
+
+    echo ">>> [beta ${drive_version}] Removing the release tag"
+    git tag --delete "release-${drive_version}" || true
+    git push --delete origin "release-${drive_version}" || true
+}
+
 changelog() {
     # Create the draft.json file with the pre-release content
     local drive_version
@@ -77,10 +87,12 @@ publish_beta() {
 }
 
 main() {
-    if [ "$1" = "--create" ]; then
-        create_beta
-    elif [ "$1" = "--publish" ]; then
-        publish_beta
+    if [ $# -eq 1 ]; then
+        case "$1" in
+            "--cancel") cancel_beta ;;
+            "--create") create_beta ;;
+            "--publish") publish_beta ;;
+        esac
     fi
 }
 


### PR DESCRIPTION
If the packages job fails, we remove the newly created tag.