### PR TITLE
NXDRIVE-317: Test tmp directories are not cleaned up after tear down

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -5,6 +5,7 @@ Release date: `2017-??-??`
 - [NXDRIVE-1038](https://jira.nuxeo.com/browse/NXDRIVE-1038): Don't quote parameters when acquiring a token
 
 ### Tests
+- [NXDRIVE-317](https://jira.nuxeo.com/browse/NXDRIVE-317): Test tmp directories are not cleaned up after tear down
 - [NXDRIVE-1034](https://jira.nuxeo.com/browse/NXDRIVE-1034): Test folders containing dots
 - [NXDRIVE-1035](https://jira.nuxeo.com/browse/NXDRIVE-1035): Update Nuxeo version to 9.10-SNAPSHOT
 

--- a/nuxeo-drive-client/tests/common.py
+++ b/nuxeo-drive-client/tests/common.py
@@ -69,6 +69,8 @@ def clean_dir(_dir):
     if not os.path.exists(_dir):
         return
 
+    log.debug('Removing directory %r', _dir)
+
     to_remove = safe_long_path(_dir)
     test_data = os.environ.get('TEST_SAVE_DATA')
     if test_data:

--- a/nuxeo-drive-client/tests/common_unit_test.py
+++ b/nuxeo-drive-client/tests/common_unit_test.py
@@ -312,9 +312,10 @@ class UnitTestCase(SimpleUnitTestCase):
 
         self.tmpdir = None
         if self.build_workspace is not None:
-            self.tmpdir = os.path.join(self.build_workspace, "tmp")
+            self.tmpdir = os.path.join(self.build_workspace, 'tmp')
             if not os.path.isdir(self.tmpdir):
                 os.makedirs(self.tmpdir)
+            self.addCleanup(clean_dir, self.tmpdir)
         self.upload_tmp_dir = tempfile.mkdtemp(u'-nxdrive-uploads', dir=self.tmpdir)
 
         # Check the local filesystem test environment
@@ -661,10 +662,6 @@ class UnitTestCase(SimpleUnitTestCase):
         Manager._singleton = None
         self.tearDownServer(server_profile)
 
-        clean_dir(self.upload_tmp_dir)
-        clean_dir(self.local_test_folder_1)
-        clean_dir(self.local_test_folder_2)
-
         if hasattr(self, 'engine_1'):
             del self.engine_1
         self.engine_1 = None
@@ -684,6 +681,12 @@ class UnitTestCase(SimpleUnitTestCase):
         del self.remote_file_system_client_2
         self.remote_file_system_client_2 = None
         self.tearedDown = True
+
+        try:
+            for root, _, files in os.walk(self.tmpdir):
+                log.error('tempdir not cleaned-up: %r (%d)', root, len(files))
+        except OSError:
+            pass
 
     def _interact(self, pause=0):
         self.app.processEvents()

--- a/nuxeo-drive-client/tests/test_bind_server.py
+++ b/nuxeo-drive-client/tests/test_bind_server.py
@@ -15,9 +15,10 @@ class BindServerTest(unittest.TestCase):
 
         self.tmp_dir = None
         if self.build_workspace is not None:
-            self.tmp_dir = os.path.join(self.build_workspace, "tmp")
+            self.tmp_dir = os.path.join(self.build_workspace, 'tmp')
             if not os.path.isdir(self.tmp_dir):
                 os.makedirs(self.tmp_dir)
+            self.addCleanup(clean_dir, self.tmp_dir)
 
         self.local_test_folder = tempfile.mkdtemp(u'-nxdrive-temp-config', dir=self.tmp_dir)
         self.nxdrive_conf_folder = os.path.join(self.local_test_folder, u'nuxeo-drive-conf')
@@ -30,8 +31,6 @@ class BindServerTest(unittest.TestCase):
         self.manager.unbind_all()
         self.manager.dispose_all()
         Manager._singleton = None
-
-        clean_dir(self.local_test_folder)
 
     def test_bind_local_folder_on_config_folder(self):
         options = Mock()

--- a/nuxeo-drive-client/tests/test_engine_dao.py
+++ b/nuxeo-drive-client/tests/test_engine_dao.py
@@ -6,6 +6,7 @@ import unittest
 
 from nxdrive.engine.dao.sqlite import EngineDAO
 from nxdrive.engine.engine import Engine
+from tests.common import clean_dir
 
 
 class EngineDAOTest(unittest.TestCase):
@@ -28,19 +29,17 @@ class EngineDAOTest(unittest.TestCase):
         self.build_workspace = os.environ.get('WORKSPACE')
         self.tmpdir = None
         if self.build_workspace is not None:
-            self.tmpdir = os.path.join(self.build_workspace, "tmp")
+            self.tmpdir = os.path.join(self.build_workspace, 'tmp')
             if not os.path.isdir(self.tmpdir):
                 os.makedirs(self.tmpdir)
+            self.addCleanup(clean_dir, self.tmpdir)
         self.tmp_db = self.get_db_temp_file()
-        db = open(self._get_default_db(), 'rb')
-        with open(self.tmp_db.name, 'wb') as f:
+
+        with open(self._get_default_db(), 'rb') as db, \
+                open(self.tmp_db.name, 'wb') as f:
             f.write(db.read())
         self._dao = EngineDAO(self.tmp_db.name)
-
-    def tearDown(self):
-        self._clean_dao(self._dao)
-        if sys.platform == 'win32' and os.path.exists(self.tmp_db.name):
-            os.remove(self.tmp_db.name)
+        self.addCleanup(self._clean_dao, self._dao)
 
     def test_init_db(self):
         init_db = self.get_db_temp_file()

--- a/nuxeo-drive-client/tests/test_manager_dao.py
+++ b/nuxeo-drive-client/tests/test_manager_dao.py
@@ -17,9 +17,10 @@ class ManagerDAOTest(unittest.TestCase):
         self.build_workspace = os.environ.get('WORKSPACE')
         self.tmpdir = None
         if self.build_workspace is not None:
-            self.tmpdir = os.path.join(self.build_workspace, "tmp")
+            self.tmpdir = os.path.join(self.build_workspace, 'tmp')
             if not os.path.isdir(self.tmpdir):
                 os.makedirs(self.tmpdir)
+            self.addCleanup(clean_dir, self.tmpdir)
         self.test_folder = tempfile.mkdtemp(u'-nxdrive-tests', dir=self.tmpdir)
         self.nuxeo_url = os.environ.get('NXDRIVE_TEST_NUXEO_URL', 'http://localhost:8080/nuxeo')
         self.admin_user = os.environ.get('NXDRIVE_TEST_USER', 'Administrator')
@@ -33,7 +34,6 @@ class ManagerDAOTest(unittest.TestCase):
 
     def tearDown(self):
         Manager._singleton = None
-        clean_dir(self.test_folder)
 
     def _get_db(self, name):
         return os.path.join(os.path.dirname(__file__), 'resources', name)

--- a/nuxeo-drive-client/tests/test_report.py
+++ b/nuxeo-drive-client/tests/test_report.py
@@ -17,6 +17,7 @@ class ReportTest(TestCase):
 
     def setUp(self):
         self.folder = tempfile.mkdtemp(u'-nxdrive-tests')
+        self.addCleanup(clean_dir, self.folder)
         options = Mock()
         options.debug = False
         options.force_locale = None
@@ -26,12 +27,10 @@ class ReportTest(TestCase):
         options.beta_update_site_url = None
         options.nxdrive_home = self.folder
         self.manager = Manager(options)
+        self.addCleanup(self.manager.dispose_db)
 
     def tearDown(self):
-        # Remove singleton
-        self.manager.dispose_db()
         Manager._singleton = None
-        clean_dir(self.folder)
 
     def test_logs(self):
         log.debug("Strange encoding \xe9")


### PR DESCRIPTION
`addCleanup()` is a `unittest` method that will be called whatever the sate of the test to ensure a good clean-up.