### PR TITLE
NXDRIVE-1042: Remove non-used jobs parameters

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -13,6 +13,7 @@ Release date: `2017-??-??`
 - [NXDRIVE-1034](https://jira.nuxeo.com/browse/NXDRIVE-1034): Test folders containing dots
 - [NXDRIVE-1035](https://jira.nuxeo.com/browse/NXDRIVE-1035): Update Nuxeo version to 9.10-SNAPSHOT
 - [NXDRIVE-1039](https://jira.nuxeo.com/browse/NXDRIVE-1039): Align the test REST API client following [NXP-22542](https://jira.nuxeo.com/browse/NXP-22542)
+- [NXDRIVE-1042](https://jira.nuxeo.com/browse/NXDRIVE-1042): Remove non-used jobs parameters
 
 
 # 2.5.9

--- a/tools/jenkins/packages.groovy
+++ b/tools/jenkins/packages.groovy
@@ -4,8 +4,6 @@
 // Default values for required envars
 python_drive_version = '2.7.14'  // XXX: PYTHON_DRIVE_VERSION
 pyqt_version = '4.12.1'  // XXX: PYQT_VERSION
-sip_version = '4.19.3'  // XXX: SIP_VERSION
-cxfreeze_version = '4.3.3'  // XXX: CXFREEZE_VERSION
 
 // Pipeline properties
 properties([
@@ -17,26 +15,6 @@ properties([
         [$class: 'StringParameterDefinition',
             name: 'BRANCH_NAME',
             defaultValue: 'master'],
-        [$class: 'StringParameterDefinition',
-            name: 'PYTHON_DRIVE_VERSION',
-            defaultValue: python_drive_version,
-            description: '<b>Required</b> Python version to use'],
-        [$class: 'StringParameterDefinition',
-            name: 'PYQT_VERSION',
-            defaultValue: pyqt_version,
-            description: '<b>Required</b> PyQt version to use (GNU/Linux and macOS only)'],
-        [$class: 'StringParameterDefinition',
-            name: 'CXFREEZE_VERSION',
-            defaultValue: cxfreeze_version,
-            description: '<i>Optional</i> cx_Freeze version to use'],
-        [$class: 'StringParameterDefinition',
-            name: 'SIP_VERSION',
-            defaultValue: sip_version,
-            description: '<i>Optional</i> SIP version to use (GNU/Linux and macOS only)'],
-        [$class: 'StringParameterDefinition',
-            name: 'ENGINE',
-            defaultValue: 'NXDRIVE',
-            description: '<i>Optional</i> The engine to use (another possible value is <i>NXDRIVENEXT</i>)'],
         [$class: 'BooleanParameterDefinition',
             name: 'CLEAN_WORKSPACE',
             defaultValue: false,

--- a/tools/jenkins/tests-8.10.groovy
+++ b/tools/jenkins/tests-8.10.groovy
@@ -4,8 +4,6 @@
 // Default values for required envars
 python_drive_version = '2.7.14'  // XXX: PYTHON_DRIVE_VERSION
 pyqt_version = '4.12.1'  // XXX: PYQT_VERSION
-sip_version = '4.19.3'  // XXX: SIP_VERSION
-cxfreeze_version = '4.3.3'  // XXX: CXFREEZE_VERSION
 
 // Pipeline properties
 properties([
@@ -18,22 +16,6 @@ properties([
             name: 'SPECIFIC_TEST',
             defaultValue: '',
             description: 'Specific test to launch. The syntax must be the same as <a href="http://doc.pytest.org/en/latest/example/markers.html#selecting-tests-based-on-their-node-id">pytest markers</a>'],
-        [$class: 'StringParameterDefinition',
-            name: 'PYTHON_DRIVE_VERSION',
-            defaultValue: python_drive_version,
-            description: '<b>Required</b> Python version to use'],
-        [$class: 'StringParameterDefinition',
-            name: 'PYQT_VERSION',
-            defaultValue: pyqt_version,
-            description: '<b>Required</b> PyQt version to use (GNU/Linux and macOS only)'],
-        [$class: 'StringParameterDefinition',
-            name: 'CXFREEZE_VERSION',
-            defaultValue: cxfreeze_version,
-            description: '<i>Optional</i> cx_Freeze version to use'],
-        [$class: 'StringParameterDefinition',
-            name: 'SIP_VERSION',
-            defaultValue: sip_version,
-            description: '<i>Optional</i> SIP version to use (GNU/Linux and macOS only)'],
         [$class: 'ChoiceParameterDefinition',
             name: 'RANDOM_BUG_MODE',
             choices: 'None\nRELAX\nSTRICT\nBYPASS',

--- a/tools/jenkins/tests.groovy
+++ b/tools/jenkins/tests.groovy
@@ -4,8 +4,6 @@
 // Default values for required envars
 python_drive_version = '2.7.14'  // XXX: PYTHON_DRIVE_VERSION
 pyqt_version = '4.12.1'  // XXX: PYQT_VERSION
-sip_version = '4.19.3'  // XXX: SIP_VERSION
-cxfreeze_version = '4.3.3'  // XXX: CXFREEZE_VERSION
 
 // Pipeline properties
 properties([
@@ -18,22 +16,6 @@ properties([
             name: 'SPECIFIC_TEST',
             defaultValue: '',
             description: 'Specific test to launch. The syntax must be the same as <a href="http://doc.pytest.org/en/latest/example/markers.html#selecting-tests-based-on-their-node-id">pytest markers</a>'],
-        [$class: 'StringParameterDefinition',
-            name: 'PYTHON_DRIVE_VERSION',
-            defaultValue: python_drive_version,
-            description: '<b>Required</b> Python version to use'],
-        [$class: 'StringParameterDefinition',
-            name: 'PYQT_VERSION',
-            defaultValue: pyqt_version,
-            description: '<b>Required</b> PyQt version to use (GNU/Linux and macOS only)'],
-        [$class: 'StringParameterDefinition',
-            name: 'CXFREEZE_VERSION',
-            defaultValue: cxfreeze_version,
-            description: '<i>Optional</i> cx_Freeze version to use'],
-        [$class: 'StringParameterDefinition',
-            name: 'SIP_VERSION',
-            defaultValue: sip_version,
-            description: '<i>Optional</i> SIP version to use (GNU/Linux and macOS only)'],
         [$class: 'ChoiceParameterDefinition',
             name: 'RANDOM_BUG_MODE',
             choices: 'None\nRELAX\nSTRICT\nBYPASS',


### PR DESCRIPTION
These parameters are not usable. If we want to reproduce a build, we just have to set the good branch name.