### PR TITLE
NXDRIVE-995: Prevent renaming from 'folder' to 'folder ' on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ debian
 dist
 dist-beta
 .DS_Store
+*.dll
 *.dylib
 *.egg-info
 ENV

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -20,7 +20,8 @@ Release date: `2017-??-??`
 #### Minor changes
 - GUI: Add more versions informations in About (Python, Qt, WebKit and SIP)
 - Jenkins: Better artifacts deployment on the server
-- Packaging: Bypass use of get-pip.py for `pip` installation
+- Jenkins: Update `pyenv` to take into account new Python versions
+- Packaging: Bypass use of get-pip.py for `pip` installation on Windows
 
 
 # 2.5.4

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -6,6 +6,7 @@ Release date: `2017-??-??`
 - [NXDRIVE-950](https://jira.nuxeo.com/browse/NXDRIVE-950): Invalid credentials loop when revoking the user's token
 - [NXDRIVE-964](https://jira.nuxeo.com/browse/NXDRIVE-964): Impossible to use an old local folder from another user
 - [NXDRIVE-994](https://jira.nuxeo.com/browse/NXDRIVE-994): Bad use of tuple for keyword xattr_names of LocalClient.update_content()
+- [NXDRIVE-995](https://jira.nuxeo.com/browse/NXDRIVE-995): Prevent renaming from 'folder' to 'folder ' on Windows
 
 ### GUI
 - [NXDRIVE-963](https://jira.nuxeo.com/browse/NXDRIVE-963): Crash when deleting an account
@@ -14,7 +15,7 @@ Release date: `2017-??-??`
 
 ### Packaging / Build
 - [NXDRIVE-992](https://jira.nuxeo.com/browse/NXDRIVE-992): Rollback release tag on Drive-package job failure
-- [NXDRIVE-992](https://jira.nuxeo.com/browse/NXDRIVE-991): Upgrade Python from 2.7.13 to 2.7.14
+- [NXDRIVE-991](https://jira.nuxeo.com/browse/NXDRIVE-991): Upgrade Python from 2.7.13 to 2.7.14
 
 #### Minor changes
 - GUI: Add more versions informations in About (Python, Qt, WebKit and SIP)

--- a/docs/technical_changes.md
+++ b/docs/technical_changes.md
@@ -1,6 +1,7 @@
 # dev
 - Changed `update_token` method in `WebSettingsApi` class. No more `static.`
 - Removed `is_osxbundle()` method from `LocalClient` class
+- Removed `is_updated()` method from `Manager` class. Use `updated` attribute instead.
 
 # 2.5.4
 - Moved `get_repository_names()` method from `RemoteDocumentClient` class to `RemoteDocumentClientForTests` class, only for tests

--- a/docs/technical_changes.md
+++ b/docs/technical_changes.md
@@ -2,6 +2,7 @@
 - Changed `update_token` method in `WebSettingsApi` class. No more `static.`
 - Removed `is_osxbundle()` method from `LocalClient` class
 - Removed `is_updated()` method from `Manager` class. Use `updated` attribute instead.
+- Moved `normalize_event_filename()` function from engine/watcher/local_watcher.py to utils.py
 
 # 2.5.4
 - Moved `get_repository_names()` method from `RemoteDocumentClient` class to `RemoteDocumentClientForTests` class, only for tests

--- a/docs/technical_changes.md
+++ b/docs/technical_changes.md
@@ -1,5 +1,6 @@
 # dev
 - Changed `update_token` method in `WebSettingsApi` class. No more `static.`
+- Removed `is_osxbundle()` method from `LocalClient` class
 
 # 2.5.4
 - Moved `get_repository_names()` method from `RemoteDocumentClient` class to `RemoteDocumentClientForTests` class, only for tests

--- a/docs/technical_changes.md
+++ b/docs/technical_changes.md
@@ -1,128 +1,132 @@
+[//]: # (Note 1: class.method ordered)
+[//]: # (Note 2: single files last)
+[//]: # (Note 3: keywords ordered [Added, Changed, Moved, Removed])
+
 # dev
-- Changed `update_token` method in `WebSettingsApi` class. No more `static.`
-- Removed `is_osxbundle()` method from `LocalClient` class
-- Removed `is_updated()` method from `Manager` class. Use `updated` attribute instead.
-- Moved `normalize_event_filename()` function from engine/watcher/local_watcher.py to utils.py
+- Removed `LocalClient.is_osxbundle()`
+- Removed `Manager.is_updated()`. Use `updated` attribute instead.
+- Changed `WebSettingsApi.update_token()`. No more static.
+- Moved engine/watcher/local_watcher.py::`normalize_event_filename()` to utils.py
 
 # 2.5.4
-- Moved `get_repository_names()` method from `RemoteDocumentClient` class to `RemoteDocumentClientForTests` class, only for tests
-- Moved `make_file_in_user_workspace()` method from `RemoteDocumentClient` class to `RemoteDocumentClientForTests` class, only for tests
-- Moved `activate_profile()` method from `RemoteDocumentClient` class to `RemoteDocumentClientForTests` class, only for tests
-- Moved `deactivate_profile()` method from `RemoteDocumentClient` class to `RemoteDocumentClientForTests` class, only for tests
-- Moved `add_to_locally_edited_collection()` method from `RemoteDocumentClient` class to `RemoteDocumentClientForTests` class, only for tests
-- Moved `get_collection_members()` method from `RemoteDocumentClient` class to `RemoteDocumentClientForTests` class, only for tests
-- Moved `mass_import()` method from `RemoteDocumentClient` class to `RemoteDocumentClientForTests` class, only for tests
-- Moved `wait_for_async_and_es_indexing()` method from `RemoteDocumentClient` class to `RemoteDocumentClientForTests` class, only for tests
-- Moved `result_set_query()` method from `RemoteDocumentClient` class to `RemoteDocumentClientForTests` class, only for tests
+- Moved `RemoteDocumentClient.activate_profile()` to `RemoteDocumentClientForTests`
+- Moved `RemoteDocumentClient.add_to_locally_edited_collection()` to `RemoteDocumentClientForTests`
+- Moved `RemoteDocumentClient.deactivate_profile()` to `RemoteDocumentClientForTests`
+- Moved `RemoteDocumentClient.get_collection_members()` to `RemoteDocumentClientForTests`
+- Moved `RemoteDocumentClient.get_repository_names()` to `RemoteDocumentClientForTests`
+- Moved `RemoteDocumentClient.make_file_in_user_workspace()` `RemoteDocumentClientForTests`
+- Moved `RemoteDocumentClient.mass_import()` to `RemoteDocumentClientForTests`
+- Moved `RemoteDocumentClient.result_set_query()` to `RemoteDocumentClientForTests`
+- Moved `RemoteDocumentClient.wait_for_async_and_es_indexing()` to `RemoteDocumentClientForTests`
 
 # 2.5.2
-- Removed `is_office_file()` function from local_watcher.py
-- Added `dynamic_states` keyword to `synchronize_state()` method in `EngineDAO` class
-- Added `force` keyword to `local_rollback()` method in `Engine` class
-- Removed `get_username()` method from `RootAlreadyBindWithDifferentAccount` class. Use `username` attribute instead.
-- Removed `get_url()` method from `RootAlreadyBindWithDifferentAccount` class. Use `url` attribute instead.
-- Removed `deprecated()` function from utils.py
-- Added `guess_server_url()` function to utils.py
-- Moved `DRIVE_STARTUP_PAGE` constant from wui/settings.py to client/common.py
-- Added `enrichers` keyword to `execute()` method in `BaseAutomationClient` class
-- Added `**kwargs` keyword to `fetch()` method in `RemoteDocumentClient` class
-- Removed `fetch()` method from `RestAPIClient` class
-- Removed `is_locked()` method from `RestAPIClient` class
-- Removed `log_on_server()` method from `RestAPIClient` class
-- Added `log_on_server()` method to `RemoteDocumentClient` class
-- Added `is_locked()` method to `RemoteDocumentClient` class
-- Added `create_user()` method to `RemoteDocumentClient` class
+- Added `enrichers` keyword to `BaseAutomationClient.execute()`
+- Added `force` keyword to `Engine.local_rollback()`
+- Added `dynamic_states` keyword to `EngineDAO.synchronize_state()`
+- Added `**kwargs` keyword to `RemoteDocumentClient.fetch()`
+- Removed `RestAPIClient.fetch()`
+- Removed `RestAPIClient.is_locked()`
+- Removed `RestAPIClient.log_on_server()`
+- Added `RemoteDocumentClient.create_user()`
+- Added `RemoteDocumentClient.log_on_server()`
+- Added `RemoteDocumentClient.is_locked()`
+- Removed `RootAlreadyBindWithDifferentAccount.get_username()`. Use `username` attribute instead.
+- Removed `RootAlreadyBindWithDifferentAccount.get_url()`. Use `url` attribute instead.
+- Added utils.py::`guess_server_url()`
+- Moved wui/settings.py::`DRIVE_STARTUP_PAGE` to client/common.py
+- Removed local_watcher.py::`is_office_file()`
+- Removed utils.py::`deprecated()`
 
 # 2.5.1
-- Removed `update_tooltip()` method from `Application` class
-- Removed `_get_debug_dialog()` method from `Application` class
+- Removed `Application._get_debug_dialog()`
+- Removed `Application.update_tooltip()`
 
 # 2.5.0
-- Removed `start_engine`, `check_fs` and `token` keywords from `_bind_server()` method in `WebSettingsApi` class. Use `kwargs.get(arg, default)` instead.
-- Removed `local_folder`, `url`, `username`, `password`, `name`, `check_fs` and `token` keywords from `bind_server_async()` method in `WebSettingsApi` class. Use `kwargs.get(arg, default)` instead.
-- Removed `check_fs` and `token` keywords from `bind_server` method of `WebSettingsApi` class. Use `kwargs.get(arg, default)` instead.
-- Removed `local_folder`, `server_url` and `engine_name` keywords from `web_authentication` method in `WebSettingsApi` class. Use `args` instead.
-- Removed `config`, `server`, `authenticated`, `username`, `password` and `pac_url` keywords from `set_proxy_settings_async()` method in `WebSettingsApi` class. Use `args` instead.
-- Removed `get_local_folder()` method from `Engine` class. Use `local_folder` attribute instead.
-- Removed `get_uid()` method from `Engine` class. Use `uid` attribute instead.
-- Removed `get_server_url()` method from `Engine` class. Use `server_url` property instead.
-- Removed `get_remote_user()` method from `Engine` class. Use `remote_user` property instead.
-- Removed `get_action()` method from `Worker` class. Use `action` property instead.
-- Removed `paintEvent()` method from `Overlay` class
-- Removed `get_appname()` method from `Manager` class. Use `app_name` attribute instead.
-- Removed `get_notification_service()` method from `Manager` class. Use `notification_service` property instead.
-- Removed `get_direct_edit()` method from `Manager` class. Use `direct_edit` attribute instead.
-- Removed `get_osi()` method from `Manager` class. Use `osi` attribute instead.
-- Removed `is_debug()` method from `Manager` class. Use `debug` attribute instead.
-- Removed `_create_notification_service()` method from `Manager` class
-- Removed `get_flags()` method from `Notification` class. Use `flags` attribute instead.
-- Removed `get_engine_uid()` method from `Notification` class. Use `engine_uid` attribute instead.
-- Removed `get_action()` method from `Notification` class. Use `action` attribute instead.
-- Removed `get_uid()` method from `Notification` class. Use `uid` attribute instead.
-- Removed `get_level()` method from `Notification` class. Use `level` attribute instead.
-- Removed `get_title()` method from `Notification` class. Use `title` attribute instead.
-- Removed `get_description()` method from `Notification` class. Use `description` attribute instead.
-- Removed `get_zoom_factor()` method from `AbstractOSIntegration` class. Use `zoom_factor` attribute instead. It is a property on Windows.
-- Removed `set_engine_uid()` method from `DriveScript` class. Use `engine_uid` attribute instead.
-- Removed `_get_skin()` method from `SimpleApplication` class. Use `skin` attribute instead.
-- Removed `get_default_tooltip()` method from `Application` class. Use `default_tooltip` attribute instead.
-- Removed `get_icon_state()` method from `Application` class. Use `icon_state` attribute instead.
-- Removed `show_message()` method from `Application` class
-- Removed `get_systray_menu()` method from `Application` class
-- Removed `get_dialog()` method from `WebDriveApi` class. Use `dialog` attribute instead.
-- Removed `set_dialog()` method from `WebDriveApi` class. Use `dialog` attribute instead.
-- Removed `set_last_url()` method from `WebDriveApi` class. Use `last_url` attribute instead.
-- Removed `set_token()` method from `WebDialog` class. Use `token` attribute instead.
-- Removed `get_frame()` method from `WebDialog` class. Use `frame` attribute instead.
-- Removed `get_view()` method from `WebDialog` class. Use `view` attribute instead.
-- Removed `show()` method from `WebDialog` class
-- Removed `__del__()` method from `WebDialog` class
-- Removed `set_last_error()` method from `WebMetadataApi` class. Use `error` attribute instead.
-- Removed `getLoadingOverlay()` method from `FolderTreeview` class
-- Removed `loadFinished()` method from `FolderTreeview` class
-- Removed `get_dirty_items()` method from `FolderTreeview` class. Use `dirty_items` attribute instead.
-- Removed `getLoadingOverlay()` method from `StatusTreeview` class
-- Removed `loadFinished()` method from `StatusTreeview` class
-- Removed `showMessage()` method from `DriveSystrayIcon` class
-- Removed `_show_popup()` method from `DriveSystrayIcon` class
-- Removed `open_about()` method from `WebSystrayApi` class
-- Removed `_create_advanced_menu()` method from `WebSystrayApi` class
-- Removed `show()` method from `WebSystrayView` class
-- Removed `underMouse()` method from `WebSystrayView` class
-- Removed `shouldHide()` method from `WebSystrayView` class
-- Removed `focusOutEvent()` method from `WebSystrayView` class
-- Removed `resizeEvent()` method from `WebSystrayView` class
-- Removed `close()` method from `WebSystrayView` class
-- Removed `dialogDeleted()` method from `WebSystray` class
-- Changed `update_token` method to `static` in `WebSettingsApi` class
-- Changed `is_office_temp_file()` function to `is_generated_tmp_file()` in utils.py. It now returns `tuple(bool, bool)`.
-- Changed `get_mac_app()` method to `static` in `Application` class
-- Changed `_message_clicked()` method to `message_clicked()` in `Application` class
-- Changed `_sslErrorHandler()` method to static `_ssl_error_handler()` in `WebDialog` class
-- Changed `_set_proxy()` method to `static` in `WebDialog` class
-- Changed `_attachJsApi()` method to `attachJsApi()` in `WebDialog` class
-- Changed `replace()` method to `resize_and_move()` in `WebSystrayView` class
-- Changed `loadChildren()` method to `load_children()` in `FolderTreeview` class
-- Changed `resolveItemUpChanged()` method to `resolve_item_up_changed()` in `FolderTreeview` class
-- Changed `updateItemChanged()` method to `update_item_changed()` in `FolderTreeview` class
-- Changed `resolveItemDownChanged()` method to `resolve_item_down_changed()` in `FolderTreeview` class
-- Changed `setClient()` method to `set_client()` in `FolderTreeview` class
-- Changed `sortChildren()` method to `sort_children()` in `FolderTreeview` class
-- Changed `loadChildrenThread()` method to `load_children_thread()` in `FolderTreeview` class
-- Changed `loadChildren()` method to `load_children()` in `StatusTreeview` class
+- Removed `AbstractOSIntegration.get_zoom_factor()`. Use `zoom_factor` attribute instead. It is a property on Windows.
+- Changed `Application.get_mac_app()` to static
+- Changed `Application._message_clicked()` to `message_clicked()`
+- Removed `Application.get_default_tooltip()` . Use `default_tooltip` attribute instead.
+- Removed `Application.get_icon_state()`. Use `icon_state` attribute instead.
+- Removed `Application.get_systray_menu()`
+- Removed `Application.show_message()`
+- Removed `DriveScript.set_engine_uid()`. Use `engine_uid` attribute instead.
+- Removed `DriveSystrayIcon._show_popup()`
+- Removed `DriveSystrayIcon.showMessage()`
+- Removed `Engine.get_local_folder()`. Use `local_folder` attribute instead.
+- Removed `Engine.get_remote_user()`. Use `remote_user` property instead.
+- Removed `Engine.get_server_url()`. Use `server_url` property instead.
+- Removed `Engine.get_uid()`. Use `uid` attribute instead.
+- Changed `FolderTreeview.loadChildren()` to `load_children()`
+- Changed `FolderTreeview.loadChildrenThread()` to `load_children_thread()`
+- Changed `FolderTreeview.resolveItemDownChanged()` to `resolve_item_down_changed()`
+- Changed `FolderTreeview.resolveItemUpChanged()` to `resolve_item_up_changed()`
+- Changed `FolderTreeview.setClient()` method to `set_client()`
+- Changed `FolderTreeview.sortChildren()` to `sort_children()`
+- Changed `FolderTreeview.updateItemChanged()` to `update_item_changed()`
+- Removed `FolderTreeview.get_dirty_items()`. Use `dirty_items` attribute instead.
+- Removed `FolderTreeview.getLoadingOverlay()`
+- Removed `FolderTreeview.loadFinished()`
+- Removed `Manager._create_notification_service()`
+- Removed `Manager.get_appname()`. Use `app_name` attribute instead.
+- Removed `Manager.get_direct_edit()`. Use `direct_edit` attribute instead.
+- Removed `Manager.get_notification_service()`. Use `notification_service` property instead.
+- Removed `Manager.get_osi()`. Use `osi` attribute instead.
+- Removed `Manager.is_debug()`. Use `debug` attribute instead.
+- Removed `Notification.get_action()`. Use `action` attribute instead.
+- Removed `Notification.get_engine_uid()`. Use `engine_uid` attribute instead.
+- Removed `Notification.get_description()`. Use `description` attribute instead.
+- Removed `Notification.get_flags()`. Use `flags` attribute instead.
+- Removed `Notification.get_level()`. Use `level` attribute instead.
+- Removed `Notification.get_title()`. Use `title` attribute instead.
+- Removed `Notification.get_uid()`. Use `uid` attribute instead.
+- Removed `Overlay.paintEvent()`
+- Removed `SimpleApplication._get_skin()`. Use `skin` attribute instead.
+- Changed `StatusTreeview.loadChildren()` to `load_children()`
+- Removed `StatusTreeview.getLoadingOverlay()`
+- Removed `StatusTreeview.loadFinished()`
+- Changed `WebDialog._attachJsApi()` to `attachJsApi()`
+- Changed `WebDialog._set_proxy()` to static
+- Changed `WebDialog._sslErrorHandler()` to static `_ssl_error_handler()`
+- Removed `WebDialog.__del__()`
+- Removed `WebDialog.get_frame()`. Use `frame` attribute instead.
+- Removed `WebDialog.get_view()`. Use `view` attribute instead.
+- Removed `WebDialog.set_token()`. Use `token` attribute instead.
+- Removed `WebDialog.show()`
+- Removed `WebDriveApi.get_dialog()`. Use `dialog` attribute instead.
+- Removed `WebDriveApi.set_dialog()`. Use `dialog` attribute instead.
+- Removed `WebDriveApi.set_last_url()`. Use `last_url` attribute instead.
+- Removed `WebMetadataApi.set_last_error()`. Use `error` attribute instead.
+- Changed `WebSettingsApi.update_token` method to static
+- Removed `start_engine`, `check_fs` and `token` keywords from `WebSettingsApi._bind_server()`. Use `kwargs.get(arg, default)` instead.
+- Removed `check_fs` and `token` keywords from `WebSettingsApi.bind_server()`. Use `kwargs.get(arg, default)` instead.
+- Removed `local_folder`, `url`, `username`, `password`, `name`, `check_fs` and `token` keywords from `WebSettingsApi.bind_server_async()`. Use `kwargs.get(arg, default)` instead.
+- Removed `config`, `server`, `authenticated`, `username`, `password` and `pac_url` keywords from `WebSettingsApi.set_proxy_settings_async()`. Use `args` instead.
+- Removed `local_folder`, `server_url` and `engine_name` keywords from `WebSettingsApi.web_authentication()`. Use `args` instead.
+- Removed `WebSystray.close()`
+- Removed `WebSystray.dialogDeleted()`
+- Removed `WebSystray.focusOutEvent()`
+- Removed `WebSystray.resizeEvent()`
+- Removed `WebSystray.shouldHide()`
+- Removed `WebSystray.show()`
+- Removed `WebSystray.underMouse()`
+- Removed `WebSystrayApi._create_advanced_menu()`
+- Removed `WebSystrayApi.open_about()`
+- Changed `WebSystrayView.replace()` to `resize_and_move()`
+- Removed `Worker.get_action()`. Use `action` property instead.
+- Changed utils.py::`is_office_temp_file()` to `is_generated_tmp_file()`. It now returns `tuple(bool, bool)`.
 
 # 2.4.8
-- Removed `size`, `digest_func`, `check_suspended` and `remote_ref` keywords from `FileInfo` class. Use `kwargs.get(arg, default)` instead.
-- Removed `digest_func`, `ignored_prefixe`, `ignored_suffixes`, `check_suspended`, `case_sensitive` and `disable_duplication` keywords from `LocalClient` class. Use `kwargs.get(arg, default)` instead.
+- Removed `size`, `digest_func`, `check_suspended` and `remote_ref` keywords from `FileInfo.__init__()`. Use `kwargs.get(arg, default)` instead.
+- Removed `digest_func`, `ignored_prefixe`, `ignored_suffixes`, `check_suspended`, `case_sensitive` and `disable_duplication` keywords from `LocalClient.__init__()`. Use `kwargs.get(arg, default)` instead.
 
 # 2.4.7
-- Changed `get_zoom_factor()` method to `static` in `AbstractOSIntegration` class
-- Changed `is_partition_supported()` method to `static` in `AbstractOSIntegration` class
-- Changed `is_same_partition()` method to `static` in `AbstractOSIntegration` class
-- Changed `_find_item_in_list()` method to `static` in `DarwinIntegration` class
-- Changed `_get_favorite_list()` method to `static` in `DarwinIntegration` class
-- Changed `_get_desktop_folder()` method to `static` in `WindowsIntegration` class
+- Changed `AbstractOSIntegration.get_zoom_factor()` to static
+- Changed `AbstractOSIntegration.is_partition_supported()` to static
+- Changed `AbstractOSIntegration.is_same_partition()` to static
+- Changed `DarwinIntegration._find_item_in_list()` to static
+- Changed `DarwinIntegration._get_favorite_list()` to static
+- Changed `WindowsIntegration._get_desktop_folder()` to static
 
 # 2.4.6
-- Removed `mark_unknown` keyword from `_do_scan_remote()` method in `RemoteWatcher` class
-- Removed `get_user_agent()` method from `Tracker` class. Use `user_agent` property instead.
+- Removed `mark_unknown` keyword from `RemoteWatcher._do_scan_remote()`
+- Removed `Tracker.get_user_agent()`. Use `user_agent` property instead.

--- a/nuxeo-drive-client/nxdrive/client/local_client.py
+++ b/nuxeo-drive-client/nxdrive/client/local_client.py
@@ -473,7 +473,8 @@ FolderType=Generic
         return digest == remote_digest
 
     def get_content(self, ref):
-        return open(self.abspath(ref), 'rb').read()
+        with open(self.abspath(ref), 'rb') as f:
+            return f.read()
 
     def is_ignored(self, parent_ref, file_name):
         # Add parent_ref to be able to filter on size if needed

--- a/nuxeo-drive-client/nxdrive/client/local_client.py
+++ b/nuxeo-drive-client/nxdrive/client/local_client.py
@@ -395,7 +395,7 @@ FolderType=Generic
     def get_remote_id(self, ref, name='ndrive'):
         # Can be move to another class
         path = self.abspath(ref)
-        return LocalClient.get_path_remote_id(path, name)
+        return self.get_path_remote_id(path, name)
 
     @staticmethod
     def get_path_remote_id(path, name='ndrive'):
@@ -706,7 +706,7 @@ FolderType=Generic
                 with warnings.catch_warnings(UserWarning):
                     temp_path = os.tempnam(
                         self.abspath(parent),
-                        LocalClient.CASE_RENAME_PREFIX + old_name + '_')
+                        self.CASE_RENAME_PREFIX + old_name + '_')
                 if AbstractOSIntegration.is_windows():
                     ctypes.windll.kernel32.SetFileAttributesW(
                         unicode(temp_path), 2)

--- a/nuxeo-drive-client/nxdrive/client/local_client.py
+++ b/nuxeo-drive-client/nxdrive/client/local_client.py
@@ -475,23 +475,6 @@ FolderType=Generic
     def get_content(self, ref):
         return open(self.abspath(ref), 'rb').read()
 
-    def is_osxbundle(self, ref):
-        '''
-        This is not reliable yet
-        '''
-        if not AbstractOSIntegration.is_mac():
-            return False
-        if os.path.isfile(self.abspath(ref)):
-            return False
-        # Don't want to synchornize app - when copy paste this file
-        # might not has been created yet
-        if os.path.isfile(os.path.join(ref, "Contents", "Info.plist")):
-            return True
-        attrs = self.get_remote_id(ref, "com.apple.FinderInfo")
-        if attrs is None:
-            return False
-        return bool(ord(attrs[8]) & 0x20)
-
     def is_ignored(self, parent_ref, file_name):
         # Add parent_ref to be able to filter on size if needed
 

--- a/nuxeo-drive-client/nxdrive/client/local_client.py
+++ b/nuxeo-drive-client/nxdrive/client/local_client.py
@@ -229,7 +229,7 @@ class LocalClient(BaseClient):
 
     def remove_remote_id(self, ref, name='ndrive'):
         path = self.abspath(ref)
-        log.trace('Removing xattr %s from %s', name, path)
+        log.trace('Removing xattr %r from %r', name, path)
         locker = self.unlock_path(path, False)
         func = (self._remove_remote_id_windows
                 if AbstractOSIntegration.is_windows()
@@ -350,8 +350,8 @@ FolderType=Generic
             info = self._read_data(icon)
             xattr.setxattr(meta_file, xattr.XATTR_RESOURCEFORK_NAME, info)
             os.chflags(meta_file, stat.UF_HIDDEN)
-        except Exception as e:
-            log.error("Exception when setting folder icon : %s", e)
+        except:
+            log.exception('Impossible to set the folder icon')
 
     def set_remote_id(self, ref, remote_id, name='ndrive'):
         if not isinstance(remote_id, bytes):
@@ -415,7 +415,6 @@ FolderType=Generic
         except:
             return None
 
-    # Getters
     def get_info(self, ref, raise_if_missing=True):
         if isinstance(ref, bytes):
             ref = unicode(ref)
@@ -663,7 +662,7 @@ FolderType=Generic
         # Remove the \\?\ prefix, specific to Windows
         os_path = os_path.lstrip('\\\\?\\')
 
-        log.trace('Sending to trash ' + os_path)
+        log.trace('Trashing %r', os_path)
 
         # Send2Trash needs bytes
         if not isinstance(os_path, bytes):
@@ -672,7 +671,7 @@ FolderType=Generic
         try:
             send2trash(os_path)
         except OSError:
-            log.debug('Cannot use trash, deleting ' + os_path)
+            log.debug('Cannot use trash, deleting %r', os_path)
             self.delete_final(ref)
         finally:
             # Don't want to unlock the current deleted
@@ -821,6 +820,6 @@ FolderType=Generic
                 name = u"%s__%d" % (short_name, int(increment) + 1)
             else:
                 name = name + u'__1'
-            log.trace("De-duplicate %s to %s", os_path, name)
+            log.trace('De-duplicate %r to %r', os_path, name)
         raise DuplicationError(
-            'Failed to de-duplicate "%s" under "%s"' % (orig_name, parent))
+            'Failed to de-duplicate %r under %r' % (orig_name, parent))

--- a/nuxeo-drive-client/nxdrive/direct_edit.py
+++ b/nuxeo-drive-client/nxdrive/direct_edit.py
@@ -13,12 +13,12 @@ from nxdrive.client.common import BaseClient, NotFound
 from nxdrive.client.local_client import LocalClient
 from nxdrive.engine.activity import Action
 from nxdrive.engine.blacklist_queue import BlacklistQueue
-from nxdrive.engine.watcher.local_watcher import DriveFSEventHandler, \
-    normalize_event_filename
+from nxdrive.engine.watcher.local_watcher import DriveFSEventHandler
 from nxdrive.engine.workers import ThreadInterrupt, Worker
 from nxdrive.logging_config import get_logger
 from nxdrive.osi import parse_protocol_url
-from nxdrive.utils import current_milli_time, guess_digest_algorithm
+from nxdrive.utils import current_milli_time, guess_digest_algorithm, \
+    normalize_event_filename
 from nxdrive.wui.application import SimpleApplication
 from nxdrive.wui.modal import WebModal
 

--- a/nuxeo-drive-client/nxdrive/engine/dao/sqlite.py
+++ b/nuxeo-drive-client/nxdrive/engine/dao/sqlite.py
@@ -136,7 +136,7 @@ class ConfigurationDAO(QObject):
 
     def __init__(self, db):
         super(ConfigurationDAO, self).__init__()
-        log.debug("Create DAO on %s", db)
+        log.debug('Create DAO on %r', db)
         self._db = db
         migrate = os.path.exists(self._db)
         # For testing purpose only should always be True
@@ -220,8 +220,8 @@ class ConfigurationDAO(QObject):
         cursor.execute("CREATE TABLE if not exists Configuration(name VARCHAR NOT NULL, value VARCHAR, PRIMARY KEY (name))")
 
     def _create_main_conn(self):
-        log.debug("Create main connexion on %s (dir exists: %d / file exists: %d)",
-                    self._db, os.path.exists(os.path.dirname(self._db)), os.path.exists(self._db))
+        log.debug('Create main connexion on %r (dir_exists=%r, file_exists=%r)',
+                  self._db, os.path.exists(os.path.dirname(self._db)), os.path.exists(self._db))
         self._conn = AutoRetryConnection(self._db, check_same_thread=False)
         self._connections.append(self._conn)
 
@@ -229,7 +229,7 @@ class ConfigurationDAO(QObject):
         log.trace(query)
 
     def dispose(self):
-        log.debug("Disposing sqlite database %r", self.get_db())
+        log.debug('Disposing SQLite database %r', self.get_db())
         for con in self._connections:
             con.close()
         self._connections = []
@@ -633,9 +633,9 @@ class EngineDAO(ConfigurationDAO):
             c = con.cursor()
             self._reinit_states(c)
             con.commit()
-            log.trace("Vacuum sqlite")
-            con.execute("VACUUM")
-            log.trace("Vacuum sqlite finished")
+            log.trace('Vacuum SQLite')
+            con.execute('VACUUM')
+            log.trace('Vacuum SQLite finished')
         finally:
             self._lock.release()
 
@@ -648,9 +648,9 @@ class EngineDAO(ConfigurationDAO):
             c.execute("UPDATE States SET error_count=0, last_sync_error_date=NULL, last_error = NULL WHERE pair_state='synchronized'")
             if self.auto_commit:
                 con.commit()
-            log.trace("Vacuum sqlite")
-            con.execute("VACUUM")
-            log.trace("Vacuum sqlite finished")
+            log.trace('Vacuum SQLite')
+            con.execute('VACUUM')
+            log.trace('Vacuum SQLite finished')
         finally:
             self._lock.release()
 
@@ -1248,8 +1248,8 @@ class EngineDAO(ConfigurationDAO):
     def synchronize_state(self, row, version=None, dynamic_states=False):
         if version is None:
             version = row.version
-        log.trace('Try to synchronize state for [local_path=%s, '
-                  'remote_name=%s, version=%s] with version=%s '
+        log.trace('Try to synchronize state for [local_path=%r, '
+                  'remote_name=%r, version=%s] with version=%s '
                   'and dynamic_states=%r',
                   row.local_path, row.remote_name, row.version, version,
                   dynamic_states)

--- a/nuxeo-drive-client/nxdrive/engine/next/simple_watcher.py
+++ b/nuxeo-drive-client/nxdrive/engine/next/simple_watcher.py
@@ -8,11 +8,11 @@ from watchdog.events import DirModifiedEvent
 
 from nxdrive.client.local_client import FileInfo
 from nxdrive.engine.activity import Action
-from nxdrive.engine.watcher.local_watcher import LocalWatcher, \
-    normalize_event_filename
+from nxdrive.engine.watcher.local_watcher import LocalWatcher
+
 from nxdrive.engine.workers import ThreadInterrupt
 from nxdrive.logging_config import get_logger
-from nxdrive.utils import current_milli_time
+from nxdrive.utils import current_milli_time, normalize_event_filename
 
 log = get_logger(__name__)
 

--- a/nuxeo-drive-client/nxdrive/engine/processor.py
+++ b/nuxeo-drive-client/nxdrive/engine/processor.py
@@ -875,12 +875,16 @@ class Processor(EngineWorker):
                         self._dao.update_remote_parent_path(doc_pair,
                                                             new_parent_path)
                     else:
-                        log.debug('Renaming local %s %r to %r',
-                                  file_or_folder,
-                                  local_client.abspath(doc_pair.local_path),
-                                  doc_pair.remote_name)
-                        updated_info = local_client.rename(
-                            doc_pair.local_path, doc_pair.remote_name)
+                        if not (AbstractOSIntegration.is_windows()
+                                and doc_pair.remote_name.endswith(' ')):
+                            # Prevent renaming from 'folder' to 'folder '
+                            log.debug(
+                                'Renaming local %s %r to %r',
+                                file_or_folder,
+                                local_client.abspath(doc_pair.local_path),
+                                doc_pair.remote_name)
+                            updated_info = local_client.rename(
+                                doc_pair.local_path, doc_pair.remote_name)
 
                     if updated_info:
                         # Should call a DAO method

--- a/nuxeo-drive-client/nxdrive/engine/processor.py
+++ b/nuxeo-drive-client/nxdrive/engine/processor.py
@@ -875,16 +875,13 @@ class Processor(EngineWorker):
                         self._dao.update_remote_parent_path(doc_pair,
                                                             new_parent_path)
                     else:
-                        if not (AbstractOSIntegration.is_windows()
-                                and doc_pair.remote_name.endswith(' ')):
-                            # Prevent renaming from 'folder' to 'folder '
-                            log.debug(
-                                'Renaming local %s %r to %r',
-                                file_or_folder,
-                                local_client.abspath(doc_pair.local_path),
-                                doc_pair.remote_name)
-                            updated_info = local_client.rename(
-                                doc_pair.local_path, doc_pair.remote_name)
+                        log.debug(
+                            'Renaming local %s %r to %r',
+                            file_or_folder,
+                            local_client.abspath(doc_pair.local_path),
+                            doc_pair.remote_name)
+                        updated_info = local_client.rename(
+                            doc_pair.local_path, doc_pair.remote_name)
 
                     if updated_info:
                         # Should call a DAO method

--- a/nuxeo-drive-client/nxdrive/engine/processor.py
+++ b/nuxeo-drive-client/nxdrive/engine/processor.py
@@ -36,7 +36,7 @@ class Processor(EngineWorker):
         self._engine = engine
 
     def _unlock_soft_path(self, path):
-        log.trace("Soft unlocking: %s", path)
+        log.trace('Soft unlocking %r', path)
         path = path.lower()
         Processor.path_locker.acquire()
         if self._engine.uid not in Processor.soft_locks:
@@ -54,11 +54,11 @@ class Processor(EngineWorker):
             Processor.readonly_locks[self._engine.uid] = dict()
         try:
             if path in Processor.readonly_locks[self._engine.uid]:
-                log.trace("readonly unlock: increase count on %s", path)
+                log.trace('Readonly unlock: increase count on %r', path)
                 Processor.readonly_locks[self._engine.uid][path][0] = Processor.readonly_locks[self._engine.uid][path][0] + 1
             else:
                 lock = local_client.unlock_ref(path)
-                log.trace("readonly unlock: unlock on %s with %d", path, lock)
+                log.trace('Readonly unlock: unlock on %r with %d', path, lock)
                 Processor.readonly_locks[self._engine.uid][path] = [1, lock]
         finally:
             Processor.readonly_locker.release()
@@ -69,19 +69,19 @@ class Processor(EngineWorker):
             Processor.readonly_locks[self._engine.uid] = dict()
         try:
             if path not in Processor.readonly_locks[self._engine.uid]:
-                log.debug("readonly lock: can't find reference on %s", path)
+                log.debug('Readonly lock: cannot find reference on %r', path)
                 return
             Processor.readonly_locks[self._engine.uid][path][0] = Processor.readonly_locks[self._engine.uid][path][0] - 1
-            log.trace("readonly lock: update lock count on %s to %d", path, Processor.readonly_locks[self._engine.uid][path][0])
+            log.trace('Readonly lock: update lock count on %r to %d', path, Processor.readonly_locks[self._engine.uid][path][0])
             if Processor.readonly_locks[self._engine.uid][path][0] <= 0:
                 local_client.lock_ref(path, Processor.readonly_locks[self._engine.uid][path][1])
-                log.trace("readonly lock: relocked path: %s with %d", path, Processor.readonly_locks[self._engine.uid][path][1])
+                log.trace('Readonly lock: relocked %r with %d', path, Processor.readonly_locks[self._engine.uid][path][1])
                 del Processor.readonly_locks[self._engine.uid][path]
         finally:
             Processor.readonly_locker.release()
 
     def _lock_soft_path(self, path):
-        log.trace("Soft locking: %s", path)
+        log.trace('Soft locking %r', path)
         path = path.lower()
         Processor.path_locker.acquire()
         if self._engine.uid not in Processor.soft_locks:
@@ -106,12 +106,12 @@ class Processor(EngineWorker):
                 lock = Lock()
         finally:
             Processor.path_locker.release()
-        log.trace("Locking '%s'", path)
+        log.trace('Locking %r', path)
         lock.acquire()
         Processor.path_locks[self._engine.uid][path] = lock
 
     def _unlock_path(self, path):
-        log.trace("Unlocking '%s'", path)
+        log.trace('Unlocking %r', path)
         Processor.path_locker.acquire()
         if self._engine.uid not in Processor.path_locks:
             Processor.path_locks[self._engine.uid] = dict()
@@ -393,7 +393,7 @@ class Processor(EngineWorker):
                 if doc_pair.local_digest == UNACCESSIBLE_HASH:
                     self._postpone_pair(doc_pair, 'Unaccessible hash')
                     return
-                log.debug("Updating remote document '%s'.",
+                log.debug('Updating remote document %r',
                           doc_pair.local_name)
                 fs_item_info = remote_client.stream_update(
                     doc_pair.remote_ref,
@@ -455,11 +455,11 @@ class Processor(EngineWorker):
             if ignore:
                 # Might be a tierce software temporary file
                 if not delay:
-                    log.debug('Ignoring generated tmp file: %s', name)
+                    log.debug('Ignoring generated tmp file: %r', name)
                     return
                 if doc_pair.error_count == 0:
                     # Save the error_count to not ignore next time
-                    log.debug('Delaying generated tmp file like: %s', name)
+                    log.debug('Delaying generated tmp file like: %r', name)
                     self.increase_error(doc_pair, 'Can be a temporary file')
                     return
 
@@ -486,7 +486,7 @@ class Processor(EngineWorker):
                 self._handle_unsynchronized(local_client, doc_pair)
                 return
             raise ValueError(
-                "Parent folder of %s, %s is not bound to a remote folder"
+                'Parent folder of %r, %r is not bound to a remote folder'
                 % (doc_pair.local_path, doc_pair.local_parent_path))
 
         if remote_ref is not None and '#' in remote_ref:
@@ -567,7 +567,7 @@ class Processor(EngineWorker):
             remote_parent_path = (parent_pair.remote_parent_path + '/'
                                   + parent_pair.remote_ref)
             if doc_pair.folderish:
-                log.debug("Creating remote folder '%s' in folder '%s'",
+                log.debug('Creating remote folder %r in folder %r',
                           name, parent_pair.remote_name)
                 fs_item_info = remote_client.make_folder(parent_ref, name,
                                                          overwrite=overwrite)
@@ -575,7 +575,7 @@ class Processor(EngineWorker):
             else:
                 # TODO Check if the file is already on the server with the
                 # TODO good digest
-                log.debug("Creating remote document '%s' in folder '%s'",
+                log.debug('Creating remote document %r in folder %r',
                           name, parent_pair.remote_name)
                 info = local_client.get_info(doc_pair.local_path)
                 if info.size != doc_pair.size:
@@ -653,17 +653,17 @@ class Processor(EngineWorker):
             return
 
         if doc_pair.remote_can_delete:
-            log.debug("Deleting or unregistering remote document '%s' (%s)", doc_pair.remote_name,
+            log.debug('Deleting or unregistering remote document %r (%s)', doc_pair.remote_name,
                       doc_pair.remote_ref)
             if doc_pair.remote_state != 'deleted':
                 remote_client.delete(doc_pair.remote_ref, parent_fs_item_id=doc_pair.remote_parent_ref)
             self._dao.remove_state(doc_pair)
         else:
-            log.debug("%s can not be remotely deleted:  either it is readonly or it is a virtual folder that "
-                      "doesn't exist in the server hierarchy", doc_pair.local_path)
+            log.debug('%r can not be remotely deleted: either it is readonly or it is a virtual folder that '
+                      'does not exist in the server hierarchy', doc_pair.local_path)
             if doc_pair.remote_state != 'deleted':
-                log.debug("Marking %s as filter since remote document '%s' (%s) can not be deleted:", doc_pair,
-                          doc_pair.remote_name, doc_pair.remote_ref)
+                log.debug('Marking %r as filter since remote document %r (%s) can not be deleted',
+                          doc_pair, doc_pair.remote_name, doc_pair.remote_ref)
                 self._dao.remove_state(doc_pair)
                 self._dao.add_filter(doc_pair.remote_parent_path + '/' + doc_pair.remote_ref)
                 self._engine.deleteReadonly.emit(doc_pair.local_name)
@@ -780,10 +780,10 @@ class Processor(EngineWorker):
         os_path = local_client.abspath(doc_pair.local_path)
         if is_renaming:
             new_os_path = os.path.join(os.path.dirname(os_path), safe_filename(doc_pair.remote_name))
-            log.debug("Replacing local file '%s' by '%s'.", os_path, new_os_path)
+            log.debug('Replacing local file %r by %r', os_path, new_os_path)
         else:
             new_os_path = os_path
-        log.debug("Updating content of local file '%s'.", os_path)
+        log.debug('Updating content of local file %r', os_path)
         self.tmp_file = self._download_content(local_client, remote_client, doc_pair, new_os_path)
         # Delete original file and rename tmp file
         remote_id = local_client.get_remote_id(doc_pair.local_path)
@@ -799,7 +799,7 @@ class Processor(EngineWorker):
         if name is None:
             name = doc_pair.local_name
         # Auto resolve duplicate
-        log.debug('Search for dupe pair with %s %s', name, doc_pair.remote_parent_ref)
+        log.debug('Search for dupe pair with %r %s', name, doc_pair.remote_parent_ref)
         dupe_pair = self._dao.get_dedupe_pair(name, doc_pair.remote_parent_ref, doc_pair.id)
         if dupe_pair is not None:
             log.debug('Dupe pair found %r', dupe_pair)
@@ -849,8 +849,8 @@ class Processor(EngineWorker):
                             self._dao.synchronize_state(doc_pair)
 
                         log.debug('DOC_PAIR(%r):'
-                                  ' old_path[exists=%r, id=%r]: %s,'
-                                  ' new_path[exists=%r, id=%r]: %s',
+                                  ' old_path[exists=%r, id=%r]: %r,'
+                                  ' new_path[exists=%r, id=%r]: %r',
                                   doc_pair, local_client.exists(old_path),
                                   local_client.get_remote_id(old_path),
                                   old_path, local_client.exists(new_path),
@@ -983,13 +983,13 @@ class Processor(EngineWorker):
         tmp_file = None
         try:
             if doc_pair.folderish:
-                log.debug("Creating local folder '%s' in '%s'", name,
+                log.debug('Creating local folder %r in %r', name,
                           local_client.abspath(parent_pair.local_path))
                 path = local_client.make_folder(local_parent_path, name)
             else:
                 path, os_path, name = local_client.get_new_file(local_parent_path,
                                                                 name)
-                log.debug("Creating local file '%s' in '%s'", name,
+                log.debug('Creating local file %r in %r', name,
                           local_client.abspath(parent_pair.local_path))
                 tmp_file = self._download_content(local_client, remote_client, doc_pair, os_path)
                 tmp_file_path = local_client.get_path(tmp_file)
@@ -1008,7 +1008,7 @@ class Processor(EngineWorker):
     def _synchronize_remotely_deleted(self, doc_pair, local_client, remote_client):
         try:
             if doc_pair.local_state != 'deleted':
-                log.debug("Deleting locally %s", local_client.abspath(doc_pair.local_path))
+                log.debug('Deleting locally %r', local_client.abspath(doc_pair.local_path))
                 if doc_pair.folderish:
                     self._engine.set_local_folder_lock(doc_pair.local_path)
                 else:
@@ -1050,9 +1050,9 @@ class Processor(EngineWorker):
                   doc_pair)
         self._dao.remove_state(doc_pair)
         if doc_pair.local_path is not None:
-            log.debug("Since the local path is not None: %s, the synchronizer"
-                      " will probably consider this as a local creation at"
-                      " next iteration and create the file or folder remotely",
+            log.debug('Since the local path is not None: %r, the synchronizer'
+                      ' will probably consider this as a local creation at'
+                      ' next iteration and create the file or folder remotely',
                       doc_pair.local_path)
         else:
             log.debug("Since the local path is None the synchronizer will"
@@ -1086,7 +1086,7 @@ class Processor(EngineWorker):
 
     def _handle_failed_remote_rename(self, source_pair, target_pair):
         # An error occurs return false
-        log.error("Renaming from %s to %s canceled",
+        log.error('Renaming %r to %r canceled',
                   target_pair.remote_name, target_pair.local_name)
         if self._engine.local_rollback(force=AbstractOSIntegration.is_windows()):
             try:

--- a/nuxeo-drive-client/nxdrive/engine/watcher/local_watcher.py
+++ b/nuxeo-drive-client/nxdrive/engine/watcher/local_watcher.py
@@ -342,11 +342,11 @@ class LocalWatcher(EngineWorker):
                             log.debug('Skip potential new %s as it is the result of a remote creation: %r',
                                       child_type, child_info.path)
                             continue
-                        log.debug("Found new %s %s", child_type, child_info.path)
+                        log.debug('Found new %s %r', child_type, child_info.path)
                         self._metrics['new_files'] += 1
                         self._dao.insert_local_state(child_info, info.path)
                     else:
-                        log.debug("Found potential moved file %s[%s]", child_info.path, remote_id)
+                        log.debug('Found potential moved file %r[%s]', child_info.path, remote_id)
                         doc_pair = self._dao.get_normal_state_from_remote(remote_id)
                         if doc_pair is not None and self.client.exists(doc_pair.local_path):
                             if (not self.client.is_case_sensitive()
@@ -365,7 +365,7 @@ class LocalWatcher(EngineWorker):
                             doc_creation_time = self.get_creation_time(doc_full_path)
                             log.trace('child_cre_time=%f, doc_cre_time=%f', child_creation_time, doc_creation_time)
                         if doc_pair is None:
-                            log.debug("Can't find reference for %s in database, put it in locally_created state",
+                            log.debug('Cannot find reference for %r in database, put it in locally_created state',
                                       child_info.path)
                             self._metrics['new_files'] += 1
                             self._dao.insert_local_state(child_info, info.path)
@@ -386,7 +386,7 @@ class LocalWatcher(EngineWorker):
                             self._protected_files[doc_pair.remote_ref] = True
                             if self.client.exists(doc_pair.local_path) and child_creation_time < doc_creation_time:
                                 # Need to put back the new created - need to check maybe if already there
-                                log.trace("Found a moved file that has been copy/paste back: %s", doc_pair.local_path)
+                                log.trace('Found a moved file that has been copy/paste back: %r', doc_pair.local_path)
                                 self.client.remove_remote_id(doc_pair.local_path)
                                 self._dao.insert_local_state(self.client.get_info(doc_pair.local_path), os.path.dirname(doc_pair.local_path))
                         else:
@@ -431,7 +431,7 @@ class LocalWatcher(EngineWorker):
                     if (child_pair.processor == 0
                             and child_pair.last_local_updated is not None
                             and last_mtime != child_pair.last_local_updated.split('.')[0]):
-                        log.trace('Update file %s', child_info.path)
+                        log.trace('Update file %r', child_info.path)
                         remote_ref = self.client.get_remote_id(child_pair.local_path)
                         if remote_ref is not None and child_pair.remote_ref is None:
                             log.debug("Possible race condition between remote and local scan, let's refresh pair: %r",
@@ -446,7 +446,7 @@ class LocalWatcher(EngineWorker):
                             # Load correct doc_pair | Put the others one back
                             # to children
                             log.warning(
-                                'Detected file substitution: %s (%s/%s)',
+                                'Detected file substitution: %r (%s/%s)',
                                 child_pair.local_path, remote_ref, child_pair.remote_ref)
                             if remote_ref is None:
                                 if not child_info.folderish:
@@ -508,7 +508,7 @@ class LocalWatcher(EngineWorker):
         for deleted in children.values():
             if deleted.pair_state == "remotely_created" or deleted.remote_state == "created":
                 continue
-            log.debug("Found deleted file %s", deleted.local_path)
+            log.debug('Found deleted file %r', deleted.local_path)
             # May need to count the children to be ok
             self._metrics['delete_files'] += 1
             if deleted.remote_ref is None:
@@ -543,7 +543,7 @@ class LocalWatcher(EngineWorker):
                 ob.winapi.BUFFER_SIZE = self._windows_watchdog_event_buffer
             except ImportError:
                 log.exception('Cannot import read_directory_changes')
-        log.debug('Watching FS modification on : %s', self.client.base_folder)
+        log.debug('Watching FS modification on : %r', self.client.base_folder)
 
         # Filter out all ignored suffixes. It will handle custom ones too.
         ignore_patterns = list(['*' + suffixe
@@ -610,7 +610,7 @@ class LocalWatcher(EngineWorker):
             dest_filename = os.path.basename(evt.dest_path)
             if dest_filename.startswith(LocalClient.CASE_RENAME_PREFIX) or \
                     os.path.basename(rel_path).startswith(LocalClient.CASE_RENAME_PREFIX):
-                log.debug('Ignoring case rename %s to %s',
+                log.debug('Ignoring case rename %r to %r',
                           evt.src_path, evt.dest_path)
                 return
 
@@ -633,7 +633,7 @@ class LocalWatcher(EngineWorker):
                     # if only file permissions have been updated
                     if not doc_pair.folderish and pair.local_digest == digest:
                         log.trace(
-                            'Dropping watchdog event [%s] as digest has not changed for %s',
+                            'Dropping watchdog event [%s] as digest has not changed for %r',
                             evt.event_type, rel_path)
                         # If pair are the same don't drop it.  It can happen
                         # in case of server rename on a document.
@@ -765,7 +765,7 @@ class LocalWatcher(EngineWorker):
                 # Unchanged digest, can be the case if only the last modification time or file permissions
                 # have been updated
                 if doc_pair.local_digest == digest:
-                    log.debug('Digest has not changed for %s (watchdog event [%s]), only update last_local_updated',
+                    log.debug('Digest has not changed for %r (watchdog event [%s]), only update last_local_updated',
                               rel_path, evt.event_type)
                     if local_info.remote_ref is None:
                         self.client.set_remote_id(rel_path, doc_pair.remote_ref)
@@ -809,14 +809,14 @@ class LocalWatcher(EngineWorker):
         self._metrics['last_event'] = current_milli_time()
         self._action = Action("Handle watchdog event")
         if evt.event_type == 'moved':
-            log.debug("Handling watchdog event [%s] on %s to %s", evt.event_type, evt.src_path, evt.dest_path)
+            log.debug('Handling watchdog event [%s] on %r to %r', evt.event_type, evt.src_path, evt.dest_path)
             # Ignore normalization of the filename on the file system
             # See https://jira.nuxeo.com/browse/NXDRIVE-188
             if evt.dest_path == normalize_event_filename(evt.src_path, action=False) or evt.dest_path == evt.src_path.strip():
                 log.debug('Ignoring move from %r to normalized name: %r', evt.src_path, evt.dest_path)
                 return
         else:
-            log.debug("Handling watchdog event [%s] on %r", evt.event_type, evt.src_path)
+            log.debug('Handling watchdog event [%s] on %r', evt.event_type, evt.src_path)
 
         try:
             src_path = normalize_event_filename(evt.src_path)
@@ -840,7 +840,7 @@ class LocalWatcher(EngineWorker):
             doc_pair = self._dao.get_state_from_local(rel_path)
             if doc_pair is not None:
                 if doc_pair.pair_state == 'unsynchronized':
-                    log.debug('Ignoring %s as marked unsynchronized',
+                    log.debug('Ignoring %r as marked unsynchronized',
                               doc_pair.local_path)
                     if evt.event_type in ('deleted', 'moved'):
                         path = (evt.dest_path
@@ -857,7 +857,7 @@ class LocalWatcher(EngineWorker):
                 return
 
             if evt.event_type == 'deleted':
-                log.debug('Unknown pair deleted: %s', rel_path)
+                log.debug('Unknown pair deleted: %r', rel_path)
                 return
 
             if evt.event_type == 'moved':
@@ -894,7 +894,7 @@ class LocalWatcher(EngineWorker):
                 return
             # if the pair is modified and not known consider as created
             if evt.event_type not in ('created', 'modified'):
-                log.debug('Unhandled case: %r %s %s', evt, rel_path, file_name)
+                log.debug('Unhandled case: %r %r %r', evt, rel_path, file_name)
                 return
 
             # If doc_pair is not None mean
@@ -902,7 +902,7 @@ class LocalWatcher(EngineWorker):
             # As Windows send a delete / create event for reparent
             local_info = self.client.get_info(rel_path, raise_if_missing=False)
             if local_info is None:
-                log.trace("Event on a disappeared file: %r %s %s", evt, rel_path, file_name)
+                log.trace("Event on a disappeared file: %r %r %r", evt, rel_path, file_name)
                 return
 
             # This might be a move but Windows don't emit this event...
@@ -950,12 +950,16 @@ class LocalWatcher(EngineWorker):
                         doc_pair_creation_time = self.get_creation_time(doc_pair_full_path)
                         from_pair_full_path = self.client.abspath(from_pair.local_path)
                         from_pair_creation_time = self.get_creation_time(from_pair_full_path)
-                        log.trace('doc_pair_full_path=%s, doc_pair_creation_time=%s, from_pair_full_path=%s, version=%d', doc_pair_full_path, doc_pair_creation_time, from_pair_full_path, from_pair.version)
+                        log.trace('doc_pair_full_path=%r, doc_pair_creation_time=%s, from_pair_full_path=%r, version=%d', doc_pair_full_path, doc_pair_creation_time, from_pair_full_path, from_pair.version)
                         # If file at the original location is newer,
                         #   it is moved to the new location earlier then copied back (what else can it be?)
                         if (not from_pair_creation_time <= doc_pair_creation_time) and evt.event_type == 'created':
-                            log.trace("Found moved file: from_pair: %f doc_pair:%f for %s", from_pair_creation_time, doc_pair_creation_time, doc_pair_full_path)
-                            log.trace("Creation time are: from: %f | new: %f : boolean: %d", from_pair_creation_time, doc_pair_creation_time, from_pair_creation_time >= doc_pair_creation_time)
+                            log.trace(
+                                'Found moved file %r (times: from=%f, to=%f)',
+                                doc_pair_full_path,
+                                from_pair_creation_time,
+                                doc_pair_creation_time,
+                            )
                             from_pair.local_state = 'moved'
                             self._dao.update_local_state(from_pair, self.client.get_info(rel_path))
                             self._dao.insert_local_state(self.client.get_info(from_pair.local_path), os.path.dirname(from_pair.local_path))

--- a/nuxeo-drive-client/nxdrive/engine/watcher/remote_watcher.py
+++ b/nuxeo-drive-client/nxdrive/engine/watcher/remote_watcher.py
@@ -140,7 +140,7 @@ class RemoteWatcher(EngineWorker):
         if doc_pair is not None:
             self._do_scan_remote(doc_pair, child_info)
             return
-        log.debug("parent_path: '%s'\t'%s'\t'%s'", parent_path, os.path.basename(parent_path),
+        log.debug('parent_path: %r\t%r\t%r', parent_path, os.path.basename(parent_path),
                   os.path.dirname(parent_path))
         parent_pair = self._dao.get_state_from_remote_with_path(os.path.basename(parent_path),
                                                                 os.path.dirname(parent_path))
@@ -155,7 +155,7 @@ class RemoteWatcher(EngineWorker):
             if child_info.folderish:
                 self._do_scan_remote(doc_pair, child_info)
         else:
-            log.debug('Remote scan_pair: %s is not available', remote_path)
+            log.debug('Remote scan_pair: %r is not available', remote_path)
             self._scan_remote()
 
     @staticmethod
@@ -170,12 +170,12 @@ class RemoteWatcher(EngineWorker):
 
     def _do_scan_remote(self, doc_pair, remote_info, force_recursion=True, moved=False):
         if remote_info.can_scroll_descendants:
-            log.debug('Performing scroll remote scan for %s (%r)',
+            log.debug('Performing scroll remote scan for %r (%r)',
                       remote_info.name, remote_info)
             self._scan_remote_scroll(doc_pair, remote_info, moved=moved)
         else:
             log.debug('Scroll scan not available, performing recursive '
-                      'remote scan for %s (%r)', remote_info.name, remote_info)
+                      'remote scan for %r (%r)', remote_info.name, remote_info)
             self._scan_remote_recursive(
                 doc_pair, remote_info, force_recursion=force_recursion)
 
@@ -202,21 +202,21 @@ class RemoteWatcher(EngineWorker):
         while 'Scrolling':
             t0 = datetime.now()
             if t1 is not None:
-                log.trace('Local processing of descendants of %s (%s) took %s ms', remote_info.name, remote_info.uid,
+                log.trace('Local processing of descendants of %r (%s) took %s ms', remote_info.name, remote_info.uid,
                           self._get_elapsed_time_milliseconds(t1, t0))
             # Scroll through a batch of descendants
-            log.trace('Scrolling through at most [%d] descendants of %s (%s)', batch_size, remote_info.name,
+            log.trace('Scrolling through at most [%d] descendants of %r (%s)', batch_size, remote_info.name,
                       remote_info.uid)
             scroll_res = self._client.scroll_descendants(remote_info.uid, scroll_id, batch_size=batch_size)
             t1 = datetime.now()
             elapsed = self._get_elapsed_time_milliseconds(t0, t1)
             descendants_info = scroll_res['descendants']
             if not descendants_info:
-                log.trace('Remote scroll request retrieved no descendants of %s (%s), took %s ms', remote_info.name,
+                log.trace('Remote scroll request retrieved no descendants of %r (%s), took %s ms', remote_info.name,
                           remote_info.uid, elapsed)
                 break
 
-            log.trace('Remote scroll request retrieved %d descendants of %s (%s), took %s ms', len(descendants_info),
+            log.trace('Remote scroll request retrieved %d descendants of %r (%s), took %s ms', len(descendants_info),
                       remote_info.name, remote_info.uid, elapsed)
             scroll_id = scroll_res['scroll_id']
 
@@ -250,7 +250,7 @@ class RemoteWatcher(EngineWorker):
         if to_process:
             t0 = datetime.now()
             to_process = sorted(to_process, key=lambda x: x.path)
-            log.trace('Processing [%d] postponed descendants of %s (%s)', len(to_process), remote_info.name,
+            log.trace('Processing [%d] postponed descendants of %r (%s)', len(to_process), remote_info.name,
                       remote_info.uid)
             for descendant_info in to_process:
                 parent_pair = self._dao.get_normal_state_from_remote(descendant_info.parent_uid)
@@ -330,11 +330,11 @@ class RemoteWatcher(EngineWorker):
             return None
         remote_parent_path = doc_pair.remote_parent_path + '/' + remote_info.uid
         if self._dao.is_path_scanned(remote_parent_path):
-            log.trace("Skip already remote scanned: %s", doc_pair.local_path)
+            log.trace('Skip already remote scanned: %r', doc_pair.local_path)
             return None
         if doc_pair.local_path is not None:
-            self._action = Action("Remote scanning : " + doc_pair.local_path)
-            log.debug("Remote scanning: %s", doc_pair.local_path)
+            self._action = Action('Remote scanning %r' % doc_pair.local_path)
+            log.debug('Remote scanning: %r', doc_pair.local_path)
         return remote_parent_path
 
     def _find_remote_child_match_or_create(self, parent_pair, child_info):
@@ -347,9 +347,9 @@ class RemoteWatcher(EngineWorker):
             for child in self._local_client.get_children_info(parent_pair.local_path):
                 if self._local_client.get_remote_id(child.path) == child_info.uid:
                     if '__' in child.name:
-                        log.debug("Found a deduplication case: %r on %s", child_info, child.path)
+                        log.debug('Found a deduplication case: %r on %r', child_info, child.path)
                     else:
-                        log.debug("Found a local rename case: %r on %s", child_info, child.path)
+                        log.debug('Found a local rename case: %r on %r', child_info, child.path)
                     child_pair = self._dao.get_state_from_local(child.path)
                     break
         if child_pair is not None:
@@ -385,7 +385,7 @@ class RemoteWatcher(EngineWorker):
                         if synced:
                             self._engine.stop_processor_on(child_pair.local_path)
                         # Push the remote_Id
-                        log.debug("set remote id on: %r / %s == %s", child_pair, child_pair.local_path, child_pair.local_path)
+                        log.debug('Set remote ID on %r / %r == %r', child_pair, child_pair.local_path, child_pair.local_path)
                         self._local_client.set_remote_id(child_pair.local_path, child_info.uid)
                         if child_pair.folderish:
                             self._dao.queue_children(child_pair)
@@ -411,7 +411,7 @@ class RemoteWatcher(EngineWorker):
             local_client.unset_readonly(doc_pair.local_path)
 
     def _partial_full_scan(self, path):
-        log.debug("Continue full scan of %s", path)
+        log.debug('Continue full scan of %r', path)
         if path == '/':
             self._scan_remote()
         else:
@@ -607,22 +607,22 @@ class RemoteWatcher(EngineWorker):
                                 log.debug("Delete pair from duplicate: %r", doc_pair)
                                 self._dao.remove_state(doc_pair, remote_recursion=True)
                                 continue
-                            log.debug("Push doc_pair '%s' in delete queue", doc_pair_repr)
+                            log.debug('Push doc_pair %r in delete queue', doc_pair_repr)
                             delete_queue.append(doc_pair)
                         else:
-                            log.debug("Ignore delete on doc_pair '%s' as a fsItem is attached", doc_pair_repr)
+                            log.debug('Ignore delete on doc_pair %r as a fsItem is attached', doc_pair_repr)
                             # To ignore completely put updated to true
                             updated = True
                             break
                     elif fs_item is None:
                         if event_id == 'securityUpdated':
-                            log.debug("Security has been updated for"
-                                      " doc_pair '%s' denying Read access,"
-                                      " marking it as deleted",
+                            log.debug('Security has been updated for'
+                                      ' doc_pair %r denying Read access,'
+                                      ' marking it as deleted',
                                       doc_pair_repr)
                             self._dao.delete_remote_state(doc_pair)
                         else:
-                            log.debug("Unknown event: '%s'", event_id)
+                            log.debug('Unknown event: %r', event_id)
                     else:
                         remote_parent_factory = doc_pair.remote_parent_ref.split('#', 1)[0]
                         new_info_parent_factory = new_info.parent_uid.split('#', 1)[0]
@@ -636,7 +636,7 @@ class RemoteWatcher(EngineWorker):
                         elif (event_id == 'documentMoved'
                               and new_info_parent_factory == COLLECTION_SYNC_ROOT_FACTORY_NAME):
                             # If moved from a sync root to a non sync root, delete from local sync root
-                            log.debug("Marking doc_pair '%s' as deleted", doc_pair_repr)
+                            log.debug('Marking doc_pair %r as deleted', doc_pair_repr)
                             self._dao.delete_remote_state(doc_pair)
                         else:
                             # Make new_info consistent with actual doc pair parent path for a doc member of a
@@ -701,11 +701,11 @@ class RemoteWatcher(EngineWorker):
 
                     child_pair, new_pair = self._find_remote_child_match_or_create(parent_pair, new_info)
                     if new_pair:
-                        log.debug("Marked doc_pair '%s' as remote creation",
+                        log.debug('Marked doc_pair %r as remote creation',
                                   child_pair.remote_name)
 
                     if child_pair.folderish and new_pair:
-                        log.debug('Remote recursive scan of the content of %s',
+                        log.debug('Remote recursive scan of the content of %r',
                                   child_pair.remote_name)
                         remote_path = child_pair.remote_parent_path + "/" + new_info.uid
                         self._force_remote_scan(child_pair, new_info, remote_path)

--- a/nuxeo-drive-client/nxdrive/manager.py
+++ b/nuxeo-drive-client/nxdrive/manager.py
@@ -21,8 +21,6 @@ from nxdrive.client.base_automation_client import get_proxies_for_handler
 from nxdrive.client.common import DEFAULT_IGNORED_PREFIXES, \
     DEFAULT_IGNORED_SUFFIXES
 from nxdrive.commandline import DEFAULT_UPDATE_SITE_URL
-from nxdrive.engine.engine import Engine
-from nxdrive.engine.next.engine_next import EngineNext
 from nxdrive.logging_config import FILE_HANDLER, get_logger
 from nxdrive.osi import AbstractOSIntegration
 from nxdrive.updater import AppUpdater, FakeUpdater
@@ -311,6 +309,8 @@ class Manager(QtCore.QObject):
         self.debug = options.debug
         self._engine_definitions = None
 
+        from nxdrive.engine.engine import Engine
+        from nxdrive.engine.next.engine_next import EngineNext
         self._engine_types = {'NXDRIVE': Engine, 'NXDRIVENEXT': EngineNext}
         self._engines = None
         self.proxies = dict()

--- a/nuxeo-drive-client/nxdrive/manager.py
+++ b/nuxeo-drive-client/nxdrive/manager.py
@@ -21,6 +21,8 @@ from nxdrive.client.base_automation_client import get_proxies_for_handler
 from nxdrive.client.common import DEFAULT_IGNORED_PREFIXES, \
     DEFAULT_IGNORED_SUFFIXES
 from nxdrive.commandline import DEFAULT_UPDATE_SITE_URL
+from nxdrive.engine.engine import Engine
+from nxdrive.engine.next.engine_next import EngineNext
 from nxdrive.logging_config import FILE_HANDLER, get_logger
 from nxdrive.osi import AbstractOSIntegration
 from nxdrive.updater import AppUpdater, FakeUpdater
@@ -294,24 +296,10 @@ class Manager(QtCore.QObject):
         Manager._singleton = self
         super(Manager, self).__init__()
 
-        # Let's bypass HTTPS verification unless --consider-ssl-errors is passed
-        # since many servers unfortunately have invalid certificates.
-        # See https://www.python.org/dev/peps/pep-0476/
-        # and https://jira.nuxeo.com/browse/NXDRIVE-506
         if not options.consider_ssl_errors:
             log.warning('--consider-ssl-errors option is False, '
                         'will not verify HTTPS certificates')
-            import ssl
-            try:
-                _create_unverified_https_context = ssl._create_unverified_context
-            except AttributeError:
-                log.info("Legacy Python that doesn't verify HTTPS certificates by default")
-            else:
-                log.info("Handle target environment that doesn't support HTTPS verification:"
-                         " globally disable verification by monkeypatching the ssl module though highly discouraged")
-                ssl._create_default_https_context = _create_unverified_https_context
-        else:
-            log.info("--consider-ssl-errors option is True, will verify HTTPS certificates")
+            self._bypass_https_verification()
 
         self._autolock_service = None
         self.nxdrive_home = os.path.expanduser(options.nxdrive_home)
@@ -323,8 +311,6 @@ class Manager(QtCore.QObject):
         self.debug = options.debug
         self._engine_definitions = None
 
-        from nxdrive.engine.next.engine_next import EngineNext
-        from nxdrive.engine.engine import Engine
         self._engine_types = {'NXDRIVE': Engine, 'NXDRIVENEXT': EngineNext}
         self._engines = None
         self.proxies = dict()
@@ -411,6 +397,25 @@ class Manager(QtCore.QObject):
         self._tracker = None
         if self.get_tracking():
             self._create_tracker()
+
+    @staticmethod
+    def _bypass_https_verification():
+        """
+        Let's bypass HTTPS verification since many servers
+        unfortunately have invalid certificates.
+        See https://www.python.org/dev/peps/pep-0476/ and NXDRIVE-506.
+        """
+
+        import ssl
+        try:
+            _context = ssl._create_unverified_context
+        except AttributeError:
+            log.info('Legacy Python that does not verify HTTPS certificates')
+        else:
+            log.info('Handle target environment that does not support HTTPS '
+                     'verification: globally disable verification by '
+                     'monkeypatching the ssl module though highly discouraged')
+            ssl._create_default_https_context = _context
 
     def _get_file_log_handler(self):
         # Might store it in global static

--- a/nuxeo-drive-client/nxdrive/manager.py
+++ b/nuxeo-drive-client/nxdrive/manager.py
@@ -1235,9 +1235,6 @@ class Manager(QtCore.QObject):
     def is_started(self):
         return self._started
 
-    def is_updated(self):
-        return self.updated
-
     def is_syncing(self):
         syncing_engines = []
         for uid, engine in self._engines.items():

--- a/nuxeo-drive-client/nxdrive/utils.py
+++ b/nuxeo-drive-client/nxdrive/utils.py
@@ -86,7 +86,7 @@ def is_generated_tmp_file(name):
             return ignore, delay
 
         # AutoCAD
-        if re.match(r'^atmp\d+$', name) is not None:
+        if re.match(r'^atmp\d+$', name.lower()) is not None:
             # Ban definitively that pattern as we have no other
             # solution for now.
             return ignore, do_not_delay

--- a/nuxeo-drive-client/nxdrive/utils.py
+++ b/nuxeo-drive-client/nxdrive/utils.py
@@ -6,6 +6,7 @@ import os
 import re
 import sys
 import time
+import unicodedata
 import urlparse
 from distutils.version import StrictVersion
 from urllib2 import HTTPError, URLError, urlopen
@@ -16,6 +17,9 @@ from Crypto.Cipher import AES
 
 from nxdrive.client.common import DEFAULT_IGNORED_SUFFIXES, DRIVE_STARTUP_PAGE
 from nxdrive.logging_config import get_logger
+
+if sys.platform == 'win32':
+    import win32api
 
 NUXEO_DRIVE_FOLDER_NAME = 'Nuxeo Drive'
 log = get_logger(__name__)
@@ -227,6 +231,66 @@ def normalized_path(path):
 
     return os.path.realpath(
         os.path.normpath(os.path.abspath(os.path.expanduser(path))))
+
+
+def normalize_event_filename(filename, action=True):
+    """
+    Normalize a file name.
+
+    :param unicode filename: The file name to normalize.
+    :param bool action: Apply changes on the file system.
+    :return unicode: The normalized file name.
+    """
+
+    # NXDRIVE-688: Ensure the name is stripped for a file
+    stripped = filename.strip()
+    if sys.platform == 'win32':
+        # Windows does not allow files/folders ending with space(s)
+        filename = stripped
+    elif (action
+          and filename != stripped
+          and os.path.exists(filename)
+          and not os.path.isdir(filename)):
+        # We can have folders ending with spaces
+        log.debug('Forcing space normalization: %r -> %r', filename, stripped)
+        os.rename(filename, stripped)
+        filename = stripped
+
+    # NXDRIVE-188: Normalize name on the file system, if needed
+    try:
+        normalized = unicodedata.normalize('NFC', unicode(filename, 'utf-8'))
+    except TypeError:
+        normalized = unicodedata.normalize('NFC', unicode(filename))
+
+    if sys.platform == 'darwin':
+        return normalized
+    elif sys.platform == 'win32' and os.path.exists(filename):
+        """
+        If `filename` exists, and as Windows is case insensitive,
+        the result of Get(Full|Long|Short)PathName() could be unexpected
+        because it will return the path of the existant `filename`.
+
+        Check this simplified code session (the file "ABC.txt" exists):
+
+            >>> win32api.GetLongPathName('abc.txt')
+            'ABC.txt'
+            >>> win32api.GetLongPathName('ABC.TXT')
+            'ABC.txt'
+            >>> win32api.GetLongPathName('ABC.txt')
+            'ABC.txt'
+
+        So, to counter that behavior, we save the actual file name
+        and restore it in the full path.
+        """
+        long_path = win32api.GetLongPathNameW(filename)
+        filename = os.path.join(os.path.dirname(long_path),
+                                os.path.basename(filename))
+
+    if action and filename != normalized and os.path.exists(filename):
+        log.debug('Forcing normalization: %r -> %r', filename, normalized)
+        os.rename(filename, normalized)
+
+    return normalized
 
 
 def safe_long_path(path):

--- a/tools/posix/deploy_jenkins_slave.sh
+++ b/tools/posix/deploy_jenkins_slave.sh
@@ -186,13 +186,15 @@ install_deps() {
 install_pyenv() {
     local url="https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer"
 
-    echo ">>> [pyenv] Setting up"
     export PYENV_ROOT="${STORAGE_DIR}/.pyenv"
     export PATH="${PYENV_ROOT}/bin:$PATH"
 
     if ! hash pyenv 2>/dev/null; then
         echo ">>> [pyenv] Downloading and installing"
         curl -L "${url}" | bash
+    else
+        echo ">>> [pyenv] Updating"
+        cd "${PYENV_ROOT}" && git pull && cd -
     fi
 
     echo ">>> [pyenv] Initializing"


### PR DESCRIPTION
Some cleanup too:
*  Use `%r` instead of `%s` for paths in logs
*  Jenkins: Update pyenv to take into account new Python versions (to fix Python version not found on our slaves)
*  Remove unused `LocalClient.is_osxbundle()`
*  Use `self` instead of creating a new `LocalClient` objects
*  Removed `Manager.is_updated()`
*  Check for `atmp****` pattern in lower case (AutoCAD)
*  Manager: move SSL check into the new `_bypass_https_verification()`
*  Little refactor of `Manager.get_system_pac_url()`
*  Moved `normalize_event_filename()` to utils.py 