### PR TITLE
NXDRIVE-991: Upgrade Python from 2.7.13 to 2.7.14

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -19,6 +19,7 @@ Release date: `2017-??-??`
 #### Minor changes
 - GUI: Add more versions informations in About (Python, Qt, WebKit and SIP)
 - Jenkins: Better artifacts deployment on the server
+- Packaging: Bypass use of get-pip.py for `pip` installation
 
 
 # 2.5.4

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -14,6 +14,7 @@ Release date: `2017-??-??`
 
 ### Packaging / Build
 - [NXDRIVE-992](https://jira.nuxeo.com/browse/NXDRIVE-992): Rollback release tag on Drive-package job failure
+- [NXDRIVE-992](https://jira.nuxeo.com/browse/NXDRIVE-991): Upgrade Python from 2.7.13 to 2.7.14
 
 #### Minor changes
 - GUI: Add more versions informations in About (Python, Qt, WebKit and SIP)

--- a/tools/checksums.txt
+++ b/tools/checksums.txt
@@ -1,7 +1,8 @@
 # Note 1: Keep lists sorted.
 # Note 2: Obsolete checksums can be safely removed from this file.
-# Note 3: Obsolete files should _not_ be removed from the server (for reproductibility reasons).
-# Note 4: Always use ZIP files on Windows to avoid any external dependency (7-Zip'n co)
+# Note 3: Obsolete files must _not_ be removed from the server (for reproductibility reasons).
+# Note 4: Always use ZIP files on Windows to avoid any external dependency (7-Zip'n co).
+# Note 5: Do not upload any Python executable on the server.
 
 # cx_Freeze
 c729d5663320f6afc23682634c7f4cc2  cx_Freeze-4.3.3.tar.gz
@@ -13,7 +14,7 @@ f1962bfd4b668d42e12d5ed87b500788  cx_Freeze-4.3.3.zip
 0112e15858cd7d318a09e7366922f874  PyQt4_gpl_x11-4.12.1.tar.gz
 
 # Python
-0f057ab4490e63e528eaa4a70df711d9  python-2.7.13.msi
+fff688dc4968ec80bbb0eedf45de82db  python-2.7.14.msi
 
 # SIP
 4708187f74a4188cb4e294060707106f  sip-4.19.3.tar.gz

--- a/tools/jenkins/packages.groovy
+++ b/tools/jenkins/packages.groovy
@@ -2,7 +2,7 @@
 // Script to build Nuxeo Drive packages on every supported platform.
 
 // Default values for required envars
-python_drive_version = '2.7.13'  // XXX: PYTHON_DRIVE_VERSION
+python_drive_version = '2.7.14'  // XXX: PYTHON_DRIVE_VERSION
 pyqt_version = '4.12.1'  // XXX: PYQT_VERSION
 sip_version = '4.19.3'  // XXX: SIP_VERSION
 cxfreeze_version = '4.3.3'  // XXX: CXFREEZE_VERSION

--- a/tools/jenkins/tests-8.10.groovy
+++ b/tools/jenkins/tests-8.10.groovy
@@ -2,7 +2,7 @@
 // Script to launch Nuxeo Drive tests on every supported platform.
 
 // Default values for required envars
-python_drive_version = '2.7.13'
+python_drive_version = '2.7.14'  // XXX: PYTHON_DRIVE_VERSION
 pyqt_version = '4.12'
 cxfreeze_version = '4.3.3'
 sip_version = '4.19'

--- a/tools/jenkins/tests-8.10.groovy
+++ b/tools/jenkins/tests-8.10.groovy
@@ -3,9 +3,9 @@
 
 // Default values for required envars
 python_drive_version = '2.7.14'  // XXX: PYTHON_DRIVE_VERSION
-pyqt_version = '4.12'
-cxfreeze_version = '4.3.3'
-sip_version = '4.19'
+pyqt_version = '4.12.1'  // XXX: PYQT_VERSION
+sip_version = '4.19.3'  // XXX: SIP_VERSION
+cxfreeze_version = '4.3.3'  // XXX: CXFREEZE_VERSION
 
 // Pipeline properties
 properties([

--- a/tools/jenkins/tests.groovy
+++ b/tools/jenkins/tests.groovy
@@ -2,7 +2,7 @@
 // Script to launch Nuxeo Drive tests on every supported platform.
 
 // Default values for required envars
-python_drive_version = '2.7.13'  // XXX: PYTHON_DRIVE_VERSION
+python_drive_version = '2.7.14'  // XXX: PYTHON_DRIVE_VERSION
 pyqt_version = '4.12.1'  // XXX: PYQT_VERSION
 sip_version = '4.19.3'  // XXX: SIP_VERSION
 cxfreeze_version = '4.3.3'  // XXX: CXFREEZE_VERSION

--- a/tools/windows/deploy_jenkins_slave.ps1
+++ b/tools/windows/deploy_jenkins_slave.ps1
@@ -183,6 +183,15 @@ function install_cxfreeze {
 }
 
 function install_deps {
+	if (-Not (check_import "import pip")) {
+		echo ">>> Installing pip"
+		# https://github.com/python/cpython/blob/master/Tools/msi/pip/pip.wxs#L28
+		& $Env:PYTHON_DIR\python $global:PYTHON_OPT -m ensurepip -U --default-pip
+		if ($lastExitCode -ne 0) {
+			ExitWithCode $lastExitCode
+		}
+	}
+
 	echo ">>> Installing requirements"
 	& $Env:PYTHON_DIR\python $global:PYTHON_OPT $global:PIP_OPT -r requirements.txt
 	if ($lastExitCode -ne 0) {
@@ -191,27 +200,6 @@ function install_deps {
 	& $Env:PYTHON_DIR\python $global:PYTHON_OPT $global:PIP_OPT -r requirements-windows.txt
 	if ($lastExitCode -ne 0) {
 		ExitWithCode $lastExitCode
-	}
-}
-
-function install_pip {
-	$output = "$Env:STORAGE_DIR\get-pip.py"
-	$url = "https://bootstrap.pypa.io/get-pip.py"
-
-	if (check_import "import pip") {
-		return
-	}
-
-	echo ">>> Installing pip"
-	download $url $output -check $false
-	& $Env:PYTHON_DIR\python $global:PYTHON_OPT $output -q -t $Env:PYTHON_DIR
-	$ret = $lastExitCode
-
-	# Cleanup
-	Remove-Item -Force $output
-
-	if ($ret -ne 0) {
-		ExitWithCode $ret
 	}
 }
 
@@ -389,7 +377,6 @@ function main {
 	check_vars
 	install_python
 	install_openssl
-	install_pip
 	install_deps
 	install_sip
 	install_pyqt


### PR DESCRIPTION
I also bypassed the use of get-pip.py for pip installation as it fails often in our Windows slaves.