### PR TITLE
NXDRIVE-1011: Cleanup queue_manager.py

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,6 +1,10 @@
 # dev
 Release date: `2017-??-??`
 
+#### Minor changes
+- Framework: Clean-up queue_manager.py
+- Framework: Fix LocalClient.get_path() to use str.partition() and prevent IndexErrors
+
 
 # 2.5.5
 Release date: `2017-10-13`

--- a/nuxeo-drive-client/nxdrive/__init__.py
+++ b/nuxeo-drive-client/nxdrive/__init__.py
@@ -25,4 +25,4 @@ To declare a beta, use this schema:
 """
 
 __author__ = 'Nuxeo'
-__version__ = '2.5.5'
+__version__ = '2.5.6'

--- a/nuxeo-drive-client/nxdrive/client/local_client.py
+++ b/nuxeo-drive-client/nxdrive/client/local_client.py
@@ -754,12 +754,12 @@ FolderType=Generic
         return abspath.startswith(self.base_folder)
 
     def get_path(self, abspath):
-        """Relative path to the local client from an absolute OS path"""
-        path = abspath.split(self.base_folder, 1)[1]
-        rel_path = path.replace(os.path.sep, '/')
-        if rel_path == '':
-            rel_path = u'/'
-        return rel_path
+        """ Relative path to the local client from an absolute OS path. """
+
+        _, _, path = abspath.partition(self.base_folder)
+        if not path:
+            return '/'
+        return path.replace(os.path.sep, '/')
 
     def abspath(self, ref):
         """Absolute path on the operating system"""

--- a/nuxeo-drive-client/nxdrive/engine/engine.py
+++ b/nuxeo-drive-client/nxdrive/engine/engine.py
@@ -921,10 +921,11 @@ class Engine(QObject):
         # Verify thread status
         thread_id = current_thread().ident
         for thread in self._threads:
-            if hasattr(thread, "worker") and isinstance(thread.worker, Processor):
-                if (thread.worker.get_thread_id() == thread_id and
-                        not thread.worker.is_started()):
-                    raise ThreadInterrupt
+            if (hasattr(thread, 'worker')
+                    and isinstance(thread.worker, Processor)
+                    and thread.worker.get_thread_id() == thread_id
+                    and not thread.worker.is_started()):
+                raise ThreadInterrupt
         # Get action
         current_file = None
         action = Action.get_current_action()


### PR DESCRIPTION
Mostly a review of `is_processing_file()` to reduce conditions call.

Also
* Fix `LocalClient.get_path()` to use `str.partition()` that prevents `IndexError`s and simplify the code.