### PR TITLE
NXDRIVE-1105: Avoid unwanted file deletions on Windows 7

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -3,6 +3,7 @@ Release date: `2018-??-??`
 
 ### Core
 - [NXDRIVE-941](https://jira.nuxeo.com/browse/NXDRIVE-941): Use a context manager for Lock
+- [NXDRIVE-1009](https://jira.nuxeo.com/browse/NXDRIVE-1009): Some folders not deleted on client when file is open
 - [NXDRIVE-1062](https://jira.nuxeo.com/browse/NXDRIVE-1062): Fix encoding for string comparisons on macOS
 - [NXDRIVE-1085](https://jira.nuxeo.com/browse/NXDRIVE-1085): Review the Auto-Lock feature
 - [NXDRIVE-1087](https://jira.nuxeo.com/browse/NXDRIVE-1087): Remove backward compatibility code for Nuxeo <= 5.8

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -9,6 +9,7 @@ Release date: `2018-??-??`
 - [NXDRIVE-1091](https://jira.nuxeo.com/browse/NXDRIVE-1091): Create the tooltip decorator
 - [NXDRIVE-1098](https://jira.nuxeo.com/browse/NXDRIVE-1098): Auto-Lock does not work when there are orphans
 - [NXDRIVE-1104](https://jira.nuxeo.com/browse/NXDRIVE-1104): Set invalid credentials on 401,403 errors only
+- [NXDRIVE-1105](https://jira.nuxeo.com/browse/NXDRIVE-1105): Avoid unwanted file deletions on Windows 7
 
 ### GUI
 - [NXDRIVE-1106](https://jira.nuxeo.com/browse/NXDRIVE-1106): Use new branding icons

--- a/nuxeo-drive-client/nxdrive/__init__.py
+++ b/nuxeo-drive-client/nxdrive/__init__.py
@@ -12,6 +12,7 @@ Contributors:
     Antoine Taillefer
     Rémi Cattiau
     Mickaël Schoentgen <mschoentgen@nuxeo.com>
+    Léa Klein <lklein@nuxeo.com>
     and https://github.com/nuxeo/nuxeo-drive/graphs/contributors
 
 Versionning

--- a/nuxeo-drive-client/nxdrive/data/ui5/i18n.js
+++ b/nuxeo-drive-client/nxdrive/data/ui5/i18n.js
@@ -390,7 +390,9 @@ LABELS={
     "URL": "URL",
     "USERNAME": "Username",
     "WEB_AUTHENTICATION_WINDOW_TITLE": "Nuxeo Drive - Web Authentication",
-    "WELCOME_MESSAGE": "Set your account and synchronize your files with the Nuxeo Platform."
+    "WELCOME_MESSAGE": "Set your account and synchronize your files with the Nuxeo Platform.",
+    "WINDOWS_ERROR": "Windows Error",
+    "WINDOWS_ERROR_OPENED_FILE": "Another software is blocking any action on the document „{{ name }}“. Please, close it."
   },
   "es": {
     "ABOUT": "Acerca de",

--- a/nuxeo-drive-client/nxdrive/engine/dao/sqlite.py
+++ b/nuxeo-drive-client/nxdrive/engine/dao/sqlite.py
@@ -16,41 +16,41 @@ SCHEMA_VERSION = "schema_version"
 # (local_state, remote_state)
 PAIR_STATES = {
     # regular cases
-    ('unknown', 'unknown'): 'unknown',
-    ('synchronized', 'synchronized'): 'synchronized',
     ('created', 'unknown'): 'locally_created',
-    ('unknown', 'created'): 'remotely_created',
+    ('deleted', 'deleted'): 'deleted',
+    ('deleted', 'synchronized'): 'locally_deleted',
     ('modified', 'synchronized'): 'locally_modified',
-    ('moved', 'synchronized'): 'locally_moved',
+    ('modified', 'unknown'): 'locally_modified',
     ('moved', 'deleted'): 'locally_moved_created',
     ('moved', 'modified'): 'locally_moved_remotely_modified',
-    ('synchronized', 'modified'): 'remotely_modified',
-    ('modified', 'unknown'): 'locally_modified',
-    ('unknown', 'modified'): 'remotely_modified',
-    ('deleted', 'synchronized'): 'locally_deleted',
+    ('moved', 'synchronized'): 'locally_moved',
     ('synchronized', 'deleted'): 'remotely_deleted',
-    ('deleted', 'deleted'): 'deleted',
+    ('synchronized', 'modified'): 'remotely_modified',
+    ('synchronized', 'synchronized'): 'synchronized',
     ('synchronized', 'unknown'): 'synchronized',
+    ('unknown', 'created'): 'remotely_created',
+    ('unknown', 'modified'): 'remotely_modified',
+    ('unknown', 'unknown'): 'unknown',
 
     # conflicts with automatic resolution
     ('created', 'deleted'): 'locally_created',
     ('deleted', 'created'): 'remotely_created',
-    ('modified', 'deleted'): 'remotely_deleted',
     ('deleted', 'modified'): 'remotely_created',
+    ('modified', 'deleted'): 'remotely_deleted',
 
     # conflict cases that need manual resolution
-    ('modified', 'modified'): 'conflicted',
     ('created', 'created'): 'conflicted',
     ('created', 'modified'): 'conflicted',
-    ('moved', 'unknown'): 'conflicted',
+    ('modified', 'modified'): 'conflicted',
     ('moved', 'moved'): 'conflicted',
+    ('moved', 'unknown'): 'conflicted',
 
     # conflict cases that have been manually resolved
     ('resolved', 'unknown'): 'locally_resolved',
 
     # inconsistent cases
-    ('unknown', 'deleted'): 'unknown_deleted',
     ('deleted', 'unknown'): 'deleted_unknown',
+    ('unknown', 'deleted'): 'unknown_deleted',
 }
 
 
@@ -93,6 +93,10 @@ class StateRow(sqlite3.Row):
             return self[name]
         except IndexError:
             return None
+
+    @property
+    def pair_state(self):
+        return PAIR_STATES.get((self.local_state, self.remote_state))
 
     def is_readonly(self):
         if self.folderish:
@@ -679,9 +683,6 @@ class EngineDAO(ConfigurationDAO):
         else:
             log.trace("Will not push pair: %s, pair=%r", pair_state, pair)
 
-    def _get_pair_state(self, row):
-        return PAIR_STATES.get((row.local_state, row.remote_state))
-
     def update_last_transfer(self, row_id, transfer):
         with self._lock:
             con = self._get_write_connection()
@@ -704,7 +705,6 @@ class EngineDAO(ConfigurationDAO):
                 con.commit()
 
     def update_local_state(self, row, info, versionned=True, queue=True):
-        row.pair_state = self._get_pair_state(row)
         log.trace('Updating local state for row=%r with info=%r', row, info)
 
         version = ''
@@ -981,7 +981,7 @@ class EngineDAO(ConfigurationDAO):
         return c.execute("SELECT * FROM States WHERE local_path=?", (path,)).fetchone()
 
     def insert_remote_state(self, info, remote_parent_path, local_path, local_parent_path):
-        pair_state = PAIR_STATES.get(('unknown','created'))
+        pair_state = PAIR_STATES.get(('unknown', 'created'))
         with self._lock:
             con = self._get_write_connection()
             c = con.cursor()
@@ -1112,7 +1112,6 @@ class EngineDAO(ConfigurationDAO):
         # Set default states to synchronized, if wanted
         if not dynamic_states:
             row.local_state = row.remote_state = 'synchronized'
-        row.pair_state = self._get_pair_state(row)
 
         with self._lock:
             con = self._get_write_connection()
@@ -1187,7 +1186,6 @@ class EngineDAO(ConfigurationDAO):
         return result
 
     def update_remote_state(self, row, info, remote_parent_path=None, versionned=True, queue=True, force_update=False, no_digest=False):
-        row.pair_state = self._get_pair_state(row)
         if remote_parent_path is None:
             remote_parent_path = row.remote_parent_path
 
@@ -1207,7 +1205,6 @@ class EngineDAO(ConfigurationDAO):
                 # It looks similar
                 if info.digest in (row.local_digest, row.remote_digest):
                     row.remote_state = 'synchronized'
-                    row.pair_state = self._get_pair_state(row)
                 if info.digest == row.remote_digest and not force_update:
                     log.trace('Not updating remote state (not dirty)'
                               ' for row=%r with info=%r', row, info)
@@ -1224,7 +1221,6 @@ class EngineDAO(ConfigurationDAO):
             # documents (a move on both sides) nor with newly remotely
             # created ones.
             row.remote_state = 'modified'
-            row.pair_state = self._get_pair_state(row)
 
         version = ''
         if versionned:

--- a/nuxeo-drive-client/nxdrive/engine/engine.py
+++ b/nuxeo-drive-client/nxdrive/engine/engine.py
@@ -102,6 +102,7 @@ class Engine(QObject):
     _start = pyqtSignal()
     _stop = pyqtSignal()
     _scanPair = pyqtSignal(str)
+    errorOpenedFile = pyqtSignal(object)
     syncStarted = pyqtSignal(object)
     syncCompleted = pyqtSignal()
     # Sent when files are in blacklist but the rest is ok

--- a/nuxeo-drive-client/nxdrive/engine/processor.py
+++ b/nuxeo-drive-client/nxdrive/engine/processor.py
@@ -663,8 +663,8 @@ class Processor(EngineWorker):
             return
 
         if doc_pair.remote_can_delete:
-            log.debug('Deleting or unregistering remote document %r (%s)', doc_pair.remote_name,
-                      doc_pair.remote_ref)
+            log.debug('Deleting or unregistering remote document %r (%s)[%s]',
+                      doc_pair.remote_name, doc_pair.remote_ref, doc_pair.pair_state)
             if doc_pair.pair_state == 'locally_deleted':
                 remote_client.delete(doc_pair.remote_ref, parent_fs_item_id=doc_pair.remote_parent_ref)
             self._dao.remove_state(doc_pair)

--- a/nuxeo-drive-client/nxdrive/manager.py
+++ b/nuxeo-drive-client/nxdrive/manager.py
@@ -542,7 +542,7 @@ class Manager(QtCore.QObject):
         for uid, engine in self._engines.items():
             if euid is not None and euid != uid:
                 continue
-            log.debug("Resume engine %s", uid)
+            log.debug('Resume engine %s', uid)
             engine.resume()
         self.resumed.emit()
 
@@ -553,7 +553,7 @@ class Manager(QtCore.QObject):
         for uid, engine in self._engines.items():
             if euid is not None and euid != uid:
                 continue
-            log.debug("Suspend engine %s", uid)
+            log.debug('Suspend engine %s', uid)
             engine.suspend()
         self.suspended.emit()
 
@@ -562,7 +562,7 @@ class Manager(QtCore.QObject):
             if euid is not None and euid != uid:
                 continue
             if engine.is_started():
-                log.debug("Stop engine %s", uid)
+                log.debug('Stop engine %s', uid)
                 engine.stop()
         self.stopped.emit()
 
@@ -573,12 +573,12 @@ class Manager(QtCore.QObject):
                 continue
             if not self._pause:
                 self.aboutToStart.emit(engine)
-                log.debug("Launch engine %s", uid)
+                log.debug('Launch engine %s', uid)
                 try:
                     engine.start()
-                except Exception as e:
-                    log.debug("Could not start the engine: %s [%r]", uid, e)
-        log.debug("Emitting started")
+                except:
+                    log.exception('Could not start the engine %s', uid)
+
         # Check only if manager is started
         self._handle_os()
         self.started.emit()

--- a/nuxeo-drive-client/nxdrive/notification.py
+++ b/nuxeo-drive-client/nxdrive/notification.py
@@ -399,6 +399,20 @@ class DirectEditUpdatedNotification(Notification):
         )
 
 
+class ErrorOpenedFile(Notification):
+    def __init__(self, path):
+        values = {'name': path}
+        super(ErrorOpenedFile, self).__init__(
+            'WINDOWS_ERROR',
+            title=Translator.get('WINDOWS_ERROR'),
+            description=Translator.get('WINDOWS_ERROR_OPENED_FILE', values),
+            level=Notification.LEVEL_ERROR,
+            flags=(Notification.FLAG_UNIQUE
+                   | Notification.FLAG_VOLATILE
+                   | Notification.FLAG_BUBBLE),
+        )
+
+
 class InvalidCredentialNotification(Notification):
     def __init__(self, engine_uid):
         super(InvalidCredentialNotification, self).__init__(
@@ -419,6 +433,8 @@ class DefaultNotificationService(NotificationService):
     def __init__(self, manager):
         super(DefaultNotificationService, self).__init__(manager)
         self._manager = manager
+
+    def init_signals(self):
         self._manager.initEngine.connect(self._connect_engine)
         self._manager.newEngine.connect(self._connect_engine)
         self._manager.direct_edit.directEditLockError.connect(self._directEditLockError)
@@ -435,6 +451,10 @@ class DefaultNotificationService(NotificationService):
         engine.newLocked.connect(self._newLocked)
         engine.invalidAuthentication.connect(self._invalidAuthentication)
         engine.online.connect(self._validAuthentication)
+        engine.errorOpenedFile.connect(self._errorOpenedFile)
+
+    def _errorOpenedFile(self, local_path):
+        self.send_notification(ErrorOpenedFile(unicode(local_path)))
 
     def _lockDocument(self, filename):
         self.send_notification(LockNotification(filename))

--- a/nuxeo-drive-client/nxdrive/notification.py
+++ b/nuxeo-drive-client/nxdrive/notification.py
@@ -3,7 +3,7 @@ import time
 from logging import getLogger
 from threading import Lock
 
-from PyQt4 import QtCore
+from PyQt4.QtCore import QObject, pyqtSignal
 
 from nxdrive.wui.translator import Translator
 
@@ -15,25 +15,33 @@ class Notification(object):
     LEVEL_WARNING = 'warning'
     LEVEL_ERROR = 'danger'
 
-    # FLAG VALUE
     # Discard notification
     FLAG_DISCARD = 1
-    # Unique ( not depending on time ), only one by type/engine is displayed
+
+    # Unique (not depending on time), only one by type/engine is displayed
     FLAG_UNIQUE = 2
+
     # Can be closed by the user
     FLAG_DISCARDABLE = 4
+
     # Will not be stored when sent
     FLAG_VOLATILE = 8
+
     # Will be stored in the db
     FLAG_PERSISTENT = 16
+
     # Will be display as systray bubble or notification center
     FLAG_BUBBLE = 32
+
     # Will be displayed inside the systray menu
     FLAG_SYSTRAY = 64
+
     # An event will be triggered on click
     FLAG_ACTIONABLE = 128
-    # Delete the notifciation on discard
+
+    # Delete the notification on discard
     FLAG_REMOVE_ON_DISCARD = 256
+
     # Discard on trigger
     FLAG_DISCARD_ON_TRIGGER = 512
 
@@ -136,10 +144,10 @@ class Notification(object):
             self.level, self.title, self.uid, self.is_unique())
 
 
-class NotificationService(QtCore.QObject):
+class NotificationService(QObject):
 
-    newNotification = QtCore.pyqtSignal(object)
-    discardNotification = QtCore.pyqtSignal(object)
+    newNotification = pyqtSignal(object)
+    discardNotification = pyqtSignal(object)
 
     def __init__(self, manager):
         super(NotificationService, self).__init__()
@@ -175,6 +183,7 @@ class NotificationService(QtCore.QObject):
             return result
 
     def send_notification(self, notification):
+        log.trace('Sending %r', notification)
         notification._time = int(time.time())
         with self._lock:
             if notification.is_persistent():
@@ -418,7 +427,6 @@ class InvalidCredentialNotification(Notification):
         super(InvalidCredentialNotification, self).__init__(
             'INVALID_CREDENTIALS',
             title=Translator.get('INVALID_CREDENTIALS'),
-            description='',
             engine_uid=engine_uid,
             level=Notification.LEVEL_ERROR,
             flags=(Notification.FLAG_UNIQUE
@@ -502,11 +510,9 @@ class DefaultNotificationService(NotificationService):
 
     def _validAuthentication(self):
         engine_uid = self.sender().uid
-        log.debug('discard_notification: ' + 'INVALID_CREDENTIALS_' + engine_uid)
         self.discard_notification('INVALID_CREDENTIALS_' + engine_uid)
 
     def _invalidAuthentication(self):
         engine_uid = self.sender().uid
         notif = InvalidCredentialNotification(engine_uid)
-        log.debug('send_notification: ' + notif.uid)
         self.send_notification(notif)

--- a/nuxeo-drive-client/tests/test_watchers.py
+++ b/nuxeo-drive-client/tests/test_watchers.py
@@ -133,7 +133,7 @@ class TestWatchers(UnitTestCase):
         children = self.engine_1.get_dao().get_states_from_partial_local(path)
         self.assertEqual(len(children), 5)
         for child in children:
-            self.assertEqual(child.pair_state, 'parent_locally_deleted')
+            self.assertEqual(child.pair_state, 'locally_deleted')
 
     def test_local_scan_delete_synced(self):
         # Test the deletion after first local scan
@@ -147,7 +147,7 @@ class TestWatchers(UnitTestCase):
         children = self.engine_1.get_dao().get_states_from_partial_local(path)
         self.assertEqual(len(children), 5)
         for child in children:
-            self.assertEqual(child.pair_state, 'parent_locally_deleted')
+            self.assertEqual(child.pair_state, 'locally_deleted')
 
     def test_local_scan_error(self):
         local = self.local_client_1

--- a/nuxeo-drive-client/tests/test_windows.py
+++ b/nuxeo-drive-client/tests/test_windows.py
@@ -95,13 +95,10 @@ class TestWindows(UnitTestCase):
         if sys.platform == 'win32':
             # As local file are locked, a WindowsError should occur during the
             # local update process, therefore:
-            # - Temporary download file (.part) should be created locally but
-            #   not renamed then removed
             # - Opened local files should still exist and not have been
             #   modified
             # - Synchronization should not fail: doc pairs should be
             #   blacklisted and other remote modifications should be locally synchronized
-            self.assertNxPart('/', 'test_update.docx')
             self.assertTrue(local.exists('/test_update.docx'))
             self.assertEqual(local.get_content('/test_update.docx'),
                              'Some content to update.')
@@ -116,7 +113,6 @@ class TestWindows(UnitTestCase):
             self.wait_sync(enforce_errors=False, fail_if_timeout=False)
             # Blacklisted files should be ignored as delay (60 seconds by
             # default) is not expired, nothing should have changed
-            self.assertNxPart('/', 'test_update.docx')
             self.assertTrue(local.exists('/test_update.docx'))
             self.assertEqual(local.get_content('/test_update.docx'),
                              'Some content to update.')
@@ -137,7 +133,6 @@ class TestWindows(UnitTestCase):
             self.assertTrue(local.exists('/test_update.docx'))
             self.assertEqual(local.get_content('/test_update.docx'),
                              'Updated content.')
-            self.assertNxPart('/', 'test_update.docx')
             self.assertFalse(local.exists('/test_delete.docx'))
         else:
             self.assertTrue(local.exists('/test_update.docx'))


### PR DESCRIPTION
So, when a folder/file is blocked because of another process using it, we delay the action for 60 secondes and notify the user. There will be no error and the action will be done when the user will close the software using that document or one of its children.

That commit may fix others issues from the epic https://jira.nuxeo.com/browse/NXDRIVE-1089, will check then.

Also:
- NXDRIVE-1009: Some folders not deleted on client when file is open
- ease future transition to Qt 5 in `notifications.py`