### PR TITLE
NXDRIVE-836: Bad behaviors with read-only documents

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2,6 +2,7 @@
 Release date: `2017-??-??`
 
 ### Core
+- [NXDRIVE-836](https://jira.nuxeo.com/browse/NXDRIVE-836): Bad behaviors with read-only documents
 - [NXDRIVE-1074](https://jira.nuxeo.com/browse/NXDRIVE-1074): Remove the Next engine source tree
 - [NXDRIVE-1075](https://jira.nuxeo.com/browse/NXDRIVE-1075): Review how TRACE level is added to loggers
 
@@ -10,6 +11,7 @@ Release date: `2017-??-??`
 - [NXDRIVE-1070](https://jira.nuxeo.com/browse/NXDRIVE-1070): Show release notes before auto-upgrading to a new version
 
 #### Minor changes
+- Framework: Review LocalWatcher class, better use of lock and atomic methods
 - GUI: Re-enable the possibility to uncheck a root in the filters window
 - Tests: Log messages are now less verbose ("thread module level message")
 - Updater: Updated minimum server version from 5.6 to 7.10

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -11,7 +11,7 @@ Release date: `2017-??-??`
 - [NXDRIVE-1070](https://jira.nuxeo.com/browse/NXDRIVE-1070): Show release notes before auto-upgrading to a new version
 
 #### Minor changes
-- Framework: Review LocalWatcher class, better use of lock and atomic methods
+- Framework: Review LocalWatcher class, better use of lock
 - GUI: Re-enable the possibility to uncheck a root in the filters window
 - Tests: Log messages are now less verbose ("thread module level message")
 - Updater: Updated minimum server version from 5.6 to 7.10

--- a/docs/technical_changes.md
+++ b/docs/technical_changes.md
@@ -4,8 +4,9 @@
 
 # dev
 - Removed `FsClient`
-- Added `formatter` keyword to logging_config.py::`configure()`
+- Removed `LocalWatcher.get_watchdog_queue_size()`
 - Removed engine/next
+- Added `formatter` keyword to logging_config.py::`configure()`
 - Removed logging_config.py::`get_logger()`. Use `logging.getLogger(__name__)` instead.
 
 # 3.0.0

--- a/nuxeo-drive-client/nxdrive/direct_edit.py
+++ b/nuxeo-drive-client/nxdrive/direct_edit.py
@@ -444,13 +444,13 @@ class DirectEdit(Worker):
             log.debug('Emitting directEditUploadCompleted')
             self.directEditUploadCompleted.emit()
 
-        while not self._watchdog_queue.empty():
-            evt = self._watchdog_queue.get()
+        while not self.watchdog_queue.empty():
+            evt = self.watchdog_queue.get()
             self.handle_watchdog_event(evt)
 
     def _execute(self):
         try:
-            self._watchdog_queue = Queue()
+            self.watchdog_queue = Queue()
             self._action = Action("Clean up folder")
             try:
                 self._cleanup()

--- a/nuxeo-drive-client/nxdrive/engine/watcher/remote_watcher.py
+++ b/nuxeo-drive-client/nxdrive/engine/watcher/remote_watcher.py
@@ -40,9 +40,6 @@ class RemoteWatcher(EngineWorker):
         self._next_check = 0
 
     def _init(self):
-        self.unhandle_fs_event = False
-        self.local_full_scan = dict()
-        self._full_scan_mode = False
         self._last_sync_date = self._dao.get_config('remote_last_sync_date')
         self._last_event_log_id = self._dao.get_config('remote_last_event_log_id')
         self._last_root_definitions = self._dao.get_config('remote_last_root_definitions')

--- a/nuxeo-drive-client/nxdrive/report.py
+++ b/nuxeo-drive-client/nxdrive/report.py
@@ -74,15 +74,13 @@ class Report(object):
         """
 
         # Lock to avoid inconsistence
-        dao._lock.acquire()
-        try:
-            myzip.write(dao._db, os.path.basename(dao._db),
-                        compress_type=ZIP_DEFLATED)
-        except:
-            log.exception('Impossible to copy the database %s',
-                          os.path.basename(dao._db))
-        finally:
-            dao._lock.release()
+        with dao._lock:
+            try:
+                myzip.write(dao._db, os.path.basename(dao._db),
+                            compress_type=ZIP_DEFLATED)
+            except:
+                log.exception('Impossible to copy the database %r',
+                              os.path.basename(dao._db))
 
     def get_path(self):
         return self._zipfile

--- a/nuxeo-drive-client/nxdrive/utils.py
+++ b/nuxeo-drive-client/nxdrive/utils.py
@@ -82,7 +82,10 @@ def is_generated_tmp_file(name):
     delay, do_not_delay, no_delay_effect = True, False, None
 
     if isinstance(name, bytes):
-        name = name.decode(locale.getpreferredencoding() or 'utf-8')
+        try:
+            name = unicode(name, encoding='utf-8')
+        except TypeError:
+            name = name.decode(locale.getpreferredencoding() or 'utf-8')
 
     # Default ignored suffixes already handle .bak, .tmp, etc..
     if name.endswith(Options.ignored_suffixes):

--- a/nuxeo-drive-client/tests/common.py
+++ b/nuxeo-drive-client/tests/common.py
@@ -18,11 +18,11 @@ from nxdrive.utils import safe_long_path
 TEST_DEFAULT_DELAY = 3
 
 TEST_WORKSPACE_PATH = (
-    u'/default-domain/workspaces/nuxeo-drive-test-workspace')
-FS_ITEM_ID_PREFIX = u'defaultFileSystemItemFactory#default#'
+    '/default-domain/workspaces/nuxeo-drive-test-workspace')
+FS_ITEM_ID_PREFIX = 'defaultFileSystemItemFactory#default#'
 
 EMPTY_DIGEST = hashlib.md5().hexdigest()
-SOME_TEXT_CONTENT = b"Some text content."
+SOME_TEXT_CONTENT = b'Some text content.'
 SOME_TEXT_DIGEST = hashlib.md5(SOME_TEXT_CONTENT).hexdigest()
 
 # 1s time resolution as we truncate remote last modification time to the

--- a/nuxeo-drive-client/tests/test_bulk_remote_changes.py
+++ b/nuxeo-drive-client/tests/test_bulk_remote_changes.py
@@ -48,14 +48,13 @@ def mock_file_to_info(self, fs_item):
 
 class TestBulkRemoteChanges(UnitTestCase):
     """
-       Test Bulk Remote Changes when network error happen 
-       mock_get_children_info will simulate network error when required.
-       test_many_changes method will make server side changes, simulate error for GetChildren API 
-           and still verify if all remote changes are successfully synced
+    Test Bulk Remote Changes when network error happenmock_get_children_info
+    will simulate network error when required.  test_many_changes method will
+    make server side changes, simulate error for GetChildren API and still
+    verify if all remote changes are successfully synced.
     """
 
     def setUp(self):
-        super(TestBulkRemoteChanges, self).setUp()
         self.last_sync_date = None
         self.last_event_log_id = None
         self.last_root_definitions = None
@@ -66,77 +65,88 @@ class TestBulkRemoteChanges(UnitTestCase):
     @patch.object(RemoteFileSystemClient, 'file_to_info', mock_file_to_info)
     def test_many_changes(self):
         """
-            Objective: The objective is to make a lot of remote changes (including a folder modified) and 
-            wait for nuxeo-drive to successfully sync even if network error happens
-            
-            1. Configure drive and wait for sync
-            2. Create 3 folders folder1, folder2 and shared
-            3. Create files inside the 3 folders: folder1/file1.txt, folder2/file2.txt, 
-                shared/readme1.txt, shared/readme2.txt
-            4. Wait for 3 folders, 4 folder to sync to local PC
-            5. Check the 3 folders and 4 files are synced to local PC
-            6. Trigger simulation of network error for GetChildren API using the mock (2 successive failures)
-            7. Do the following changes in DM side in same order:
-                I.   Create 'folder1/sample1.txt'
-                II.  Delete 'shared' folder, and immediately restore 'shared' folder
-                IV.  Restore 'shared/readme1.txt'
-                V.   Create 'shared/readme3.txt'
-                VI.  Create 'folder2/sample2.txt'
-            8. Wait for remote changes to sync for unaffected folders folder1 and folder2 
-            9. Check that folder1/sample1.txt and folder2/sample2.txt are synced to local PC
-            10. Sleep for two remote scan attempts (to compenstate for two network failures)
-            11. Check if two files 'shared/readme1.txt' and 'shared/readme3.txt' are synced to local PC
+Objective: The objective is to make a lot of remote changes (including a folder
+modified) and wait for nuxeo-drive to successfully sync even if network error
+happens.
+
+1. Configure drive and wait for sync
+2. Create 3 folders folder1, folder2 and shared
+3. Create files inside the 3 folders: folder1/file1.txt, folder2/file2.txt, 
+    shared/readme1.txt, shared/readme2.txt
+4. Wait for 3 folders, 4 folder to sync to local PC
+5. Check the 3 folders and 4 files are synced to local PC
+6. Trigger simulation of network error for GetChildren API using the mock
+   (2 successive failures)
+7. Do the following changes in DM side in same order:
+    I.   Create 'folder1/sample1.txt'
+    II.  Delete 'shared' folder, and immediately restore 'shared' folder
+    IV.  Restore 'shared/readme1.txt'
+    V.   Create 'shared/readme3.txt'
+    VI.  Create 'folder2/sample2.txt'
+8. Wait for remote changes to sync for unaffected folders folder1 and folder2
+9. Check that folder1/sample1.txt and folder2/sample2.txt are synced to local PC
+10. Sleep for two remote scan attempts (to compenstate for two network failures)
+11. Check if two files 'shared/readme1.txt' and 'shared/readme3.txt' are synced
+to local PC.
         """
         global network_error
-        remote_client = self.remote_document_client_1
-        local_client = self.local_client_1
+        remote = self.remote_document_client_1
+        local = self.local_client_1
 
         self.engine_1.start()
         self.wait_sync(wait_for_async=True)
 
         # create some folders on the server
-        folder1 = remote_client.make_folder(self.workspace, u"folder1")
-        shared = remote_client.make_folder(self.workspace, u"shared")
-        folder2 = remote_client.make_folder(self.workspace, u"folder2")
+        folder1 = remote.make_folder(self.workspace, 'folder1')
+        folder2 = remote.make_folder(self.workspace, 'folder2')
+        shared = remote.make_folder(self.workspace, 'shared')
 
-        readme1 = remote_client.make_file(shared, "readme1.txt", "This is a readme file")
-        readme2 = remote_client.make_file(shared, "readme2.txt", "This is a readme file")
-        remote_client.make_file(folder1, "file1.txt", "This is a sample file1")
-        remote_client.make_file(folder2, "file2.txt", "This is a sample file2")
+        remote.make_file(folder1, 'file1.txt', content='This is a sample file1')
+        remote.make_file(folder2, 'file2.txt', content='This is a sample file2')
+        readme1 = remote.make_file(
+            shared, 'readme1.txt', content='This is a readme file')
+        remote.make_file(shared, 'readme2.txt', content='This is a readme file')
 
         self.wait_sync(wait_for_async=True)
 
-        self.assertTrue(local_client.exists('/folder1'), "'/folder1' should sync")
-        self.assertTrue(local_client.exists('/folder2'), "'/folder1' should sync")
-        self.assertTrue(local_client.exists('/shared'), "'/shared' folder should sync")
-        self.assertTrue(local_client.exists('/folder1/file1.txt'), "'/folder1/file1.txt' should sync")
-        self.assertTrue(local_client.exists('/folder2/file2.txt'), "'/folder2/file2.txt' should sync")
-        self.assertTrue(local_client.exists('/shared/readme1.txt'), "'/shared/readme1.txt' should sync")
-        self.assertTrue(local_client.exists('/shared/readme2.txt'), "'/shared/readme2.txt' should sync")
+        assert local.exists('/folder1')
+        assert local.exists('/folder2')
+        assert local.exists('/shared')
+        assert local.exists('/folder1/file1.txt')
+        assert local.exists('/folder2/file2.txt')
+        assert local.exists('/shared/readme1.txt')
+        assert local.exists('/shared/readme2.txt')
 
         # Simulate network error for GetChildren API twice
-        # This is to ensure drive will eventually recover even after multiple failures of GetChildren API
+        # This is to ensure Drive will eventually recover even after multiple
+        # failures of GetChildren API.
         network_error = 2
-        remote_client.make_file(folder1, "sample1.txt", "This is a another sample file1")
+        remote.make_file(
+            folder1, 'sample1.txt', content='This is a another sample file1')
         self.remote_document_client_2.register_as_root(shared)
+
         # Delete folder 'shared'
-        remote_client.delete(shared)
+        remote.delete(shared)
         self.wait_sync(wait_for_async=True)
+
         # Restore folder 'shared' from trash
-        remote_client.undelete(shared)
-        self.wait_sync(wait_for_async=True)
-        # restore file 'shared/readme1.txt' from trash
-        remote_client.undelete(readme1)
-        remote_client.make_file(shared, "readme3.txt", "This is a another shared file")
-        remote_client.make_file(folder2, "sample2.txt", "This is a another sample file2")
-
+        remote.undelete(shared)
         self.wait_sync(wait_for_async=True)
 
-        self.assertTrue(local_client.exists('/folder2/sample2.txt'), "'/folder2/sample2.txt' should sync")
-        self.assertTrue(local_client.exists('/folder1/sample1.txt'), "'/folder1/sample1.txt' should sync")
+        # Restore file 'shared/readme1.txt' from trash
+        remote.undelete(readme1)
+        remote.make_file(
+            shared, 'readme3.txt', content='This is a another shared file')
+        remote.make_file(
+            folder2, 'sample2.txt', content='This is a another sample file2')
 
-        # Although sync failed for one folder, GetChangeSummary will return zero event in successive calls
-        # We need to wait two remote scans, so sleep for TEST_DEFAULT_DELAY * 2
+        self.wait_sync(wait_for_async=True)
+        assert local.exists('/folder2/sample2.txt')
+        assert local.exists('/folder1/sample1.txt')
+
+        # Although sync failed for one folder, GetChangeSummary will return
+        # zero event in successive calls.  We need to wait two remote scans,
+        # so sleep for TEST_DEFAULT_DELAY * 2
         sleep(TEST_DEFAULT_DELAY * 2)
-        self.assertTrue(local_client.exists('/shared/readme1.txt'), "'/shared/readme1.txt' should sync")
-        self.assertTrue(local_client.exists('/shared/readme3.txt'), "'/shared/readme3.txt' should sync")
+        assert local.exists('/shared/readme1.txt')
+        assert local.exists('/shared/readme3.txt')

--- a/nuxeo-drive-client/tests/test_local_client.py
+++ b/nuxeo-drive-client/tests/test_local_client.py
@@ -36,52 +36,51 @@ class StubLocalClient(object):
 
     def test_make_documents(self):
         doc_1 = self.local_client_1.make_file('/', 'Document 1.txt')
-        self.assertTrue(self.local_client_1.exists(doc_1))
-        self.assertEqual(self.local_client_1.get_content(doc_1), b'')
+        assert self.local_client_1.exists(doc_1)
+        assert not self.local_client_1.get_content(doc_1)
         doc_1_info = self.local_client_1.get_info(doc_1)
-        self.assertEqual(doc_1_info.name, 'Document 1.txt')
-        self.assertEqual(doc_1_info.path, doc_1)
-        self.assertEqual(doc_1_info.get_digest(), EMPTY_DIGEST)
-        self.assertFalse(doc_1_info.folderish)
+        assert doc_1_info.name == 'Document 1.txt'
+        assert doc_1_info.path == doc_1
+        assert doc_1_info.get_digest() == EMPTY_DIGEST
+        assert not doc_1_info.folderish
 
-        doc_2 = self.local_client_1.make_file('/', 'Document 2.txt',
-                                              content=SOME_TEXT_CONTENT)
-        self.assertTrue(self.local_client_1.exists(doc_2))
-        self.assertEqual(self.local_client_1.get_content(doc_2),
-                         SOME_TEXT_CONTENT)
+        doc_2 = self.local_client_1.make_file(
+            '/', 'Document 2.txt', content=SOME_TEXT_CONTENT)
+        assert self.local_client_1.exists(doc_2)
+        assert self.local_client_1.get_content(doc_2) ==  SOME_TEXT_CONTENT
         doc_2_info = self.local_client_1.get_info(doc_2)
-        self.assertEqual(doc_2_info.name, 'Document 2.txt')
-        self.assertEqual(doc_2_info.path, doc_2)
-        self.assertEqual(doc_2_info.get_digest(), SOME_TEXT_DIGEST)
-        self.assertFalse(doc_2_info.folderish)
+        assert doc_2_info.name == 'Document 2.txt'
+        assert doc_2_info.path == doc_2
+        assert doc_2_info.get_digest() == SOME_TEXT_DIGEST
+        assert not doc_2_info.folderish
 
         self.local_client_1.delete(doc_2)
-        self.assertTrue(self.local_client_1.exists(doc_1))
-        self.assertFalse(self.local_client_1.exists(doc_2))
+        assert self.local_client_1.exists(doc_1)
+        assert not self.local_client_1.exists(doc_2)
 
         folder_1 = self.local_client_1.make_folder('/', 'A new folder')
-        self.assertTrue(self.local_client_1.exists(folder_1))
+        assert self.local_client_1.exists(folder_1)
         folder_1_info = self.local_client_1.get_info(folder_1)
-        self.assertEqual(folder_1_info.name, 'A new folder')
-        self.assertEqual(folder_1_info.path, folder_1)
-        self.assertEqual(folder_1_info.get_digest(), None)
-        self.assertTrue(folder_1_info.folderish)
+        assert folder_1_info.name == 'A new folder'
+        assert folder_1_info.path == folder_1
+        assert not folder_1_info.get_digest()
+        assert folder_1_info.folderish
 
-        doc_3 = self.local_client_1.make_file(folder_1, 'Document 3.txt',
-                                              content=SOME_TEXT_CONTENT)
+        doc_3 = self.local_client_1.make_file(
+            folder_1, 'Document 3.txt', content=SOME_TEXT_CONTENT)
         self.local_client_1.delete(folder_1)
-        self.assertFalse(self.local_client_1.exists(folder_1))
-        self.assertFalse(self.local_client_1.exists(doc_3))
+        assert not self.local_client_1.exists(folder_1)
+        assert not self.local_client_1.exists(doc_3)
 
     def test_get_info_invalid_date(self):
         doc_1 = self.local_client_1.make_file('/', 'Document 1.txt')
         os.utime(self.local_client_1.abspath(
                 os.path.join('/', 'Document 1.txt')), (0, 999999999999999))
         doc_1_info = self.local_client_1.get_info(doc_1)
-        self.assertEqual(doc_1_info.name, 'Document 1.txt')
-        self.assertEqual(doc_1_info.path, doc_1)
-        self.assertEqual(doc_1_info.get_digest(), EMPTY_DIGEST)
-        self.assertFalse(doc_1_info.folderish)
+        assert doc_1_info.name == 'Document 1.txt'
+        assert doc_1_info.path == doc_1
+        assert doc_1_info.get_digest() == EMPTY_DIGEST
+        assert not doc_1_info.folderish
 
     def test_complex_filenames(self):
         # create another folder with the same title
@@ -89,7 +88,7 @@ class StubLocalClient(object):
 
         folder_1 = self.local_client_1.make_folder('/', title_with_accents)
         folder_1_info = self.local_client_1.get_info(folder_1)
-        self.assertEqual(folder_1_info.name, title_with_accents)
+        assert folder_1_info.name == title_with_accents
 
         # create another folder with the same title
         with pytest.raises(DuplicationDisabledError):
@@ -99,21 +98,20 @@ class StubLocalClient(object):
         long_filename = u"\xe9" * 50 + u"%$#!()[]{}+_-=';&^" + u".doc"
         file_1 = self.local_client_1.make_file(folder_1, long_filename)
         file_1 = self.local_client_1.get_info(file_1)
-        self.assertEqual(file_1.name, long_filename)
-        self.assertEqual(file_1.path, folder_1_info.path + u"/" + long_filename)
+        assert file_1.name == long_filename
+        assert file_1.path == folder_1_info.path + u"/" + long_filename
 
         # Create a file with invalid chars
         invalid_filename = u"a/b\\c*d:e<f>g?h\"i|j.doc"
         escaped_filename = u"a-b-c-d-e-f-g-h-i-j.doc"
         file_2 = self.local_client_1.make_file(folder_1, invalid_filename)
         file_2 = self.local_client_1.get_info(file_2)
-        self.assertEqual(file_2.name, escaped_filename)
-        self.assertEqual(
-                file_2.path, folder_1_info.path + u'/' + escaped_filename)
+        assert file_2.name == escaped_filename
+        assert file_2.path == folder_1_info.path + u'/' + escaped_filename
 
+    @pytest.mark.xfail(True, raises=NotFound, reason='Must fail.')
     def test_missing_file(self):
-        with pytest.raises(NotFound):
-            self.local_client_1.get_info('/Something Missing')
+        self.local_client_1.get_info('/Something Missing')
 
     @pytest.mark.timeout(30)
     def test_case_sensitivity(self):
@@ -127,7 +125,7 @@ class StubLocalClient(object):
         else:
             with pytest.raises(DuplicationDisabledError):
                 local.make_file('/', 'ABC.txt')
-        self.assertEqual(len(local.get_children_info('/')), sensitive + 1)
+        assert len(local.get_children_info('/')) == sensitive + 1
 
     @pytest.mark.skipif(
         sys.platform != 'win32',
@@ -148,17 +146,17 @@ class StubLocalClient(object):
         with pytest.raises(DuplicationDisabledError):
             local.make_file('/', short_name)
         path = local.abspath(folder)
-        self.assertEqual(os.path.basename(path), long_name)
+        assert os.path.basename(path) == long_name
 
         # Get the short name
         short = win32api.GetShortPathName(path)
-        self.assertEqual(os.path.basename(short), short_name)
+        assert os.path.basename(short) == short_name
 
         # Sync and check the short name is nowhere
         self.wait_sync()
         children = remote.get_children_info(self.workspace)
-        self.assertTrue(len(children), 1)
-        self.assertEqual(children[0].name, long_name)
+        assert len(children) == 1
+        assert children[0].name == long_name
 
     def test_get_children_info(self):
         folder_1 = self.local_client_1.make_folder('/', 'Folder 1')
@@ -186,10 +184,10 @@ class StubLocalClient(object):
                     '/', 'File 2.txt.LOCK', content=data)
 
         workspace_children = self.local_client_1.get_children_info('/')
-        self.assertEqual(len(workspace_children), 3)
-        self.assertEqual(workspace_children[0].path, file_1)
-        self.assertEqual(workspace_children[1].path, folder_1)
-        self.assertEqual(workspace_children[2].path, folder_2)
+        assert len(workspace_children) == 3
+        assert workspace_children[0].path == file_1
+        assert workspace_children[1].path == folder_1
+        assert workspace_children[2].path == folder_2
 
     def test_deep_folders(self):
         # Check that local client can workaround the default Windows
@@ -200,45 +198,42 @@ class StubLocalClient(object):
 
         # Last Level
         last_level_folder_info = self.local_client_1.get_info(folder)
-        self.assertEqual(last_level_folder_info.path, '/0123456789' * 30)
+        assert last_level_folder_info.path == '/0123456789' * 30
 
         # Create a nested file
-        deep_file = self.local_client_1.make_file(folder, 'File.txt',
-                                                  content=b'Some Content.')
+        deep_file = self.local_client_1.make_file(
+            folder, 'File.txt', content=b'Some Content.')
 
         # Check the consistency of get_children_info and get_info
         deep_file_info = self.local_client_1.get_info(deep_file)
         deep_children = self.local_client_1.get_children_info(folder)
-        self.assertEqual(len(deep_children), 1)
+        assert len(deep_children) == 1
         deep_child_info = deep_children[0]
-        self.assertEqual(deep_file_info.name, deep_child_info.name)
-        self.assertEqual(deep_file_info.path, deep_child_info.path)
-        self.assertEqual(deep_file_info.get_digest(),
-                         deep_child_info.get_digest())
+        assert deep_file_info.name == deep_child_info.name
+        assert deep_file_info.path == deep_child_info.path
+        assert deep_file_info.get_digest() == deep_child_info.get_digest()
 
         # Update the file content
         self.local_client_1.update_content(deep_file, b'New Content.')
-        self.assertEqual(self.local_client_1.get_content(deep_file),
-                         b'New Content.')
+        assert self.local_client_1.get_content(deep_file) == b'New Content.'
 
         # Delete the folder
         self.local_client_1.delete(folder)
-        self.assertFalse(self.local_client_1.exists(folder))
-        self.assertFalse(self.local_client_1.exists(deep_file))
+        assert not self.local_client_1.exists(folder)
+        assert not self.local_client_1.exists(deep_file)
 
         # Delete the root folder and descendants
         self.local_client_1.delete('/0123456789')
-        self.assertFalse(self.local_client_1.exists('/0123456789'))
+        assert not self.local_client_1.exists('/0123456789')
 
     def test_get_new_file(self):
-        path, os_path, name = self.local_client_1.get_new_file('/',
-                                                               'Document 1.txt')
-        self.assertEqual(path, '/Document 1.txt')
-        self.assertTrue(os_path.endswith(os.path.join(self.workspace_title,
-                                                      'Document 1.txt')))
-        self.assertEqual(name, 'Document 1.txt')
-        self.assertFalse(self.local_client_1.exists(path))
-        self.assertFalse(os.path.exists(os_path))
+        path, os_path, name = self.local_client_1.get_new_file(
+            '/', 'Document 1.txt')
+        assert path == '/Document 1.txt'
+        assert os_path.endswith(os.path.join(self.workspace_title, 'Document 1.txt'))
+        assert name == 'Document 1.txt'
+        assert not self.local_client_1.exists(path)
+        assert not os.path.exists(os_path)
 
     def test_xattr(self):
         ref = self.local_client_1.make_file('/', 'File 2.txt', content=b'baz\n')
@@ -246,19 +241,19 @@ class StubLocalClient(object):
         mtime = int(os.path.getmtime(path))
         sleep(1)
         self.local_client_1.set_remote_id(ref, 'TEST')
-        self.assertEqual(mtime, int(os.path.getmtime(path)))
+        assert mtime == int(os.path.getmtime(path))
         sleep(1)
         self.local_client_1.remove_remote_id(ref)
-        self.assertEqual(mtime, int(os.path.getmtime(path)))
+        assert mtime == int(os.path.getmtime(path))
 
     def test_get_path(self):
         doc = 'doc.txt'
         abs_path = os.path.join(
             self.local_nxdrive_folder_1, self.workspace_title, doc)
-        self.assertEqual(self.local_client_1.get_path(abs_path), '/' + doc)
+        assert self.local_client_1.get_path(abs_path) == '/' + doc
 
         # Encoding test
-        self.assertEqual(self.local_client_1.get_path('été.txt'), '/')
+        assert self.local_client_1.get_path('été.txt') == '/'
 
     def test_is_equal_digests(self):
         content = b'joe'
@@ -266,28 +261,28 @@ class StubLocalClient(object):
                                                    content=content)
         local_digest = hashlib.md5(content).hexdigest()
         # Equal digests
-        self.assertTrue(self.local_client_1.is_equal_digests(
-            local_digest, local_digest, local_path))
+        assert self.local_client_1.is_equal_digests(
+            local_digest, local_digest, local_path)
 
         # Different digests with same digest algorithm
         other_content = b'jack'
         remote_digest = hashlib.md5(other_content).hexdigest()
-        self.assertNotEqual(local_digest, remote_digest)
-        self.assertFalse(self.local_client_1.is_equal_digests(
-            local_digest, remote_digest, local_path))
+        assert local_digest != remote_digest
+        assert not self.local_client_1.is_equal_digests(
+            local_digest, remote_digest, local_path)
 
         # Different digests with different digest algorithms but same content
         remote_digest = hashlib.sha1(content).hexdigest()
-        self.assertNotEqual(local_digest, remote_digest)
-        self.assertTrue(self.local_client_1.is_equal_digests(
-            local_digest, remote_digest, local_path))
+        assert local_digest != remote_digest
+        assert self.local_client_1.is_equal_digests(
+            local_digest, remote_digest, local_path)
 
         # Different digests with different digest algorithms and different
         # content
         remote_digest = hashlib.sha1(other_content).hexdigest()
-        self.assertNotEqual(local_digest, remote_digest)
-        self.assertFalse(self.local_client_1.is_equal_digests(
-            local_digest, remote_digest, local_path))
+        assert local_digest != remote_digest
+        assert not self.local_client_1.is_equal_digests(
+            local_digest, remote_digest, local_path)
 
 
 class TestLocalClientNative(StubLocalClient, UnitTestCase):
@@ -345,35 +340,25 @@ class TestLocalClientSimulation(StubLocalClient, UnitTestCase):
         self.engine_1.start()
         self.wait_sync()
 
+    @pytest.mark.xfail(
+        sys.platform == 'win32', raises=IOError,
+        reason='Explorer cannot find the directory as the path is way to long')
     def test_complex_filenames(self):
         """
-        It should fail on Windows:
+        It should fail on Windows: IOError: [Errno 2] No such file or directory
         Explorer cannot find the directory as the path is way to long.
         """
 
-        if sys.platform == 'win32':
-            try:
-                # IOError: [Errno 2] No such file or directory
-                with pytest.raises(IOError):
-                    super(TestLocalClientSimulation,
-                          self).test_complex_filenames()
-            except AssertionError:
-                # Sometimes it does not raise the expected assertion ...
-                # TODO: More tests to know why.
-                pass
-        else:
-            super(TestLocalClientSimulation, self).test_complex_filenames()
+        super(TestLocalClientSimulation, self).test_complex_filenames()
 
+    @pytest.mark.xfail(
+        sys.platform == 'win32', raises=OSError,
+        reason='Explorer cannot deal with very long paths')
     def test_deep_folders(self):
         """
         It should fail on Windows:
+            WindowsError: [Error 206] The filename or extension is too long
         Explorer cannot deal with very long paths.
         """
 
-        if sys.platform == 'win32':
-            # WindowsError: [Error 206] The filename or extension is too long
-            with pytest.raises(OSError) as ex:
-                super(TestLocalClientSimulation, self).test_deep_folders()
-                self.assertEqual(ex.errno, 206)
-        else:
-            super(TestLocalClientSimulation, self).test_deep_folders()
+        super(TestLocalClientSimulation, self).test_deep_folders()

--- a/nuxeo-drive-client/tests/test_local_storage_issue.py
+++ b/nuxeo-drive-client/tests/test_local_storage_issue.py
@@ -49,7 +49,7 @@ class TestLocalStorageSpaceIssue(UnitTestCase):
         self.wait_sync(wait_for_async=True, timeout=10, fail_if_timeout=False, enforce_errors=False)
         # Temporary download file (.nxpart) should be created locally but not renamed then removed
         # Synchronization should not fail: doc pair should be blacklisted and there should be 1 error
-        self.assertNxPart('/', name='test_KO.odt', present=False)
+        self.assertNxPart('/', 'test_KO.odt')
         self.assertFalse(local.exists('/test_KO.odt'))
         states_in_error = self.engine_1.get_dao().get_errors(limit=0)
         self.assertEqual(len(states_in_error), 1)
@@ -80,7 +80,7 @@ class TestLocalStorageSpaceIssue(UnitTestCase):
         self.queue_manager_1.requeue_errors()
         self.wait_sync(timeout=10, fail_if_timeout=False, enforce_errors=False)
         # Doc pair should be blacklisted again and there should still be 1 error
-        self.assertNxPart('/', name='test_KO.odt', present=False)
+        self.assertNxPart('/', 'test_KO.odt')
         self.assertFalse(local.exists('/test_KO.odt'))
         states_in_error = self.engine_1.get_dao().get_errors(limit=0)
         self.assertEqual(len(states_in_error), 1)
@@ -95,7 +95,7 @@ class TestLocalStorageSpaceIssue(UnitTestCase):
         self.queue_manager_1.requeue_errors()
         self.wait_sync(enforce_errors=False)
         # Previously blacklisted file should be created locally and there should be no more errors left
-        self.assertNxPart('/', name='test_KO.odt', present=False)
+        self.assertNxPart('/', 'test_KO.odt')
         self.assertTrue(local.exists('/test_KO.odt'))
         states_in_error = self.engine_1.get_dao().get_errors(limit=0)
         self.assertEqual(len(states_in_error), 0)

--- a/nuxeo-drive-client/tests/test_permission_hierarchy.py
+++ b/nuxeo-drive-client/tests/test_permission_hierarchy.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import hashlib
+import sys
 from urllib2 import HTTPError
 
 import pytest
@@ -156,6 +157,13 @@ class TestPermissionHierarchy(UnitTestCase):
         self.assertIsNone(self.remote_file_system_client_2.get_fs_item(
             folder_b_fs))
 
+    @pytest.mark.xfail(
+        sys.platform == 'win32',
+        reason='Following the NXDRIVE-836 fix, this test always fails because '
+               'when moving a file from a RO folder to a RW folder will end up'
+               ' being a simple file creation. As we cannot know events order,'
+               ' we cannot understand a local move is being made just before '
+               'a security update. To bo fixed with the engine refactoring.')
     def test_sync_move_permission_removal(self):
         local = self.local_client_2
 

--- a/nuxeo-drive-client/tests/test_readonly.py
+++ b/nuxeo-drive-client/tests/test_readonly.py
@@ -1,12 +1,16 @@
 # coding: utf-8
 import os
+import shutil
+import sys
 import time
 from logging import getLogger
-from unittest import skipIf
+from urllib2 import HTTPError
 
-from nxdrive.osi import AbstractOSIntegration
-from tests.common import OS_STAT_MTIME_RESOLUTION, TEST_WORKSPACE_PATH
-from tests.common_unit_test import RandomBug, UnitTestCase
+import pytest
+
+from nxdrive.engine.watcher.local_watcher import WIN_MOVE_RESOLUTION_PERIOD
+from tests.common import TEST_WORKSPACE_PATH
+from tests.common_unit_test import UnitTestCase
 
 log = getLogger(__name__)
 
@@ -14,168 +18,531 @@ log = getLogger(__name__)
 class TestReadOnly(UnitTestCase):
 
     def setUp(self):
-        super(TestReadOnly, self).setUp()
         self.engine_1.start()
         self.wait_sync(wait_for_async=True)
 
-    def _set_readonly_permission(self, user, doc_path, grant):
-        op_input = "doc:" + doc_path
-        if grant:
-            self.root_remote_client.execute("Document.SetACE", op_input=op_input, user=user, permission="Read")
-            self.root_remote_client.block_inheritance(doc_path,
-                                                      overwrite=False)
-        else:
-            self.root_remote_client.execute("Document.SetACE", op_input=op_input, user=user, permission="Write",
-                                            grant="true")
-
-    def test_rename_readonly_file(self):
-        local = self.local_client_1
-        remote = self.remote_document_client_1
-        # Create documents in the remote root workspace
-        # then synchronize
-        remote.make_folder('/', 'Test folder')
-        remote.make_file('/Test folder', 'joe.odt', 'Some content')
-        remote.make_file('/Test folder', 'jack.odt', 'Some content')
-        remote.make_folder('/Test folder', 'Sub folder 1')
-        remote.make_file('/Test folder/Sub folder 1', 'sub file 1.txt',
-                         'Content')
-        self._set_readonly_permission(self.user_1, TEST_WORKSPACE_PATH + '/Test folder', True)
-        self.wait_sync(wait_for_async=True)
-        self.assertTrue(local.exists('/Test folder'))
-        self.assertTrue(local.exists('/Test folder/joe.odt'))
-        self.assertTrue(local.exists('/Test folder/jack.odt'))
-        self.assertTrue(local.exists('/Test folder/Sub folder 1'))
-        self.assertTrue(local.exists('/Test folder/Sub folder 1/sub file 1.txt'))
-
-        # Local changes
-        time.sleep(OS_STAT_MTIME_RESOLUTION)
-        # Create new file
-        # Fake the readonly forcing
-        local.unset_readonly('/Test folder')
-        local.make_file('/Test folder', 'local.odt', 'New local content')
-        # Create new folder with files
-        local.make_folder('/Test folder', 'Local sub folder 2')
-        local.make_file('/Test folder/Local sub folder 2', 'local sub file 2.txt', 'Other local content')
-        # Update file
-        local.unset_readonly('/Test folder/joe.odt')
-        local.update_content('/Test folder/joe.odt', 'Some locally updated content')
-        local.set_readonly('/Test folder/joe.odt')
-        local.set_readonly('/Test folder')
-
-        # TODO Might rollback if rollback only !
-        self.wait_sync()
-        self.assertFalse(remote.exists('/Test folder/local.odt'))
-        self.assertFalse(remote.exists('/Test folder/Local sub folder 2'))
-        self.assertFalse(remote.exists('/Test folder/Local sub folder 2/local sub file 2.txt'))
-        self.assertTrue(local.exists('/Test folder/local.odt'))
-        self.assertEqual(remote.get_content('/Test folder/joe.odt'), 'Some content')
-
-    def touch(self, fname):
+    @staticmethod
+    def touch(fname):
+        dirname = os.path.dirname(fname)
+        if sys.platform == 'win32' and not os.path.isdir(dirname):
+            os.mkdir(dirname)
         try:
             with open(fname, 'w') as f:
                 f.write('Test')
-        except Exception as e:
-            log.debug('Exception occurs during touch: %r', e)
+        except IOError:
+            log.exception('Enable to touch')
             return False
         return True
 
-    @skipIf(AbstractOSIntegration.is_windows(),
-            'Readonly folder let new file creation')
-    def test_readonly_user_access(self):
-        # Should not be able to create content in root folder
-        fname = os.path.join(self.local_nxdrive_folder_1, 'test.txt')
-        self.assertFalse(self.touch(fname), "Should not be able to create in ROOT folder")
-        fname = os.path.join(self.sync_root_folder_1, 'test.txt')
-        self.assertTrue(self.touch(fname), "Should be able to create in SYNCROOT folder")
-        fname = os.path.join(self.sync_root_folder_1, 'Test folder', 'test.txt')
-        self.assertFalse(self.touch(fname), "Should be able to create in SYNCROOT folder")
-        fname = os.path.join(self.sync_root_folder_1, 'Test folder', 'Sub folder 1', 'test.txt')
-        self.assertFalse(self.touch(fname), "Should be able to create in SYNCROOT folder")
+    def test_document_locked(self):
+        """ Check locked documents: they are read-only. """
 
-    @skipIf(AbstractOSIntegration.is_windows(),
-            'Readonly folder let new file creation')
-    @RandomBug('NXDRIVE-816', target='mac', mode='BYPASS')
-    def test_file_readonly_change(self):
-        local = self.local_client_1
-        remote = self.remote_document_client_1
-        # Create documents in the remote root workspace
-        # then synchronize
-        remote.make_folder('/', 'Test folder')
-        remote.make_file('/Test folder', 'joe.odt', 'Some content')
-        remote.make_file('/Test folder', 'jack.odt', 'Some content')
-        remote.make_folder('/Test folder', 'Sub folder 1')
-        remote.make_file('/Test folder/Sub folder 1', 'sub file 1.txt',
-                         'Content')
-        self._set_readonly_permission(self.user_1, TEST_WORKSPACE_PATH + '/Test folder', True)
-        self.wait_sync(wait_for_async=True)
-        self.assertTrue(local.exists('/Test folder'))
-        self.assertTrue(local.exists('/Test folder/joe.odt'))
-        self.assertTrue(local.exists('/Test folder/jack.odt'))
-        self.assertTrue(local.exists('/Test folder/Sub folder 1'))
-        self.assertTrue(local.exists('/Test folder/Sub folder 1/sub file 1.txt'))
-
-        # Update the content on the server
-        self.root_remote_client.update_content(TEST_WORKSPACE_PATH + '/Test folder/joe.odt',
-                                               'Some remotely updated content', 'joe.odt')
-        self.wait_sync(wait_for_async=True)
-        self.assertTrue(local.get_content('/Test folder/joe.odt'), 'Some remotely updated content')
-
-        # Remove the readonly
-        self._set_readonly_permission(self.user_1, TEST_WORKSPACE_PATH + '/Test folder', False)
-        self.wait_sync(wait_for_async=True)
-        fname = os.path.join(self.sync_root_folder_1, 'Test folder', 'test.txt')
-        fname2 = os.path.join(self.sync_root_folder_1, 'Test folder', 'Sub folder 1', 'test.txt')
-        # Check it works
-        self.assertTrue(self.touch(fname))
-        self.assertTrue(self.touch(fname2))
-
-        # First remove the files
-        os.remove(fname)
-        os.remove(fname2)
-        # Put it back readonly
-        self._set_readonly_permission(self.user_1, TEST_WORKSPACE_PATH + '/Test folder', True)
-        self.wait_sync(wait_for_async=True)
-
-        # Check it works
-        self.assertFalse(self.touch(fname))
-        self.assertFalse(self.touch(fname2))
-
-    def test_locked_document(self):
         remote = self.remote_document_client_1
         remote.make_folder('/', 'Test locking')
         remote.make_file('/Test locking', 'myDoc.odt', 'Some content')
         self.wait_sync(wait_for_async=True)
 
         # Check readonly flag is not set for a document that isn't locked
-        user1_file_path = os.path.join(self.sync_root_folder_1, 'Test locking', 'myDoc.odt')
-        self.assertTrue(os.path.exists(user1_file_path))
-        self.assertTrue(self.touch(user1_file_path))
+        user1_file_path = os.path.join(
+            self.sync_root_folder_1, 'Test locking', 'myDoc.odt')
+        assert os.path.exists(user1_file_path)
+        assert self.touch(user1_file_path)
         self.wait_sync()
 
-        # Check readonly flag is not set for a document locked by the current user
+        # Check readonly flag is not set for a document locked by the
+        # current user
         remote.lock('/Test locking/myDoc.odt')
         self.wait_sync(wait_for_async=True)
-        self.assertTrue(self.touch(user1_file_path))
+        assert self.touch(user1_file_path)
         remote.unlock('/Test locking/myDoc.odt')
         self.wait_sync(wait_for_async=True)
 
         # Check readonly flag is set for a document locked by another user
         self.remote_document_client_2.lock('/Test locking/myDoc.odt')
         self.wait_sync(wait_for_async=True)
-        self.assertFalse(self.touch(user1_file_path))
+        assert not self.touch(user1_file_path)
 
         # Check readonly flag is unset for a document unlocked by another user
         self.remote_document_client_2.unlock('/Test locking/myDoc.odt')
         self.wait_sync(wait_for_async=True)
-        self.assertTrue(self.touch(user1_file_path))
+        assert self.touch(user1_file_path)
 
-    def test_local_readonly_modify(self):
+    def test_file_add(self):
+        """
+        Should not be able to create files in root folder.
+        On Windows, those files are ignored.
+        """
+
+        remote = self.remote_document_client_1
+
+        # Try to create the file
+        state = self.touch(os.path.join(self.local_nxdrive_folder_1, 'test.txt'))
+
+        if sys.platform != 'win32':
+            # The creation must have failed
+            assert not state
+        else:
+            # The file is locally created and should be ignored
+            self.wait_sync(wait_for_async=True)
+            ignored = self.engine_1.get_dao().get_unsynchronizeds()
+            assert len(ignored) == 1
+            assert ignored[0].local_path == '/test.txt'
+
+            # Check there is nothing uploaded to the server
+            assert not remote.get_children_info('/')
+
+    def test_file_content_change(self):
+        """
+        No upload server side but possible to change the file locally
+        without error, if the OS allowes it (unlikely).
+        """
+
         local = self.local_client_1
-        local.make_folder('/', 'Test')
-        local.make_file('/Test', 'Test.txt', 'Some content')
+        remote = self.remote_document_client_1
+
+        # Create documents and sync
+        folder = remote.make_folder('/', 'folder')
+        remote.make_file(folder, 'foo.txt', content=b'42')
+        self.set_readonly(self.user_1, TEST_WORKSPACE_PATH + '/folder')
+        self.wait_sync(wait_for_async=True)
+        assert remote.exists('/folder')
+        assert remote.exists('/folder/foo.txt')
+
+        # Try to change the file content locally
+        with pytest.raises(IOError):
+            with open(local.abspath('/folder/foo.txt'), 'w') as handler:
+                handler.write(b'Change')
+
+        with pytest.raises(IOError):
+            local.update_content('/folder/foo.txt', b'Locally changed')
+
+        # Try to change the file content remotely
+        with pytest.raises(HTTPError):
+            remote.update_content('/folder/foo.txt', 'Remotely changed')
+
+    def test_file_delete(self):
+        """ Local deletions are filtered. """
+
+        remote = self.remote_document_client_1
+        local = self.local_client_1
+
+        folder = remote.make_folder('/', 'test-ro')
+        remote.make_file(folder, 'test.txt', content=b'42')
+        self.set_readonly(self.user_1, TEST_WORKSPACE_PATH + '/test-ro')
+        self.wait_sync(wait_for_async=True)
+        assert local.exists('/test-ro/test.txt')
+        assert not self.engine_1.get_dao().get_filters()
+
+        # Delete the file and check if is re-downloaded
+        local.unset_readonly('/test-ro')
+        local.delete('/test-ro/test.txt')
+        if sys.platform == 'win32':
+            time.sleep((WIN_MOVE_RESOLUTION_PERIOD // 1000) + 1)
         self.wait_sync()
-        self.engine_1.stop()
-        local.update_content('/Test/Test.txt', 'Another content')
-        self.engine_1.start()
+        assert not local.exists('/test-ro/test.txt')
+
+        # Check that it is filtered
+        assert self.engine_1.get_dao().get_filters()
+
+        # Check the file is still present on the server
+        assert remote.exists('/test-ro/test.txt')
+
+    def test_file_move_from_ro_to_ro(self):
+        """
+        Local moves from a read-only folder to a read-only folder.
+          - source is ignored
+          - destination is ignored
+
+        Server side: no changes.
+        Client side: no errors.
+        """
+
+        remote = self.remote_document_client_1
+        local = self.local_client_1
+
+        # folder-src is the source from where documents will be moved, RO
+        # folder-dst is the destination where documents will be moved, RO
+        src = local.make_folder('/', 'folder-src')
+        dst = local.make_folder('/', 'folder-dst')
+        local.make_file('/folder-src', 'here.txt', content=b'stay here')
         self.wait_sync()
-        self.assertEqual(len(self.engine_1.get_dao().get_errors()), 0)
+        assert remote.exists('/folder-src/here.txt')
+        assert remote.exists('/folder-dst')
+
+        self.set_readonly(self.user_1, TEST_WORKSPACE_PATH)
+        self.wait_sync(wait_for_async=True)
+
+        doc_abs = os.path.join(local.abspath(src), 'here.txt')
+        dst_abs = local.abspath(dst)
+        if sys.platform != 'win32':
+            # The move should fail
+            with pytest.raises(IOError):
+                shutil.move(doc_abs, dst_abs)
+        else:
+            # The move happens
+            shutil.move(doc_abs, dst_abs)
+            time.sleep((WIN_MOVE_RESOLUTION_PERIOD // 1000) + 1)
+            self.wait_sync()
+
+            # Check that nothing has changed
+            assert not local.exists('/folder-src/here.txt')
+            assert local.exists('/folder-dst/here.txt')
+            assert remote.exists('/folder-src/here.txt')
+
+            # But also, check that the server received nothing
+            assert not remote.exists('/folder-dst/here.txt')
+
+            # We should not have any error
+            assert not self.engine_1.get_dao().get_errors(limit=0)
+
+    def test_file_move_from_ro_to_rw(self):
+        """
+        Local moves from a read-only folder to a read-write folder.
+          - source is ignored
+          - destination is seen as a creation
+
+        Server side: only the files in the RW folder are created.
+        Client side: no errors.
+
+        Associated ticket: NXDRIVE-836
+        """
+
+        remote = self.remote_document_client_1
+        local = self.local_client_1
+
+        # folder-ro is the source from where documents will be moved, RO
+        # folder-rw is the destination where documents will be moved, RW
+        src = local.make_folder('/', 'folder-ro')
+        dst = local.make_folder('/', 'folder-rw')
+        local.make_file('/folder-ro', 'here.txt', content=b'stay here')
+        self.wait_sync()
+        assert remote.exists('/folder-ro/here.txt')
+        assert remote.exists('/folder-rw')
+
+        self.set_readonly(self.user_1, TEST_WORKSPACE_PATH + '/folder-ro')
+        self.wait_sync(wait_for_async=True)
+
+        doc_abs = os.path.join(local.abspath(src), 'here.txt')
+        dst_abs = local.abspath(dst)
+        if sys.platform != 'win32':
+            # The move should fail
+            with pytest.raises(OSError):
+                shutil.move(doc_abs, dst_abs)
+        else:
+            # The move happens
+            shutil.move(doc_abs, dst_abs)
+            time.sleep((WIN_MOVE_RESOLUTION_PERIOD // 1000) + 1)
+            self.wait_sync()
+
+            # Check that nothing has changed
+            assert not local.exists('/folder-ro/here.txt')
+            assert local.exists('/folder-rw/here.txt')
+            assert remote.exists('/folder-ro/here.txt')
+
+            # But also, check that the server received the new document because
+            # the destination is RW
+            assert remote.exists('/folder-rw/here.txt')
+
+            # We should not have any error
+            assert not self.engine_1.get_dao().get_errors(limit=0)
+
+    @pytest.mark.skip(True, reason='TODO NXDRIVE-740')
+    def test_file_move_from_rw_to_ro(self): pass
+
+    def test_file_rename(self):
+        """
+        No upload server side but possible to rename the file locally
+        without error.
+        """
+
+        local = self.local_client_1
+        remote = self.remote_document_client_1
+
+        # Create documents and sync
+        folder = local.make_folder('/', 'folder')
+        local.make_file('/folder', 'foo.txt', content=b'42')
+        self.wait_sync()
+        assert remote.exists('/folder')
+        assert remote.exists('/folder/foo.txt')
+
+        # Set read-only
+        self.set_readonly(self.user_1, TEST_WORKSPACE_PATH + '/folder')
+        self.wait_sync(wait_for_async=True)
+
+        # Locally rename the file
+        doc = os.path.join(local.abspath(folder), 'foo.txt')
+        dst = os.path.join(local.abspath(folder), 'bar.txt')
+        if sys.platform != 'win32':
+            # The rename should fail
+            with pytest.raises(OSError):
+                os.rename(doc, dst)
+        else:
+            # The rename happens locally but nothing remotely
+            os.rename(doc, dst)
+            self.wait_sync()
+            assert remote.exists('/folder/foo.txt')
+            assert not remote.exists('/folder/bar.txt')
+
+            # We should not have any error
+            assert not self.engine_1.get_dao().get_errors(limit=0)
+
+    def test_folder_add(self):
+        """
+        Should not be able to create folders in root folder.
+        On Windows, those folders are ignored.
+        """
+
+        remote = self.remote_document_client_1
+        folder = os.path.join(self.local_nxdrive_folder_1, 'foo', 'test.txt')
+
+        if sys.platform != 'win32':
+            # The creation must have failed
+            assert not self.touch(folder)
+        else:
+            # The folder and its child are locally created
+            self.touch(folder)
+
+            # Sync and check that it is ignored
+            self.wait_sync(wait_for_async=True)
+            ignored = [d.local_path
+                       for d in self.engine_1.get_dao().get_unsynchronizeds()]
+            assert list(sorted(ignored)) == ['/foo', '/foo/test.txt']
+
+            # Check there is nothing uploaded to the server
+            assert not remote.get_children_info('/')
+
+    def test_folder_delete(self):
+        """ Local deletions are filtered. """
+
+        remote = self.remote_document_client_1
+        local = self.local_client_1
+
+        folder = remote.make_folder('/', 'test-ro')
+        remote.make_folder(folder, 'foo')
+        self.set_readonly(self.user_1, TEST_WORKSPACE_PATH + '/test-ro')
+        self.wait_sync(wait_for_async=True)
+        assert local.exists('/test-ro/foo')
+        assert not self.engine_1.get_dao().get_filters()
+
+        # Delete the file and check if is re-downloaded
+        local.unset_readonly('/test-ro')
+        local.delete('/test-ro/foo')
+        if sys.platform == 'win32':
+            time.sleep((WIN_MOVE_RESOLUTION_PERIOD // 1000) + 1)
+        self.wait_sync()
+        assert not local.exists('/test-ro/foo')
+
+        # Check that it is filtered
+        assert self.engine_1.get_dao().get_filters()
+
+        # Check the file is still present on the server
+        assert remote.exists('/test-ro/foo')
+
+    def test_folder_move_from_ro_to_ro(self):
+        """
+        Local moves from a read-only folder to a read-only folder.
+          - source is ignored
+          - destination is ignored
+
+        Server side: no changes.
+        Client side: no errors.
+        """
+
+        remote = self.remote_document_client_1
+        local = self.local_client_1
+
+        # folder-src is the source that will be moved, RO
+        # folder-dst is the destination, RO
+        folder_ro1 = remote.make_folder('/', 'folder-src')
+        folder_ro2 = remote.make_folder('/', 'folder-dst')
+        remote.make_file(folder_ro1, 'here.txt', content=b'stay here')
+        remote.make_file(folder_ro2, 'there.txt', content=b'stay here too')
+        self.set_readonly(self.user_1, TEST_WORKSPACE_PATH)
+        self.wait_sync(wait_for_async=True)
+        assert local.exists('/folder-src/here.txt')
+        assert remote.exists('/folder-dst')
+
+        src = local.abspath('/folder-src')
+        dst = local.abspath('/folder-dst')
+        if sys.platform != 'win32':
+            # The move should fail
+            with pytest.raises(OSError):
+                shutil.move(src, dst)
+        else:
+            # The move happens
+            shutil.move(src, dst)
+            time.sleep((WIN_MOVE_RESOLUTION_PERIOD // 1000) + 1)
+            self.wait_sync()
+
+            # Check that nothing has changed
+            assert not local.exists('/folder-src')
+            assert local.exists('/folder-dst/there.txt')
+            assert local.exists('/folder-dst/folder-src/here.txt')
+            assert remote.exists('/folder-src/here.txt')
+            assert remote.exists('/folder-dst/there.txt')
+
+            # But also, check that the server received nothing
+            assert not remote.exists('/folder-dst/folder-src')
+
+            # We should not have any error
+            assert not self.engine_1.get_dao().get_errors(limit=0)
+
+    def test_folder_move_from_ro_to_rw(self):
+        """
+        Local moves from a read-only folder to a read-write folder.
+          - source is ignored
+          - destination is filtered
+
+        Server side: no changes.
+        Client side: no errors.
+        """
+
+        remote = self.remote_document_client_1
+        local = self.local_client_1
+
+        # folder-src is the source that will be moved, RO
+        # folder-dst is the destination, RO
+        folder_ro1 = remote.make_folder('/', 'folder-src')
+        folder_ro2 = remote.make_folder('/', 'folder-dst')
+        remote.make_file(folder_ro1, 'here.txt', content=b'stay here')
+        remote.make_file(folder_ro2, 'there.txt', content=b'stay here too')
+        self.set_readonly(self.user_1, TEST_WORKSPACE_PATH)
+        self.wait_sync(wait_for_async=True)
+        assert local.exists('/folder-src/here.txt')
+        assert remote.exists('/folder-dst')
+
+        src = local.abspath('/folder-src')
+        dst = local.abspath('/folder-dst')
+        if sys.platform != 'win32':
+            # The move should fail
+            with pytest.raises(OSError):
+                shutil.move(src, dst)
+        else:
+            # The move happens
+            shutil.move(src, dst)
+            time.sleep((WIN_MOVE_RESOLUTION_PERIOD // 1000) + 1)
+            self.wait_sync()
+
+            # Check that nothing has changed
+            assert not local.exists('/folder-src')
+            assert local.exists('/folder-dst/there.txt')
+            assert local.exists('/folder-dst/folder-src/here.txt')
+            assert remote.exists('/folder-src/here.txt')
+            assert remote.exists('/folder-dst/there.txt')
+            assert not remote.exists('/folder-dst/folder-src')
+            assert not remote.exists('/folder-dst/folder-src/here.txt')
+
+            # We should not have any error
+            assert not self.engine_1.get_dao().get_errors(limit=0)
+
+            # Check that it is filtered
+            assert self.engine_1.get_dao().get_filters()
+            doc_pair = remote.get_info(folder_ro1)
+            root_path = (
+                '/org.nuxeo.drive.service.impl.DefaultTopLevelFolderItemFactory#'
+                '/defaultSyncRootFolderItemFactory#default#'
+                '{}/defaultFileSystemItemFactory#default#{}')
+            ref = root_path.format(doc_pair.root, doc_pair.uid)
+            assert self.engine_1.get_dao().is_filter(ref)
+
+    @pytest.mark.skip(True, reason='TODO NXDRIVE-740')
+    def test_folder_move_from_rw_to_ro(self): pass
+
+    def test_folder_rename(self):
+        """
+        No upload server side but possible to rename the folder locally
+        without error, and it will be re-renamed.
+        """
+
+        local = self.local_client_1
+        remote = self.remote_document_client_1
+
+        # Create documents and sync
+        folder = local.make_folder('/', 'foo')
+        self.wait_sync()
+        assert remote.exists('/foo')
+
+        # Set read-only
+        self.set_readonly(self.user_1, TEST_WORKSPACE_PATH)
+        self.wait_sync(wait_for_async=True)
+
+        # Check can_delete flag in pair state
+        state = self.get_dao_state_from_engine_1('/foo')
+        assert not state.remote_can_delete
+
+        # Locally rename the folder
+        src = local.abspath(folder)
+        dst = os.path.join(os.path.dirname(src), 'bar')
+        if sys.platform != 'win32':
+            # The rename should fail
+            with pytest.raises(OSError):
+                os.rename(src, dst)
+        else:
+            # The rename happens locally but:
+            #     - nothing remotely
+            #     - the folder is re-renamed to its original name
+            os.rename(src, dst)
+            self.wait_sync()
+            assert local.exists('/foo')
+            assert not local.exists('/bar')
+            assert remote.exists('/foo')
+            assert not remote.exists('/bar')
+
+            # We should not have any error
+            assert not self.engine_1.get_dao().get_errors(limit=0)
+
+    @pytest.mark.skipif(
+        sys.platform != 'win32',
+        reason='Windows only.')
+    def test_nxdrive_836(self):
+        """
+        NXDRIVE-836: Bad behaviors with read-only documents on Windows.
+
+Scenario:
+
+1. User1: Server: Create folder "ReadFolder" and share with User2 with read
+   permission and upload doc/xml files into it
+2. User1: Server: Create folder "MEFolder" and share with User2 with Manage
+   Everything permission
+3. User2: Server: Enable Nuxeo Drive Synchronization for both folders
+4. User2: Client: Launch Drive client and Wait for sync completion
+5. User2: Client: Move the files(drag and drop) from "ReadFolder" to "MEFolder"
+6. User1: Server: Remove the read permission for "ReadFolder" for User2
+7. User2: Client: Remove the read only attribue for moved files in "MEFolder"
+   and Edit the files.
+
+Expected Result: Files should sync with the server.
+        """
+
+        local = self.local_client_1
+        remote = self.remote_document_client_1
+
+        # Create documents and sync
+        remote.make_folder('/', 'ReadFolder')
+        remote.make_folder('/', 'MEFolder')
+        remote.make_file('/ReadFolder', 'shareme.doc', content=b'Scheherazade')
+        self.set_readonly(self.user_1, TEST_WORKSPACE_PATH + '/ReadFolder')
+        self.wait_sync(wait_for_async=True)
+
+        # Checks
+        for client in (remote, local):
+            for doc in ('/ReadFolder/shareme.doc', '/MEFolder'):
+                assert client.exists(doc)
+
+        # Move
+        src = local.abspath('/ReadFolder/shareme.doc')
+        dst = local.abspath('/MEFolder')
+        shutil.move(src, dst)
+        time.sleep((WIN_MOVE_RESOLUTION_PERIOD // 1000) + 1)
+        self.wait_sync()
+
+        # Remove read-only
+        self.set_readonly(self.user_1, TEST_WORKSPACE_PATH + '/ReadFolder', grant=False)
+        self.wait_sync(wait_for_async=True)
+        local.unset_readonly('/MEFolder/shareme.doc')
+
+        # Checks
+        assert remote.exists('/ReadFolder/shareme.doc')
+        assert remote.exists('/MEFolder/shareme.doc')
+        assert not self.engine_1.get_dao().get_errors(limit=0)
+        assert not self.engine_1.get_dao().get_unsynchronizeds()

--- a/nuxeo-drive-client/tests/test_synchronization.py
+++ b/nuxeo-drive-client/tests/test_synchronization.py
@@ -970,6 +970,24 @@ class TestSynchronization(UnitTestCase):
         self.assertEqual(children[0].name, file1)
         self.assertEqual(children[1].name, file2)
 
+    def test_local_modify_offline(self):
+        local = self.local_client_1
+        engine = self.engine_1
+
+        engine.start()
+        self.wait_sync(wait_for_async=True)
+
+        local.make_folder('/', 'Test')
+        local.make_file('/Test', 'Test.txt', 'Some content')
+        self.wait_sync()
+
+        engine.stop()
+        local.update_content('/Test/Test.txt', 'Another content')
+
+        engine.start()
+        self.wait_sync()
+        assert not engine.get_dao().get_errors()
+
     def test_unsynchronize_accentued_document(self):
         remote = self.remote_document_client_1
         local = self.local_client_1

--- a/nuxeo-drive-client/tests/test_windows.py
+++ b/nuxeo-drive-client/tests/test_windows.py
@@ -101,7 +101,7 @@ class TestWindows(UnitTestCase):
             #   modified
             # - Synchronization should not fail: doc pairs should be
             #   blacklisted and other remote modifications should be locally synchronized
-            self.assertNxPart('/', name='test_update.docx', present=False)
+            self.assertNxPart('/', 'test_update.docx')
             self.assertTrue(local.exists('/test_update.docx'))
             self.assertEqual(local.get_content('/test_update.docx'),
                              'Some content to update.')
@@ -116,7 +116,7 @@ class TestWindows(UnitTestCase):
             self.wait_sync(enforce_errors=False, fail_if_timeout=False)
             # Blacklisted files should be ignored as delay (60 seconds by
             # default) is not expired, nothing should have changed
-            self.assertNxPart('/', name='test_update.docx', present=False)
+            self.assertNxPart('/', 'test_update.docx')
             self.assertTrue(local.exists('/test_update.docx'))
             self.assertEqual(local.get_content('/test_update.docx'),
                              'Some content to update.')
@@ -137,13 +137,13 @@ class TestWindows(UnitTestCase):
             self.assertTrue(local.exists('/test_update.docx'))
             self.assertEqual(local.get_content('/test_update.docx'),
                              'Updated content.')
-            self.assertNxPart('/', name='test_update.docx', present=False)
+            self.assertNxPart('/', 'test_update.docx')
             self.assertFalse(local.exists('/test_delete.docx'))
         else:
             self.assertTrue(local.exists('/test_update.docx'))
             self.assertEqual(local.get_content('/test_update.docx'),
                              'Updated content.')
-            self.assertNxPart('/', name='test_update.docx', present=False)
+            self.assertNxPart('/', 'test_update.docx')
             self.assertFalse(local.exists('/test_delete.docx'))
 
     @unittest.skipUnless(sys.platform == 'win32', 'Windows only.')


### PR DESCRIPTION
Alos:
- Framework: Review LocalWatcher class, better use of lock
- Updater: Updated minimum server version from 5.6 to 7.10
- \[Windows\] Jenkins: Added `-direct` argument to the deploy script to prevent downloading any dependency
