### PR TITLE
NXDRIVE-1034: Test folders containing dots

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -3,6 +3,7 @@ Release date: `2017-??-??`
 
 ### Tests
 - [NXDRIVE-1034](https://jira.nuxeo.com/browse/NXDRIVE-1034): Test folders containing dots
+- [NXDRIVE-1035](https://jira.nuxeo.com/browse/NXDRIVE-1035): Update Nuxeo version to 9.10-SNAPSHOT
 
 
 # 2.5.9

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,6 +1,9 @@
 # dev
 Release date: `2017-??-??`
 
+### Tests
+- [NXDRIVE-1034](https://jira.nuxeo.com/browse/NXDRIVE-1034): Test folders containing dots
+
 
 # 2.5.9
 Release date: `2017-11-08`

--- a/ftest/pom.xml
+++ b/ftest/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.nuxeo.ecm.distribution</groupId>
     <artifactId>nuxeo-distribution</artifactId>
-    <version>9.3-SNAPSHOT</version>
+    <version>9.10-SNAPSHOT</version>
     <relativePath></relativePath>
   </parent>
 

--- a/nuxeo-drive-client/nxdrive/__init__.py
+++ b/nuxeo-drive-client/nxdrive/__init__.py
@@ -25,4 +25,4 @@ To declare a beta, use this schema:
 """
 
 __author__ = 'Nuxeo'
-__version__ = '2.5.9'
+__version__ = '2.5.10'

--- a/nuxeo-drive-client/tests/test_local_creations.py
+++ b/nuxeo-drive-client/tests/test_local_creations.py
@@ -134,3 +134,25 @@ class TestLocalCreations(UnitTestCase):
         children = local.get_children_info('/')
         self.assertEqual(len(children), 1)
         self.assertEqual(children[0].name, filename_upper)
+
+    def test_local_create_folders_with_dots(self):
+        """ Check that folders containing dots are well synced. """
+
+        remote = self.remote_document_client_1
+        local = self.local_client_1
+        engine = self.engine_1
+
+        engine.start()
+        self.wait_sync(wait_for_async=True)
+
+        folder1 = 'Affaire.1487689320370'
+        folder2 = 'Affaire.1487689320.370'
+        local.make_folder('/', folder1)
+        local.make_folder('/', folder2)
+        self.wait_sync()
+
+        # Check
+        assert remote.exists('/' + folder1)
+        assert remote.exists('/' + folder2)
+        assert local.exists('/' + folder1)
+        assert local.exists('/' + folder2)

--- a/nuxeo-drive-client/tests/test_remote_document_client.py
+++ b/nuxeo-drive-client/tests/test_remote_document_client.py
@@ -446,3 +446,23 @@ class TestRemoteDocumentClient(UnitTestCase):
 
         remote.unlock(doc_id)
         self.assertFalse(remote.is_locked(doc_id))
+
+    def test_create_folders_with_dots(self):
+        """ Check that folders containing dots are well synced. """
+
+        remote = self.remote_document_client_1
+        local = self.local_client_1
+        engine = self.engine_1
+
+        folder1 = 'Affaire.1487689320370'
+        folder2 = 'Affaire.1487689320.370'
+        remote.make_folder(self.workspace, folder1)
+        remote.make_folder(self.workspace, folder2)
+        engine.start()
+        self.wait_sync(wait_for_async=True)
+
+        # Check
+        assert remote.exists('/' + folder1)
+        assert remote.exists('/' + folder2)
+        assert local.exists('/' + folder1)
+        assert local.exists('/' + folder2)


### PR DESCRIPTION
Add simple tests to ensure we support folders with dots in their names.

Also:
  * Bump version to 2.5.10
  * NXDRIVE-1035: Update Nuxeo version to 9.10-SNAPSHOT for the tests