### PR TITLE
NXDRIVE-1046: Review the LocalClient class

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -8,6 +8,7 @@ Release date: `2017-??-??`
 - [NXDRIVE-1036](https://jira.nuxeo.com/browse/NXDRIVE-1036): Cannot unsync an accentued root
 - [NXDRIVE-1038](https://jira.nuxeo.com/browse/NXDRIVE-1038): Don't quote parameters when acquiring a token
 - [NXDRIVE-1040](https://jira.nuxeo.com/browse/NXDRIVE-1040): Handle documents that are indexed but inexistant
+- [NXDRIVE-1046](https://jira.nuxeo.com/browse/NXDRIVE-1046): Review the LocalClient class
 - [NXP-23113](https://jira.nuxeo.com/browse/NXP-23113): Add new DE and JA translations
 
 ### Tests

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -17,6 +17,7 @@ Release date: `2017-??-??`
 - [NXDRIVE-1039](https://jira.nuxeo.com/browse/NXDRIVE-1039): Align the test REST API client following [NXP-22542](https://jira.nuxeo.com/browse/NXP-22542)
 - [NXDRIVE-1042](https://jira.nuxeo.com/browse/NXDRIVE-1042): Remove non-used jobs parameters
 - [NXDRIVE-1045](https://jira.nuxeo.com/browse/NXDRIVE-1045): Fix tests tearDown generating a LoginException server-side
+- [NXDRIVE-1047](https://jira.nuxeo.com/browse/NXDRIVE-1047): The setup stage from Jenkins job Drive-tests is useless
 
 #### Minor changes
 - Packaging: Updated `Send2Trash` from 1.4.1 to 1.4.2

--- a/docs/technical_changes.md
+++ b/docs/technical_changes.md
@@ -14,6 +14,8 @@
 - Removed `Engine.get_beta_update_url()`. Use `Options.beta_update_site_url` instead.
 - Removed `ignored_prefixes` keyword from `LocalClient.__init__()`. Use `Options.ignored_prefixes` instead.
 - Removed `ignored_suffixes` keyword from `LocalClient.__init__()`. Use `Options.ignored_suffixes` instead.
+- Added `is_abs` keyword to `LocalClient.lock_ref()`
+- Added `is_abs` keyword to `LocalClient.unlock_ref()`
 - Removed `options` keyword from `Manager.__init__()`. Use `Options` instead.
 - Removed `Manager.generate_device_id()`. Use `devide_id` property instead.
 - Removed `Manager.get_configuration_folder()`. Use `nxdrive_home` property instead.

--- a/nuxeo-drive-client/nxdrive/engine/dao/sqlite.py
+++ b/nuxeo-drive-client/nxdrive/engine/dao/sqlite.py
@@ -96,7 +96,8 @@ class StateRow(sqlite3.Row):
         try:
             return self[name]
         except IndexError:
-            raise IndexError('No key with that name.', locals())
+            raise AttributeError(
+                '%s object has not attribute %r' % (type(self).__name__, name))
 
     def is_readonly(self):
         if self.folderish:

--- a/nuxeo-drive-client/tests/test_readonly.py
+++ b/nuxeo-drive-client/tests/test_readonly.py
@@ -170,12 +170,12 @@ class TestReadOnly(UnitTestCase):
         self.assertTrue(self.touch(user1_file_path))
 
     def test_local_readonly_modify(self):
-        self.local_root_client_1.make_folder('/', 'Test')
-        self.local_root_client_1.make_file('/Test', 'Test.txt', 'Some content')
+        local = self.local_client_1
+        local.make_folder('/', 'Test')
+        local.make_file('/Test', 'Test.txt', 'Some content')
         self.wait_sync()
         self.engine_1.stop()
-        self.local_root_client_1.update_content('/Test/Test.txt', 'Another content')
+        local.update_content('/Test/Test.txt', 'Another content')
         self.engine_1.start()
         self.wait_sync()
         self.assertEqual(len(self.engine_1.get_dao().get_errors()), 0)
-

--- a/tools/integration_tests_setup.py
+++ b/tools/integration_tests_setup.py
@@ -179,6 +179,9 @@ def set_environment(server_url, engine):
     os.environ['NXDRIVE_TEST_USER'] = "Administrator"
     os.environ['NXDRIVE_TEST_PASSWORD'] = "Administrator"
 
+    # Convenient way to try a specific test without having to abort and start a new job
+    os.environ['SPECIFIC_TEST'] = ''
+
 
 def clean_pyc(dir_):
     for root, dirnames, filenames in os.walk(dir_):

--- a/tools/jenkins/tests-8.10.groovy
+++ b/tools/jenkins/tests-8.10.groovy
@@ -111,24 +111,6 @@ for (def x in slaves) {
                         }
                     }
 
-                    stage(osi + ' Setup') {
-                        // Set up a complete isolated environment
-                        try {
-                            dir('sources') {
-                                if (osi == 'macOS') {
-                                    sh 'tools/osx/deploy_jenkins_slave.sh'
-                                } else if (osi == 'GNU/Linux') {
-                                    sh 'tools/linux/deploy_jenkins_slave.sh'
-                                } else {
-                                    bat 'powershell ".\\tools\\windows\\deploy_jenkins_slave.ps1"'
-                                }
-                            }
-                        } catch(e) {
-                            currentBuild.result = 'UNSTABLE'
-                            throw e
-                        }
-                    }
-
                     stage(osi + ' Tests') {
                         // Launch the tests suite
                         def jdk = tool name: 'java-8-oracle'

--- a/tools/jenkins/tests.groovy
+++ b/tools/jenkins/tests.groovy
@@ -110,24 +110,6 @@ for (def x in slaves) {
                         }
                     }
 
-                    stage(osi + ' Setup') {
-                        // Set up a complete isolated environment
-                        try {
-                            dir('sources') {
-                                if (osi == 'macOS') {
-                                    sh 'tools/osx/deploy_jenkins_slave.sh'
-                                } else if (osi == 'GNU/Linux') {
-                                    sh 'tools/linux/deploy_jenkins_slave.sh'
-                                } else {
-                                    bat 'powershell ".\\tools\\windows\\deploy_jenkins_slave.ps1"'
-                                }
-                            }
-                        } catch(e) {
-                            currentBuild.result = 'UNSTABLE'
-                            throw e
-                        }
-                    }
-
                     stage(osi + ' Tests') {
                         // Launch the tests suite
                         if (currentBuild.result == 'UNSTABLE' || currentBuild.result == 'FAILURE') {


### PR DESCRIPTION
Using `abspath()` only when needed sped up methods like `delete()`, `move()` or `rename()`. 

I also removed the setup stage from Jenkins Drive-test job, useless.