### PR TITLE
NXDRIVE-1034: Cannot unsync an accentued root on Windows

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -3,6 +3,7 @@ Release date: `2017-??-??`
 
 ### Core
 - [NXDRIVE-968](https://jira.nuxeo.com/browse/NXDRIVE-968): Improve logs disk space usage (set level to DEBUG)
+- [NXDRIVE-1034](https://jira.nuxeo.com/browse/NXDRIVE-1034): Cannot unsync an accentued root on Windows
 - [NXDRIVE-1038](https://jira.nuxeo.com/browse/NXDRIVE-1038): Don't quote parameters when acquiring a token
 - [NXDRIVE-1040](https://jira.nuxeo.com/browse/NXDRIVE-1040): Handle documents that are indexed but inexistant
 

--- a/nuxeo-drive-client/nxdrive/client/remote_document_client.py
+++ b/nuxeo-drive-client/nxdrive/client/remote_document_client.py
@@ -229,6 +229,15 @@ class RemoteDocumentClient(BaseAutomationClient):
         return self.delete_blob(self._check_ref(ref), xpath=xpath)
 
     def exists(self, ref, use_trash=True, include_versions=False):
+        # type: (unicode, bool, bool) -> bool
+        """
+        Check if a document exists on the server.
+
+        :param ref: Document reference (UID).
+        :param use_trash: Filter documents inside the trash.
+        :param include_versions:
+        :rtype: bool
+        """
         ref = self._check_ref(ref)
         id_prop = 'ecm:path' if ref.startswith('/') else 'ecm:uuid'
         if use_trash:

--- a/nuxeo-drive-client/nxdrive/engine/dao/sqlite.py
+++ b/nuxeo-drive-client/nxdrive/engine/dao/sqlite.py
@@ -983,8 +983,8 @@ class EngineDAO(ConfigurationDAO):
     def _get_recursive_remote_condition(self, doc_pair):
         remote_path = (self._escape(doc_pair.remote_parent_path)
                        + '/' + self._escape(doc_pair.remote_name))
-        return (' WHERE remote_parent_path LIKE "{0}/%"'
-                '       OR remote_parent_path = "{0}"').format(remote_path)
+        return (" WHERE remote_parent_path LIKE '" + remote_path + "/%'"
+                " OR remote_parent_path = '" + remote_path + "'")
 
     def update_remote_parent_path(self, doc_pair, new_path):
         self._lock.acquire()

--- a/nuxeo-drive-client/tests/test_synchronization.py
+++ b/nuxeo-drive-client/tests/test_synchronization.py
@@ -969,3 +969,20 @@ class TestSynchronization(UnitTestCase):
         self.assertEqual(len(children), 2)
         self.assertEqual(children[0].name, file1)
         self.assertEqual(children[1].name, file2)
+
+    def test_unsynchronize_accentued_document(self):
+        remote = self.remote_document_client_1
+        local = self.local_client_1
+        engine = self.engine_1
+        engine.start()
+
+        # Create the folder
+        root_name = u'Été indien'
+        root = remote.make_folder(self.workspace, root_name)
+        self.wait_sync(wait_for_async=True)
+        assert local.exists('/' + root_name)
+
+        # Remove the folder
+        remote.delete(root)
+        self.wait_sync(wait_for_async=True)
+        assert not local.exists('/' + root_name)


### PR DESCRIPTION
It was due to encoding error.