### PR TITLE
NXDRIVE-1104: Set invalid credentials on 401,403 errors only

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -11,7 +11,10 @@ Release date: `2018-??-??`
 - [NXDRIVE-887](https://jira.nuxeo.com/browse/NXDRIVE-887): Integrate SonarCloud code quality check
 
 #### Minor changes
+- Doc: Add a link to get for up-to-date envvars value
+- Framework: Review EngineNext class
 - Jenkins: Discard old builds
+- Tests: Add a simple test for .rvt files
 
 
 # 3.0.4

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -5,6 +5,7 @@ Release date: `2018-??-??`
 - [NXDRIVE-941](https://jira.nuxeo.com/browse/NXDRIVE-941): Use a context manager for Lock
 - [NXDRIVE-1085](https://jira.nuxeo.com/browse/NXDRIVE-1085): Review the Auto-Lock feature
 - [NXDRIVE-1087](https://jira.nuxeo.com/browse/NXDRIVE-1087): Remove backward compatibility code for Nuxeo <= 5.8
+- [NXDRIVE-1104](https://jira.nuxeo.com/browse/NXDRIVE-1104): Set invalid credentials on 401,403 errors only
 
 ### Tests
 - [NXDRIVE-887](https://jira.nuxeo.com/browse/NXDRIVE-887): Integrate SonarCloud code quality check

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -82,6 +82,8 @@ Each build can be driven by several envars.
 
 If an envar is specifying a version, this means that the specified version of the library/software sources will be downloaded from the official website and compiled to fit Drive needs. It allows to create full isolated and reproductible build environnements.
 
+__Important__: those values are given as example, if you want up-to-date ones, pick them from [tools/checksums.txt](https://github.com/nuxeo/nuxeo-drive/blob/master/tools/checksums.txt).
+
 ### Required Envars
 
 - `PYTHON_DRIVE_VERSION` is the required **Python version** to use, i.e. `2.7.13`.

--- a/docs/technical_changes.md
+++ b/docs/technical_changes.md
@@ -4,6 +4,7 @@
 
 # dev
 - Removed `CLIHandler.edit()`
+- Removed `exception` keyword argument from `Engine.set_invalid_credentials()`
 - Removed `Manager.edit()`
 - Removed `Manager.get_autolock_service()`. Use `autolock_service` attribute instead.
 - Removed `Manager.get_tracker()`

--- a/docs/technical_changes.md
+++ b/docs/technical_changes.md
@@ -11,6 +11,7 @@
 - Changed `ProcessAutoLockerWorker.__init__(..., manager, watched_folders=None)` to `ProcessAutoLockerWorker.__init__(..., dao, folder)`
 - Removed `ProcessAutoLockerWorker.get_open_files()`
 - Removed `WindowsIntegration.get_open_files()`
+- Removed osi/\_\_init__.py::`get_open_files()`
 - Removed osi/windows/win32_handlers.py
 
 # 3.0.4

--- a/nuxeo-drive-client/nxdrive/engine/engine.py
+++ b/nuxeo-drive-client/nxdrive/engine/engine.py
@@ -765,7 +765,7 @@ class Engine(QObject):
         if self._remote_token is None:
             raise Exception
         self._dao.update_config("remote_token", self._remote_token)
-        self.set_invalid_credentials(False)
+        self.set_invalid_credentials(value=False)
         self.invalidate_client_cache()
         # In case of a binding
         self._check_root()
@@ -775,7 +775,8 @@ class Engine(QObject):
         self._load_configuration()
         self._remote_token = token
         self._dao.update_config("remote_token", self._remote_token)
-        self.set_invalid_credentials(False)
+        self.set_invalid_credentials(value=False)
+        self.invalidate_client_cache()
         self.start()
 
     def bind(self, binder):

--- a/nuxeo-drive-client/nxdrive/engine/engine.py
+++ b/nuxeo-drive-client/nxdrive/engine/engine.py
@@ -974,7 +974,7 @@ class Engine(QObject):
             return None
 
         cache = self._get_client_cache()
-        cache_key = self._manager.device_id, filtered
+        cache_key = (self._manager.device_id, filtered)
         remote_client = cache.get(cache_key)
 
         if remote_client is None:

--- a/nuxeo-drive-client/nxdrive/engine/engine.py
+++ b/nuxeo-drive-client/nxdrive/engine/engine.py
@@ -487,14 +487,14 @@ class Engine(QObject):
             initialized=True,
             pwd_update_required=self.has_invalid_credentials())
 
-    def set_invalid_credentials(self, value=True, reason=None, exception=None):
+    def set_invalid_credentials(self, value=True, reason=None):
         changed = self._invalid_credentials != value
         self._invalid_credentials = value
         if value and changed:
             msg = 'Setting invalid credentials'
-            if reason is not None:
+            if reason:
                 msg += ', reason is: %s' % reason
-            log.error(msg, exc_info=exception is not None)
+            log.error(msg)
             self.invalidAuthentication.emit()
 
     def has_invalid_credentials(self):

--- a/nuxeo-drive-client/nxdrive/engine/next/engine_next.py
+++ b/nuxeo-drive-client/nxdrive/engine/next/engine_next.py
@@ -2,25 +2,14 @@
 """ Evolution to try new engine solution. """
 
 from logging import getLogger
-from nxdrive.client.remote_document_client import RemoteDocumentClient
-from nxdrive.client.remote_file_system_client import RemoteFileSystemClient
-from nxdrive.client.remote_filtered_file_system_client import \
-    RemoteFilteredFileSystemClient
+
 from nxdrive.engine.engine import Engine
-from nxdrive.options import Options
 
 log = getLogger(__name__)
 
 
 class EngineNext(Engine):
-
-    def __init__(self, manager, definition, binder=None, processors=5,
-                 remote_doc_client_factory=RemoteDocumentClient,
-                 remote_fs_client_factory=RemoteFileSystemClient,
-                 remote_filtered_fs_client_factory=RemoteFilteredFileSystemClient):
-        super(EngineNext, self).__init__(manager, definition, binder, processors,
-                 remote_doc_client_factory, remote_fs_client_factory, remote_filtered_fs_client_factory)
-        self._type = "NXDRIVENEXT"
+    type = 'NXDRIVENEXT'
 
     def create_processor(self, item_getter, name=None):
         from nxdrive.engine.next.processor import Processor
@@ -28,6 +17,8 @@ class EngineNext(Engine):
 
     def _create_queue_manager(self, processors):
         from nxdrive.engine.next.queue_manager import QueueManager
+        from nxdrive.options import Options
+
         if Options.debug:
             return QueueManager(self, self._dao, max_file_processors=2)
         return QueueManager(self, self._dao)

--- a/nuxeo-drive-client/nxdrive/engine/watcher/remote_watcher.py
+++ b/nuxeo-drive-client/nxdrive/engine/watcher/remote_watcher.py
@@ -454,6 +454,7 @@ class RemoteWatcher(EngineWorker):
             # Being there means invalid credentials
             self._engine.set_offline()
             return None
+
         if self._engine.is_offline():
             try:
                 # Try to get the server status
@@ -461,10 +462,12 @@ class RemoteWatcher(EngineWorker):
 
                 # If retrieved
                 self._engine.set_offline(value=False)
+                return self._client
             except ThreadInterrupt as e:
                 raise e
             except:
                 return None
+
         return self._client
 
     def _handle_changes(self, first_pass=False):

--- a/nuxeo-drive-client/nxdrive/engine/watcher/remote_watcher.py
+++ b/nuxeo-drive-client/nxdrive/engine/watcher/remote_watcher.py
@@ -482,10 +482,12 @@ class RemoteWatcher(EngineWorker):
                 self._action = Action('Remote scanning')
                 self._scan_remote()
                 self._end_action()
+
                 # Might need to handle the changes now
                 if first_pass:
                     self.initiate.emit()
                 return True
+
             full_scan = self._dao.get_config('remote_need_full_scan', None)
             if full_scan is not None:
                 self._partial_full_scan(full_scan)
@@ -499,10 +501,7 @@ class RemoteWatcher(EngineWorker):
                 paths = self._dao.get_paths_to_scan()
             self._action = Action('Handle remote changes')
             self._update_remote_states()
-            if first_pass:
-                self.initiate.emit()
-            else:
-                self.updated.emit()
+            (self.updated, self.initiate)[first_pass].emit()
         except HTTPError as e:
             err = 'HTTP error %d while trying to handle remote changes' % e.code
             if e.code in (401, 403):

--- a/nuxeo-drive-client/nxdrive/engine/workers.py
+++ b/nuxeo-drive-client/nxdrive/engine/workers.py
@@ -206,14 +206,6 @@ class EngineWorker(Worker):
     def _reset_clients(self):
         pass
 
-    def _clean(self, reason, e=None):
-        if isinstance(e, HTTPError) and e.code == 401:
-            reason = 'got HTTPError %d while cleaning EngineWorker "%s"' % \
-                     (e.code, self._name)
-            self._engine.set_invalid_credentials(reason=reason, exception=e)
-            self._reset_clients()
-        self._engine.get_dao().dispose_thread()
-
     def giveup_error(self, doc_pair, error, exception=None):
         details = repr(exception) if exception else None
         log.debug('Give up for error [%s] (%r) for %r', error, details, doc_pair)

--- a/nuxeo-drive-client/nxdrive/notification.py
+++ b/nuxeo-drive-client/nxdrive/notification.py
@@ -407,7 +407,8 @@ class InvalidCredentialNotification(Notification):
             description='',
             engine_uid=engine_uid,
             level=Notification.LEVEL_ERROR,
-            flags=(Notification.FLAG_VOLATILE
+            flags=(Notification.FLAG_UNIQUE
+                   | Notification.FLAG_PERSISTENT
                    | Notification.FLAG_BUBBLE
                    | Notification.FLAG_ACTIONABLE
                    | Notification.FLAG_SYSTRAY),

--- a/nuxeo-drive-client/nxdrive/notification.py
+++ b/nuxeo-drive-client/nxdrive/notification.py
@@ -408,7 +408,7 @@ class InvalidCredentialNotification(Notification):
             engine_uid=engine_uid,
             level=Notification.LEVEL_ERROR,
             flags=(Notification.FLAG_UNIQUE
-                   | Notification.FLAG_PERSISTENT
+                   | Notification.FLAG_VOLATILE
                    | Notification.FLAG_BUBBLE
                    | Notification.FLAG_ACTIONABLE
                    | Notification.FLAG_SYSTRAY),

--- a/nuxeo-drive-client/nxdrive/notification.py
+++ b/nuxeo-drive-client/nxdrive/notification.py
@@ -407,8 +407,7 @@ class InvalidCredentialNotification(Notification):
             description='',
             engine_uid=engine_uid,
             level=Notification.LEVEL_ERROR,
-            flags=(Notification.FLAG_UNIQUE
-                   | Notification.FLAG_VOLATILE
+            flags=(Notification.FLAG_VOLATILE
                    | Notification.FLAG_BUBBLE
                    | Notification.FLAG_ACTIONABLE
                    | Notification.FLAG_SYSTRAY),

--- a/nuxeo-drive-client/nxdrive/osi/__init__.py
+++ b/nuxeo-drive-client/nxdrive/osi/__init__.py
@@ -140,19 +140,6 @@ class AbstractOSIntegration(object):
     def get_system_configuration(self):
         return dict()
 
-    def get_open_files(self, pids=None):
-        # Default implementation using psutil
-        res = []
-        for p in psutil.process_iter():
-            try:
-                if pids is not None and p._pid not in pids:
-                    continue
-                for f in p.open_files():
-                    res.append((p._pid, f[0]))
-            except (psutil.AccessDenied, psutil.ZombieProcess):
-                pass
-        return res
-
     @staticmethod
     def os_version_below(version):
         return version_compare(AbstractOSIntegration.get_os_version(), version) < 0

--- a/nuxeo-drive-client/tests/test_utils.py
+++ b/nuxeo-drive-client/tests/test_utils.py
@@ -125,6 +125,8 @@ class TestUtils(unittest.TestCase):
         # Unknown
         self.assertEqual(guess_mime_type('file.unknown'),
                          'application/octet-stream')
+        self.assertEqual(guess_mime_type('file.rvt'),
+                         'application/octet-stream')
 
         # Cases badly handled by Windows
         # See https://jira.nuxeo.com/browse/NXP-11660


### PR DESCRIPTION
The systray icon will no longer being red when a HTTP error is not a real credentials one.