### PR TITLE
NXDRIVE-1006: Improve calls to /site/automation

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2,6 +2,7 @@
 Release date: `2017-??-??`
 
 ### Core
+- [NXDRIVE-1006](https://jira.nuxeo.com/browse/NXDRIVE-1006): Improve calls to /site/automation
 - [NXDRIVE-1012](https://jira.nuxeo.com/browse/NXDRIVE-1012): Remote watcher is missing keywords
 - [NXDRIVE-1013](https://jira.nuxeo.com/browse/NXDRIVE-1012): Fix and improve connection test for new account creation
 

--- a/docs/technical_changes.md
+++ b/docs/technical_changes.md
@@ -7,6 +7,9 @@
 - Added `BaseAutomationClient.server_reachable()`
 - Removed `WindowsIntegration.register_desktop_link()`
 - Removed `WindowsIntegration.unregister_desktop_link()`
+- Added `get_device()` to utils.py
+- Removed `DEFAULT_ENCODING` contant from utils.py
+- Removed `WIN32_SUFFIX` contant from utils.py
 
 # 2.5.5
 - Removed `LocalClient.is_osxbundle()`

--- a/docs/technical_changes.md
+++ b/docs/technical_changes.md
@@ -3,6 +3,8 @@
 [//]: # (Note 3: keywords ordered [Added, Changed, Moved, Removed])
 
 # dev
+- Added `BaseAutomationClient.check_access()`
+- Added `BaseAutomationClient.server_reachable()`
 - Removed `WindowsIntegration.register_desktop_link()`
 - Removed `WindowsIntegration.unregister_desktop_link()`
 

--- a/nuxeo-drive-client/nxdrive/client/__init__.py
+++ b/nuxeo-drive-client/nxdrive/client/__init__.py
@@ -11,6 +11,3 @@ from nxdrive.client.remote_file_system_client import RemoteFileInfo, \
 from nxdrive.client.remote_filtered_file_system_client import \
     RemoteFilteredFileSystemClient
 from nxdrive.client.rest_api_client import RestAPIClient
-
-# Backward compatibility with old remote client name, to be removed
-NuxeoClient = RemoteDocumentClient

--- a/nuxeo-drive-client/nxdrive/client/base_automation_client.py
+++ b/nuxeo-drive-client/nxdrive/client/base_automation_client.py
@@ -12,7 +12,7 @@ import tempfile
 import time
 import urllib2
 from urllib import urlencode
-from urllib2 import ProxyHandler
+from urllib2 import ProxyHandler, quote
 from urlparse import urlparse
 
 from poster.streaminghttp import get_handlers
@@ -22,7 +22,7 @@ from nxdrive.client.common import BaseClient, DEFAULT_IGNORED_PREFIXES, \
     safe_filename
 from nxdrive.engine.activity import Action, FileAction
 from nxdrive.logging_config import get_logger
-from nxdrive.utils import DEVICE_DESCRIPTIONS, TOKEN_PERMISSION, force_decode, \
+from nxdrive.utils import TOKEN_PERMISSION, force_decode, get_device, \
     guess_digest_algorithm, guess_mime_type
 
 log = None
@@ -617,14 +617,11 @@ class BaseAutomationClient(BaseClient):
 
         parameters = {
             'deviceId': self.device_id,
-            'applicationName': self.application_name,
+            'applicationName': quote(self.application_name),
             'permission': TOKEN_PERMISSION,
             'revoke': str(revoke).lower(),
+            'deviceDescription': get_device(),
         }
-        device = DEVICE_DESCRIPTIONS.get(sys.platform)
-        if not device:
-            device = sys.platform.replace(' ', '')
-        parameters['deviceDescription'] = device
         url = self.server_url + 'authentication/token?'
         url += urlencode(parameters)
 

--- a/nuxeo-drive-client/nxdrive/client/base_automation_client.py
+++ b/nuxeo-drive-client/nxdrive/client/base_automation_client.py
@@ -237,7 +237,7 @@ class BaseAutomationClient(BaseClient):
         self.check_access()
 
     def __repr__(self):
-        attrs = ', '.join('{}={!r}'.format(attr, getattr(self, attr))
+        attrs = ', '.join('{}={!r}'.format(attr, getattr(self, attr, None))
                           for attr in sorted(self.__init__.__code__.co_varnames[1:]))
         return '<{} {}>'.format(self.__class__.__name__, attrs)
 

--- a/nuxeo-drive-client/nxdrive/client/base_automation_client.py
+++ b/nuxeo-drive-client/nxdrive/client/base_automation_client.py
@@ -157,6 +157,8 @@ class BaseAutomationClient(BaseClient):
     # Parameters used when negotiating authentication token:
     application_name = 'Nuxeo Drive'
 
+    __operations = None
+
     def __init__(self, server_url, user_id, device_id, client_version,
                  proxies=None, proxy_exceptions=None,
                  password=None, token=None, repository=DEFAULT_REPOSITORY_NAME,
@@ -230,13 +232,43 @@ class BaseAutomationClient(BaseClient):
         self.new_upload_api_available = True
         self.rest_api_url = server_url + 'api/v1/'
         self.batch_upload_path = 'upload'
+        self.is_event_log_id = True
 
-        self.fetch_api()
+        self.check_access()
 
     def __repr__(self):
-        attrs = ', '.join('{}={!r}'.format(attr, getattr(self, attr, None))
+        attrs = ', '.join('{}={!r}'.format(attr, getattr(self, attr))
                           for attr in sorted(self.__init__.__code__.co_varnames[1:]))
         return '<{} {}>'.format(self.__class__.__name__, attrs)
+
+    @property
+    def operations(self):
+        """
+        A dict of all operations and their parameters.
+        Fetched on demand as it is a heavy work for the server and the network.
+
+        :rtype: dict
+        """
+
+        if not self.__operations:
+            self.fetch_api()
+        return self.__operations
+
+    def check_access(self):
+        """ Simple call to check credentials. """
+
+        url = self.automation_url + 'logInAudit'
+        headers = self._get_common_headers()
+        log.trace('Checking credentials at %r with headers=%r', url, headers)
+        req = urllib2.Request(url, headers=headers)
+        try:
+            self.opener.open(req, timeout=self.timeout)
+        except urllib2.HTTPError as exc:
+            if exc.code in (401, 403):
+                raise Unauthorized(self.server_url, self.user_id, exc.code)
+            raise exc
+        except:
+            raise
 
     def fetch_api(self):
         base_error_message = (
@@ -290,13 +322,13 @@ class BaseAutomationClient(BaseClient):
                 msg += ": " + e.msg
             e.msg = msg
             raise e
-        self.operations = {}
-        for operation in response["operations"]:
-            self.operations[operation['id']] = operation
-            op_aliases = operation.get('aliases')
-            if op_aliases:
-                for op_alias in op_aliases:
-                    self.operations[op_alias] = operation
+
+        operations = {}
+        for operation in response['operations']:
+            operations[operation['id']] = operation
+            for alias in operation.get('aliases', []):
+                operations[alias] = operation
+        self.__operations = operations
 
         # Is event log id available in change summary?
         # See https://jira.nuxeo.com/browse/NXP-14826
@@ -304,8 +336,9 @@ class BaseAutomationClient(BaseClient):
         self.is_event_log_id = 'lowerBound' in [
                         param['name'] for param in change_summary_op['params']]
 
+
     def execute(self, command, url=None, op_input=None, timeout=-1,
-                check_params=True, void_op=False, extra_headers=None,
+                check_params=False, void_op=False, extra_headers=None,
                 enrichers=None, file_out=None, **params):
         """Execute an Automation operation"""
         if check_params:
@@ -463,6 +496,25 @@ class BaseAutomationClient(BaseClient):
             raise e
         return self._read_response(resp, url)
 
+    def server_reachable(self):
+        """
+        Simple call to the server status page to check if it is reachable.
+        """
+
+        url = self.server_url + 'runningstatus'
+        headers = self._get_common_headers()
+        log.trace('Checking server availability at %r with headers=%r',
+                  url, headers)
+        req = urllib2.Request(url, headers=headers)
+        try:
+            ret = self.opener.open(req, timeout=self.timeout)
+        except:
+            pass
+        else:
+            if ret.code == 200:
+                return True
+        return False
+
     def upload(self, batch_id, file_path, filename=None, file_index=0,
                mime_type=None):
         """Upload a file through an Automation batch
@@ -569,9 +621,10 @@ class BaseAutomationClient(BaseClient):
             'permission': TOKEN_PERMISSION,
             'revoke': str(revoke).lower(),
         }
-        device_description = DEVICE_DESCRIPTIONS.get(sys.platform)
-        if device_description:
-            parameters['deviceDescription'] = device_description
+        device = DEVICE_DESCRIPTIONS.get(sys.platform)
+        if not device:
+            device = sys.platform.replace(' ', '')
+        parameters['deviceDescription'] = device
         url = self.server_url + 'authentication/token?'
         url += urlencode(parameters)
 
@@ -647,7 +700,8 @@ class BaseAutomationClient(BaseClient):
             raise ValueError("Either password or token must be provided")
 
     def _get_common_headers(self):
-        """Headers to include in every HTTP requests
+        """
+        Headers to include in every HTTP requests
 
         Includes the authentication heads (token based or basic auth if no
         token).
@@ -655,13 +709,12 @@ class BaseAutomationClient(BaseClient):
         Also include an application name header to make it possible for the
         server to compute access statistics for various client types (e.g.
         browser vs devices).
-
         """
         return {
             'X-User-Id': self.user_id,
             'X-Device-Id': self.device_id,
             'X-Client-Version': self.client_version,
-            'User-Agent': self.application_name + "/" + self.client_version,
+            'User-Agent': self.application_name + '/' + self.client_version,
             'X-Application-Name': self.application_name,
             self.auth[0]: self.auth[1],
             'Cache-Control': 'no-cache',

--- a/nuxeo-drive-client/nxdrive/client/local_client.py
+++ b/nuxeo-drive-client/nxdrive/client/local_client.py
@@ -756,6 +756,9 @@ FolderType=Generic
     def get_path(self, abspath):
         """ Relative path to the local client from an absolute OS path. """
 
+        if isinstance(abspath, bytes):
+            abspath = abspath.decode(sys.getfilesystemencoding() or 'utf-8')
+
         _, _, path = abspath.partition(self.base_folder)
         if not path:
             return '/'

--- a/nuxeo-drive-client/nxdrive/engine/watcher/remote_watcher.py
+++ b/nuxeo-drive-client/nxdrive/engine/watcher/remote_watcher.py
@@ -424,15 +424,16 @@ class RemoteWatcher(EngineWorker):
         try:
             self._client = self._engine.get_remote_client()
         except HTTPError as e:
-            if e.code == 401 or e.code == 403:
-                if not self._engine.has_invalid_credentials():
-                    self._engine.set_invalid_credentials(reason='got HTTPError %d while checking if offline' % e.code,
-                                                         exception=e)
+            if (e.code in (401, 403)
+                    and not self._engine.has_invalid_credentials()):
+                self._engine.set_invalid_credentials(
+                    reason='got HTTPError %d while checking if offline' % e.code,
+                    exception=e)
         except Unauthorized as e:
             if not self._engine.has_invalid_credentials():
-                self._engine.set_invalid_credentials(reason='got Unauthorized with code %s while checking if offline'
-                                                     % e.code if hasattr(e, 'code') and e.code else 'None',
-                                                     exception=e)
+                self._engine.set_invalid_credentials(
+                    reason='got Unauthorized with code %r while checking if offline' % getattr(e, 'code'),
+                    exception=e)
         except:
             pass
 
@@ -442,8 +443,8 @@ class RemoteWatcher(EngineWorker):
             return None
         if self._engine.is_offline():
             try:
-                # Try to get the api
-                self._client.fetch_api()
+                # Try to get the server status
+                self._client.server_reachable()
                 # if retrieved
                 self._engine.set_offline(False)
                 return self._client

--- a/nuxeo-drive-client/nxdrive/utils.py
+++ b/nuxeo-drive-client/nxdrive/utils.py
@@ -22,15 +22,12 @@ from nxdrive.logging_config import get_logger
 if sys.platform == 'win32':
     import win32api
 
-NUXEO_DRIVE_FOLDER_NAME = 'Nuxeo Drive'
-log = get_logger(__name__)
-
-WIN32_SUFFIX = os.path.join('library.zip', 'nxdrive')
-OSX_SUFFIX = "Contents/Resources/lib/python2.7/site-packages.zip/nxdrive"
-
-ENCODING = locale.getpreferredencoding()
-DEFAULT_ENCODING = 'utf-8'
-
+DEVICE_DESCRIPTIONS = {
+    'cygwin': 'Windows',
+    'darwin': 'macOS',
+    'linux2': 'GNU/Linux',
+    'win32': 'Windows',
+}
 WIN32_PATCHED_MIME_TYPES = {
     'image/pjpeg': 'image/jpeg',
     'image/x-png': 'image/png',
@@ -43,19 +40,25 @@ WIN32_PATCHED_MIME_TYPES = {
     'application/x-mspowerpoint.12':
     'application/vnd.openxmlformats-officedocument.presentationml.presentation',
 }
-
-DEVICE_DESCRIPTIONS = {
-    'linux2': 'Linux',
-    'darwin': 'Mac',
-    'cygwin': 'Windows',
-    'win32': 'Windows',
-}
-
 TOKEN_PERMISSION = 'ReadWrite'
+NUXEO_DRIVE_FOLDER_NAME = 'Nuxeo Drive'
+OSX_SUFFIX = "Contents/Resources/lib/python2.7/site-packages.zip/nxdrive"
+ENCODING = locale.getpreferredencoding()
+
+log = get_logger(__name__)
 
 
 def current_milli_time():
     return int(round(time.time() * 1000))
+
+
+def get_device():
+    """ Retreive the device type. """
+
+    device = DEVICE_DESCRIPTIONS.get(sys.platform)
+    if not device:
+        device = sys.platform.replace(' ', '')
+    return device
 
 
 def is_hexastring(value):

--- a/nuxeo-drive-client/nxdrive/wui/settings.py
+++ b/nuxeo-drive-client/nxdrive/wui/settings.py
@@ -1,9 +1,9 @@
 # coding: utf-8
-import sys
 import urllib2
 import urlparse
 from collections import namedtuple
 from urllib import urlencode
+from urllib2 import quote
 
 from PyQt4 import QtCore, QtGui
 
@@ -14,8 +14,7 @@ from nxdrive.engine.engine import InvalidDriveException, \
     RootAlreadyBindWithDifferentAccount
 from nxdrive.logging_config import get_logger
 from nxdrive.manager import FolderAlreadyUsed, ProxySettings
-from nxdrive.utils import DEVICE_DESCRIPTIONS, TOKEN_PERMISSION, \
-    guess_server_url
+from nxdrive.utils import TOKEN_PERMISSION, get_device, guess_server_url
 from nxdrive.wui.authentication import WebAuthenticationApi, \
     WebAuthenticationDialog
 from nxdrive.wui.dialog import Promise, WebDialog, WebDriveApi
@@ -294,12 +293,10 @@ class WebSettingsApi(WebDriveApi):
     def _get_authentication_url(self, server_url):
         token_params = {
             'deviceId': self._manager.get_device_id(),
-            'applicationName': self._manager.app_name,
+            'applicationName': quote(self._manager.app_name),
             'permission': TOKEN_PERMISSION,
+            'deviceDescription': get_device(),
         }
-        device_description = DEVICE_DESCRIPTIONS.get(sys.platform)
-        if device_description:
-            token_params['deviceDescription'] = device_description
         # Force login in case of anonymous user configuration
         token_params['forceAnonymousLogin'] = 'true'
 

--- a/nuxeo-drive-client/tests/common_unit_test.py
+++ b/nuxeo-drive-client/tests/common_unit_test.py
@@ -298,7 +298,7 @@ class UnitTestCase(SimpleUnitTestCase):
             return MacLocalClient(path)
         return LocalClient(path)
 
-    def setUpApp(self, server_profile=None):
+    def setUpApp(self, server_profile=None, register_roots=True):
         # Save the current path for test files
         self.location = dirname(__file__)
 
@@ -378,36 +378,39 @@ class UnitTestCase(SimpleUnitTestCase):
         self.bind_engine(2, start_engine=False)
         self.queue_manager_2 = self.engine_2.get_queue_manager()
 
-        self.sync_root_folder_1 = os.path.join(self.local_nxdrive_folder_1, self.workspace_title_1)
-        self.sync_root_folder_2 = os.path.join(self.local_nxdrive_folder_2, self.workspace_title_2)
+        self.sync_root_folder_1 = os.path.join(
+            self.local_nxdrive_folder_1, self.workspace_title_1)
+        self.sync_root_folder_2 = os.path.join(
+            self.local_nxdrive_folder_2, self.workspace_title_2)
 
         self.local_root_client_1 = self.engine_1.get_local_client()
         self.local_root_client_2 = self.engine_2.get_local_client()
 
-        self.local_client_1 = self.get_local_client(os.path.join(self.local_nxdrive_folder_1, self.workspace_title))
-        self.local_client_2 = self.get_local_client(os.path.join(self.local_nxdrive_folder_2, self.workspace_title))
+        self.local_client_1 = self.get_local_client(self.sync_root_folder_1)
+        self.local_client_2 = self.get_local_client(self.sync_root_folder_2)
 
         # Document client to be used to create remote test documents
         # and folders
-        remote_document_client_1 = RemoteDocumentClientForTests(
+        self.remote_document_client_1 = RemoteDocumentClientForTests(
             self.nuxeo_url, self.user_1, u'nxdrive-test-device-1',
             self.version,
             password=self.password_1, base_folder=self.workspace_1,
             upload_tmp_dir=self.upload_tmp_dir)
 
-        remote_document_client_2 = RemoteDocumentClientForTests(
+        self.remote_document_client_2 = RemoteDocumentClientForTests(
             self.nuxeo_url, self.user_2, u'nxdrive-test-device-2',
             self.version,
             password=self.password_2, base_folder=self.workspace_2,
             upload_tmp_dir=self.upload_tmp_dir)
+
         # File system client to be used to create remote test documents
         # and folders
-        remote_file_system_client_1 = RemoteFileSystemClient(
+        self.remote_file_system_client_1 = RemoteFileSystemClient(
             self.nuxeo_url, self.user_1, u'nxdrive-test-device-1',
             self.version,
             password=self.password_1, upload_tmp_dir=self.upload_tmp_dir)
 
-        remote_file_system_client_2 = RemoteFileSystemClient(
+        self.remote_file_system_client_2 = RemoteFileSystemClient(
             self.nuxeo_url, self.user_2, u'nxdrive-test-device-2',
             self.version,
             password=self.password_2, upload_tmp_dir=self.upload_tmp_dir)
@@ -419,13 +422,9 @@ class UnitTestCase(SimpleUnitTestCase):
         )
 
         # Register sync roots
-        remote_document_client_1.register_as_root(self.workspace_1)
-        remote_document_client_2.register_as_root(self.workspace_2)
-
-        self.remote_document_client_1 = remote_document_client_1
-        self.remote_document_client_2 = remote_document_client_2
-        self.remote_file_system_client_1 = remote_file_system_client_1
-        self.remote_file_system_client_2 = remote_file_system_client_2
+        if register_roots:
+            self.remote_document_client_1.register_as_root(self.workspace_1)
+            self.remote_document_client_2.register_as_root(self.workspace_2)
 
     def bind_engine(self, number, start_engine=True):
         number_str = str(number)

--- a/nuxeo-drive-client/tests/test_remote_changes.py
+++ b/nuxeo-drive-client/tests/test_remote_changes.py
@@ -6,16 +6,19 @@ from tests.common_unit_test import UnitTestCase
 
 class TestRemoteChanges(UnitTestCase):
 
+    def setUpApp(self):
+        super(TestRemoteChanges, self).setUpApp(register_roots=False)
+
     def setUp(self):
         super(TestRemoteChanges, self).setUp()
         self.last_sync_date = None
         self.last_event_log_id = None
         self.last_root_definitions = None
         # Initialize last event log id (lower bound)
-        self.wait()
         self.get_changes()
 
     def get_changes(self):
+        self.wait()
         remote_client = self.remote_file_system_client_1
         summary = remote_client.get_changes(self.last_root_definitions,
                                             log_id=self.last_event_log_id,
@@ -23,37 +26,31 @@ class TestRemoteChanges(UnitTestCase):
         self.last_sync_date = summary['syncDate']
         if remote_client.is_event_log_id_available():
             self.last_event_log_id = summary['upperBound']
-        self.last_root_definitions = (
-            summary['activeSynchronizationRootDefinitions'])
+        self.last_root_definitions = summary['activeSynchronizationRootDefinitions']
         return summary
 
     def test_changes_without_active_roots(self):
         remote_client = self.remote_file_system_client_1
-        self.remote_document_client_1.unregister_as_root(self.workspace)
-        self.wait()
-        self.get_changes()  # Reset
         summary = self.get_changes()
-        self.assertFalse(summary['hasTooManyChanges'])
-        self.assertEqual(summary['fileSystemChanges'], [])
-        self.assertEqual(summary['activeSynchronizationRootDefinitions'], '')
+        assert not summary['hasTooManyChanges']
+        assert not summary['fileSystemChanges']
+        assert not summary['activeSynchronizationRootDefinitions']
         first_timestamp = summary['syncDate']
-        self.assertTrue(first_timestamp > 0)
+        assert first_timestamp > 0
         first_event_log_id = 0
         if remote_client.is_event_log_id_available():
             first_event_log_id = summary['upperBound']
-            self.assertGreater(first_event_log_id, 0)
+            assert first_event_log_id >= 0
 
-        self.wait()
         summary = self.get_changes()
-
-        self.assertFalse(summary['hasTooManyChanges'])
-        self.assertEqual(summary['fileSystemChanges'], [])
-        self.assertEqual(summary['activeSynchronizationRootDefinitions'], '')
+        assert not summary['hasTooManyChanges']
+        assert not summary['fileSystemChanges']
+        assert not summary['activeSynchronizationRootDefinitions']
         second_time_stamp = summary['syncDate']
-        self.assertTrue(second_time_stamp >= first_timestamp)
+        assert second_time_stamp >= first_timestamp
         if remote_client.is_event_log_id_available():
             second_event_log_id = summary['upperBound']
-            self.assertGreaterEqual(second_event_log_id, first_event_log_id)
+            assert second_event_log_id >= first_event_log_id
 
     def test_changes_root_registrations(self):
         # Lets create some folders in Nuxeo
@@ -63,143 +60,134 @@ class TestRemoteChanges(UnitTestCase):
         remote_client.make_folder(folder_2, 'Folder 2.2')
 
         # Check no changes without any registered roots
-        remote_client.unregister_as_root(self.workspace)
-        self.wait()
-        self.get_changes()  # Reset
         summary = self.get_changes()
-        self.assertFalse(summary['hasTooManyChanges'])
-        self.assertEqual(summary['activeSynchronizationRootDefinitions'], '')
-        self.assertEqual(summary['fileSystemChanges'], [])
+        assert not summary['hasTooManyChanges']
+        assert not summary['activeSynchronizationRootDefinitions']
+        assert not summary['fileSystemChanges']
 
         # Let's register one of the previously created folders as sync root
         remote_client.register_as_root(folder_1)
 
-        self.wait()
         summary = self.get_changes()
-
-        self.assertFalse(summary['hasTooManyChanges'])
+        assert not summary['hasTooManyChanges']
         root_defs = summary['activeSynchronizationRootDefinitions'].split(',')
-        self.assertEqual(len(root_defs), 1)
-        self.assertTrue(root_defs[0].startswith('default:'))
-        self.assertEqual(len(summary['fileSystemChanges']), 1)
+        assert len(root_defs) == 1
+        assert root_defs[0].startswith('default:')
+        assert len(summary['fileSystemChanges']) == 1
+
         change = summary['fileSystemChanges'][0]
-        self.assertEqual(change['fileSystemItemName'], 'Folder 1')
-        self.assertEqual(change['repositoryId'], "default")
-        self.assertEqual(change['docUuid'], folder_1)
+        assert change['fileSystemItemName'] == 'Folder 1'
+        assert change['repositoryId'] == 'default'
+        assert change['docUuid'] == folder_1
 
         # Let's register the second root
         remote_client.register_as_root(folder_2)
 
-        self.wait()
         summary = self.get_changes()
-
-        self.assertFalse(summary['hasTooManyChanges'])
+        assert not summary['hasTooManyChanges']
         root_defs = summary['activeSynchronizationRootDefinitions'].split(',')
-        self.assertEqual(len(root_defs), 2)
-        self.assertTrue(root_defs[0].startswith('default:'))
-        self.assertTrue(root_defs[1].startswith('default:'))
-        self.assertEqual(len(summary['fileSystemChanges']), 1)
+        assert len(root_defs) == 2
+        assert root_defs[0].startswith('default:')
+        assert root_defs[1].startswith('default:')
+        assert len(summary['fileSystemChanges']) == 1
         change = summary['fileSystemChanges'][0]
-        self.assertEqual(change['fileSystemItemName'], 'Folder 2')
-        self.assertEqual(change['repositoryId'], "default")
-        self.assertEqual(change['docUuid'], folder_2)
+        assert change['fileSystemItemName'] == 'Folder 2'
+        assert change['repositoryId'] == 'default'
+        assert change['docUuid'] == folder_2
 
         # Let's do nothing and refetch the changes
         summary = self.get_changes()
-        self.assertFalse(summary['hasTooManyChanges'])
+        assert not summary['hasTooManyChanges']
         root_defs = summary['activeSynchronizationRootDefinitions'].split(',')
-        self.assertEqual(len(root_defs), 2)
-        self.assertTrue(root_defs[0].startswith('default:'))
-        self.assertTrue(root_defs[1].startswith('default:'))
-        self.assertEqual(len(summary['fileSystemChanges']), 0)
+        assert len(root_defs) == 2
+        assert root_defs[0].startswith('default:')
+        assert root_defs[1].startswith('default:')
+        assert not len(summary['fileSystemChanges'])
 
         # Let's unregister both roots at the same time
         remote_client.unregister_as_root(folder_1)
         remote_client.unregister_as_root(folder_2)
 
-        self.wait()
         summary = self.get_changes()
 
-        self.assertFalse(summary['hasTooManyChanges'])
+        assert not summary['hasTooManyChanges']
         raw_root_defs = summary['activeSynchronizationRootDefinitions']
-        self.assertEqual(raw_root_defs, '')
-        self.assertEqual(len(summary['fileSystemChanges']), 2)
+        assert not raw_root_defs
+        assert len(summary['fileSystemChanges']) == 2
+
         change = summary['fileSystemChanges'][0]
-        self.assertEqual(change['eventId'], 'deleted')
-        self.assertIsNone(change['fileSystemItemName'])
-        self.assertEqual(change['repositoryId'], "default")
-        self.assertEqual(change['docUuid'], folder_2)
+        assert change['eventId'] == 'deleted'
+        assert not change['fileSystemItemName']
+        assert change['repositoryId'] == 'default'
+        assert change['docUuid'] == folder_2
+
         change = summary['fileSystemChanges'][1]
-        self.assertEqual(change['eventId'], 'deleted')
-        self.assertIsNone(change['fileSystemItemName'])
-        self.assertEqual(change['repositoryId'], "default")
-        self.assertEqual(change['docUuid'], folder_1)
+        assert change['eventId'] == 'deleted'
+        assert not change['fileSystemItemName']
+        assert change['repositoryId'] == 'default'
+        assert change['docUuid'] == folder_1
 
         # Let's do nothing and refetch the changes
         summary = self.get_changes()
-        self.assertFalse(summary['hasTooManyChanges'])
+        assert not summary['hasTooManyChanges']
         raw_root_defs = summary['activeSynchronizationRootDefinitions']
-        self.assertEqual(raw_root_defs, '')
-        self.assertEqual(len(summary['fileSystemChanges']), 0)
+        assert not raw_root_defs
+        assert not len(summary['fileSystemChanges'])
 
     def test_sync_root_parent_registration(self):
         # Create a folder
         remote_client = self.remote_document_client_1
         folder_1 = remote_client.make_folder(self.workspace, 'Folder 1')
-        remote_client.unregister_as_root(self.workspace)
-        self.wait()
-        self.get_changes()  # Reset
+        self.get_changes()
 
         # Mark Folder 1 as a sync root
         remote_client.register_as_root(folder_1)
-        self.wait()
-        summary = self.get_changes()
 
-        self.assertEqual(len(summary['fileSystemChanges']), 1)
+        summary = self.get_changes()
+        assert len(summary['fileSystemChanges']) == 1
+
         change = summary['fileSystemChanges'][0]
-        self.assertEqual(change['eventId'], 'rootRegistered')
-        self.assertEqual(change['fileSystemItemName'], 'Folder 1')
-        self.assertEqual(change['fileSystemItemId'], 'defaultSyncRootFolderItemFactory#default#%s' % folder_1)
+        assert change['eventId'] == 'rootRegistered'
+        assert change['fileSystemItemName'] == 'Folder 1'
+        assert change['fileSystemItemId'] == 'defaultSyncRootFolderItemFactory#default#%s' % folder_1
 
         # Mark parent folder as a sync root, should unregister Folder 1
         remote_client.register_as_root(self.workspace)
-        self.wait()
         summary = self.get_changes()
+        assert len(summary['fileSystemChanges']) == 2
 
-        self.assertEqual(len(summary['fileSystemChanges']), 2)
         for change in summary['fileSystemChanges']:
             if change['eventId'] == 'rootRegistered':
-                self.assertEqual(change['fileSystemItemName'], 'Nuxeo Drive Test Workspace')
-                self.assertEqual(change['fileSystemItemId'],
-                                 'defaultSyncRootFolderItemFactory#default#%s' % self.workspace)
-                self.assertIsNotNone(change['fileSystemItem'])
+                assert change['fileSystemItemName'] == 'Nuxeo Drive Test Workspace'
+                assert change['fileSystemItemId'] == 'defaultSyncRootFolderItemFactory#default#%s' % self.workspace
+                assert change['fileSystemItem'] is not None
             elif change['eventId'] == 'deleted':
-                self.assertIsNone(change['fileSystemItemName'])
-                self.assertEqual(change['fileSystemItemId'], 'default#%s' % folder_1)
-                self.assertIsNone(change['fileSystemItem'])
+                assert not change['fileSystemItemName']
+                assert change['fileSystemItemId'] == 'default#%s' % folder_1
+                assert not change['fileSystemItem']
             else:
-                self.fail('Unexpected event %s' % change['eventId'])
+                self.fail('Unexpected event %r' % change['eventId'])
 
     def test_lock_unlock_events(self):
         remote = self.remote_document_client_1
+        remote.register_as_root(self.workspace_1)
         doc_id = remote.make_file(self.workspace, 'TestLocking.txt', 'File content')
-        self.wait()
         self.get_changes()
 
         remote.lock(doc_id)
-        self.wait()
         summary = self.get_changes()
-        self.assertEqual(len(summary['fileSystemChanges']), 1)
+        assert len(summary['fileSystemChanges']) == 1
+
         change = summary['fileSystemChanges'][0]
-        self.assertEqual(change['eventId'], 'documentLocked')
-        self.assertEqual(change['docUuid'], doc_id)
-        self.assertEqual(change['fileSystemItemName'], 'TestLocking.txt')
+        assert change['eventId'] == 'documentLocked'
+        assert change['docUuid'] == doc_id
+        assert change['fileSystemItemName'] == 'TestLocking.txt'
 
         remote.unlock(doc_id)
-        self.wait()
         summary = self.get_changes()
-        self.assertEqual(len(summary['fileSystemChanges']), 1)
+        assert len(summary['fileSystemChanges']) == 1
+
         change = summary['fileSystemChanges'][0]
-        self.assertEqual(change['eventId'], 'documentUnlocked')
-        self.assertEqual(change['docUuid'], doc_id)
-        self.assertEqual(change['fileSystemItemName'], 'TestLocking.txt')
+        assert change['eventId'] == 'documentUnlocked'
+        assert change['docUuid'] == doc_id
+        assert change['fileSystemItemName'] == 'TestLocking.txt'

--- a/nuxeo-drive-client/tests/test_remote_changes.py
+++ b/nuxeo-drive-client/tests/test_remote_changes.py
@@ -1,4 +1,6 @@
 # coding: utf-8
+from __future__ import unicode_literals
+
 from tests.common_unit_test import UnitTestCase
 
 
@@ -31,26 +33,27 @@ class TestRemoteChanges(UnitTestCase):
         self.wait()
         self.get_changes()  # Reset
         summary = self.get_changes()
-        self.assertEqual(summary['hasTooManyChanges'], False)
+        self.assertFalse(summary['hasTooManyChanges'])
         self.assertEqual(summary['fileSystemChanges'], [])
         self.assertEqual(summary['activeSynchronizationRootDefinitions'], '')
         first_timestamp = summary['syncDate']
         self.assertTrue(first_timestamp > 0)
+        first_event_log_id = 0
         if remote_client.is_event_log_id_available():
             first_event_log_id = summary['upperBound']
-            self.assertTrue(first_event_log_id > 0)
+            self.assertGreater(first_event_log_id, 0)
 
         self.wait()
         summary = self.get_changes()
 
-        self.assertEqual(summary['hasTooManyChanges'], False)
+        self.assertFalse(summary['hasTooManyChanges'])
         self.assertEqual(summary['fileSystemChanges'], [])
         self.assertEqual(summary['activeSynchronizationRootDefinitions'], '')
         second_time_stamp = summary['syncDate']
         self.assertTrue(second_time_stamp >= first_timestamp)
         if remote_client.is_event_log_id_available():
             second_event_log_id = summary['upperBound']
-            self.assertTrue(second_event_log_id >= first_event_log_id)
+            self.assertGreaterEqual(second_event_log_id, first_event_log_id)
 
     def test_changes_root_registrations(self):
         # Lets create some folders in Nuxeo
@@ -64,7 +67,7 @@ class TestRemoteChanges(UnitTestCase):
         self.wait()
         self.get_changes()  # Reset
         summary = self.get_changes()
-        self.assertEqual(summary['hasTooManyChanges'], False)
+        self.assertFalse(summary['hasTooManyChanges'])
         self.assertEqual(summary['activeSynchronizationRootDefinitions'], '')
         self.assertEqual(summary['fileSystemChanges'], [])
 
@@ -74,13 +77,13 @@ class TestRemoteChanges(UnitTestCase):
         self.wait()
         summary = self.get_changes()
 
-        self.assertEqual(summary['hasTooManyChanges'], False)
+        self.assertFalse(summary['hasTooManyChanges'])
         root_defs = summary['activeSynchronizationRootDefinitions'].split(',')
         self.assertEqual(len(root_defs), 1)
         self.assertTrue(root_defs[0].startswith('default:'))
         self.assertEqual(len(summary['fileSystemChanges']), 1)
         change = summary['fileSystemChanges'][0]
-        self.assertEqual(change['fileSystemItemName'], u"Folder 1")
+        self.assertEqual(change['fileSystemItemName'], 'Folder 1')
         self.assertEqual(change['repositoryId'], "default")
         self.assertEqual(change['docUuid'], folder_1)
 
@@ -90,20 +93,20 @@ class TestRemoteChanges(UnitTestCase):
         self.wait()
         summary = self.get_changes()
 
-        self.assertEqual(summary['hasTooManyChanges'], False)
+        self.assertFalse(summary['hasTooManyChanges'])
         root_defs = summary['activeSynchronizationRootDefinitions'].split(',')
         self.assertEqual(len(root_defs), 2)
         self.assertTrue(root_defs[0].startswith('default:'))
         self.assertTrue(root_defs[1].startswith('default:'))
         self.assertEqual(len(summary['fileSystemChanges']), 1)
         change = summary['fileSystemChanges'][0]
-        self.assertEqual(change['fileSystemItemName'], u"Folder 2")
+        self.assertEqual(change['fileSystemItemName'], 'Folder 2')
         self.assertEqual(change['repositoryId'], "default")
         self.assertEqual(change['docUuid'], folder_2)
 
         # Let's do nothing and refetch the changes
         summary = self.get_changes()
-        self.assertEqual(summary['hasTooManyChanges'], False)
+        self.assertFalse(summary['hasTooManyChanges'])
         root_defs = summary['activeSynchronizationRootDefinitions'].split(',')
         self.assertEqual(len(root_defs), 2)
         self.assertTrue(root_defs[0].startswith('default:'))
@@ -117,24 +120,24 @@ class TestRemoteChanges(UnitTestCase):
         self.wait()
         summary = self.get_changes()
 
-        self.assertEqual(summary['hasTooManyChanges'], False)
+        self.assertFalse(summary['hasTooManyChanges'])
         raw_root_defs = summary['activeSynchronizationRootDefinitions']
         self.assertEqual(raw_root_defs, '')
         self.assertEqual(len(summary['fileSystemChanges']), 2)
         change = summary['fileSystemChanges'][0]
-        self.assertEqual(change['eventId'], u"deleted")
+        self.assertEqual(change['eventId'], 'deleted')
         self.assertIsNone(change['fileSystemItemName'])
         self.assertEqual(change['repositoryId'], "default")
         self.assertEqual(change['docUuid'], folder_2)
         change = summary['fileSystemChanges'][1]
-        self.assertEqual(change['eventId'], u"deleted")
+        self.assertEqual(change['eventId'], 'deleted')
         self.assertIsNone(change['fileSystemItemName'])
         self.assertEqual(change['repositoryId'], "default")
         self.assertEqual(change['docUuid'], folder_1)
 
         # Let's do nothing and refetch the changes
         summary = self.get_changes()
-        self.assertEqual(summary['hasTooManyChanges'], False)
+        self.assertFalse(summary['hasTooManyChanges'])
         raw_root_defs = summary['activeSynchronizationRootDefinitions']
         self.assertEqual(raw_root_defs, '')
         self.assertEqual(len(summary['fileSystemChanges']), 0)
@@ -154,9 +157,9 @@ class TestRemoteChanges(UnitTestCase):
 
         self.assertEqual(len(summary['fileSystemChanges']), 1)
         change = summary['fileSystemChanges'][0]
-        self.assertEqual(change['eventId'], u'rootRegistered')
-        self.assertEqual(change['fileSystemItemName'], u'Folder 1')
-        self.assertEqual(change['fileSystemItemId'], u'defaultSyncRootFolderItemFactory#default#%s' % folder_1)
+        self.assertEqual(change['eventId'], 'rootRegistered')
+        self.assertEqual(change['fileSystemItemName'], 'Folder 1')
+        self.assertEqual(change['fileSystemItemId'], 'defaultSyncRootFolderItemFactory#default#%s' % folder_1)
 
         # Mark parent folder as a sync root, should unregister Folder 1
         remote_client.register_as_root(self.workspace)
@@ -165,14 +168,14 @@ class TestRemoteChanges(UnitTestCase):
 
         self.assertEqual(len(summary['fileSystemChanges']), 2)
         for change in summary['fileSystemChanges']:
-            if change['eventId'] == u'rootRegistered':
-                self.assertEqual(change['fileSystemItemName'], u'Nuxeo Drive Test Workspace')
+            if change['eventId'] == 'rootRegistered':
+                self.assertEqual(change['fileSystemItemName'], 'Nuxeo Drive Test Workspace')
                 self.assertEqual(change['fileSystemItemId'],
-                                 u'defaultSyncRootFolderItemFactory#default#%s' % self.workspace)
+                                 'defaultSyncRootFolderItemFactory#default#%s' % self.workspace)
                 self.assertIsNotNone(change['fileSystemItem'])
-            elif change['eventId'] == u'deleted':
+            elif change['eventId'] == 'deleted':
                 self.assertIsNone(change['fileSystemItemName'])
-                self.assertEqual(change['fileSystemItemId'], u'default#%s' % folder_1)
+                self.assertEqual(change['fileSystemItemId'], 'default#%s' % folder_1)
                 self.assertIsNone(change['fileSystemItem'])
             else:
                 self.fail('Unexpected event %s' % change['eventId'])
@@ -188,15 +191,15 @@ class TestRemoteChanges(UnitTestCase):
         summary = self.get_changes()
         self.assertEqual(len(summary['fileSystemChanges']), 1)
         change = summary['fileSystemChanges'][0]
-        self.assertEqual(change['eventId'], u"documentLocked")
+        self.assertEqual(change['eventId'], 'documentLocked')
         self.assertEqual(change['docUuid'], doc_id)
-        self.assertEqual(change['fileSystemItemName'], u"TestLocking.txt")
+        self.assertEqual(change['fileSystemItemName'], 'TestLocking.txt')
 
         remote.unlock(doc_id)
         self.wait()
         summary = self.get_changes()
         self.assertEqual(len(summary['fileSystemChanges']), 1)
         change = summary['fileSystemChanges'][0]
-        self.assertEqual(change['eventId'], u"documentUnlocked")
+        self.assertEqual(change['eventId'], 'documentUnlocked')
         self.assertEqual(change['docUuid'], doc_id)
-        self.assertEqual(change['fileSystemItemName'], u"TestLocking.txt")
+        self.assertEqual(change['fileSystemItemName'], 'TestLocking.txt')

--- a/nuxeo-drive-client/tests/test_remote_document_client.py
+++ b/nuxeo-drive-client/tests/test_remote_document_client.py
@@ -27,6 +27,9 @@ def wait_for_deletion(client, doc, retries_left=10, delay=0.300,
 
 class TestRemoteDocumentClient(UnitTestCase):
 
+    def test_repr(self):
+        assert repr(self.remote_document_client_1)
+
     def test_authentication_failure(self):
         with self.assertRaises(Unauthorized):
             RemoteDocumentClient(

--- a/nuxeo-drive-client/tests/test_utils.py
+++ b/nuxeo-drive-client/tests/test_utils.py
@@ -1,9 +1,7 @@
 # coding: utf-8
 import hashlib
-import os
 import sys
 import unittest
-import urlparse
 
 from nxdrive.manager import ProxySettings
 from nxdrive.utils import guess_digest_algorithm, guess_mime_type, \
@@ -195,8 +193,11 @@ class TestUtils(unittest.TestCase):
         except:
             pass
 
-    @unittest.skipIf(sys.platform == 'win32', 'Random failure on Windows')
     def test_guess_server_url(self):
+        domain = 'localhost'
+        good_url = 'http://localhost:8080/nuxeo'
+        self.assertEqual(guess_server_url(domain), good_url)
+
         # HTTPS domain
         domain = 'intranet.nuxeo.com'
         good_url = 'https://intranet.nuxeo.com/nuxeo'

--- a/tools/posix/deploy_jenkins_slave.sh
+++ b/tools/posix/deploy_jenkins_slave.sh
@@ -353,7 +353,8 @@ launch_tests() {
         --exitfirst \
         --strict \
         --failed-first \
-        -r Efx
+        -r Efx \
+        -vv
 }
 
 start_nxdrive() {

--- a/tools/windows/deploy_jenkins_slave.ps1
+++ b/tools/windows/deploy_jenkins_slave.ps1
@@ -329,7 +329,8 @@ function launch_tests {
 		--exitfirst `
 		--strict `
 		--failed-first `
-		-r Efx
+		-r Efx `
+		-vv
 	if ($lastExitCode -ne 0) {
 		ExitWithCode $lastExitCode
 	}


### PR DESCRIPTION
  - Cache operations and parameters.
  - Do not call fetch_api().
  - By default, do not check parameters in fetch_api().
  - Add check_access() and server_reachable().
    Tests for server_reachable() were added to the Python client.

Also:
  - Stronger utils.py guess_server_url()
  - Remove spaces from utils.py DEVICE_DESCRIPTIONS
  - Use sys.platform when no device description found
  - Encoding fix and test for LocalClient.get_path()