### PR TITLE
NXDRIVE-1030: Bugfix release 2.5.8

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2,6 +2,13 @@
 Release date: `2017-??-??`
 
 
+# 2.5.8
+Release date: `2017-11-08`
+
+#### Minor changes
+- Packaging: Fix bad bash comparison in tools/release.sh to prevent PyPi upload
+
+
 # 2.5.7
 Release date: `2017-11-07`
 

--- a/nuxeo-drive-client/nxdrive/__init__.py
+++ b/nuxeo-drive-client/nxdrive/__init__.py
@@ -25,4 +25,4 @@ To declare a beta, use this schema:
 """
 
 __author__ = 'Nuxeo'
-__version__ = '2.5.7'
+__version__ = '2.5.8'

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -95,7 +95,7 @@ publish_on_pip() {
     local version_ok
 
     version_ok="$(python -c "import sys; print(sys.version_info > (2, 7, 12))")"
-    if [ "${version_ok}" == "False" ]; then
+    if [ "${version_ok}" = "False" ]; then
         cur_version=$(python --version 2>&1 | awk '{print $2}')
         echo ">>> Python 2.7.13 or newer is required."
         echo ">>> Current version is ${cur_version}"


### PR DESCRIPTION
Fix bad bash comparison in tools/release.sh to prevent PyPi upload in case of bad Python version.