### PR TITLE
NXBT-1744 fix discardoldbuild jenkinsfile

### DIFF
--- a/tools/jenkins/tests-8.10.groovy
+++ b/tools/jenkins/tests-8.10.groovy
@@ -9,8 +9,7 @@ pyqt_version = '4.12.1'  // XXX: PYQT_VERSION
 properties([
     disableConcurrentBuilds(),
     pipelineTriggers([[$class: 'TimerTrigger', spec: '@midnight']]),
-    [$class: 'BuildDiscarderProperty', strategy:
-        [$class: 'LogRotator', daysToKeepStr: '60', numToKeepStr: '60', artifactNumToKeepStr: '1']],
+    [$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', daysToKeepStr: '60', numToKeepStr: '60', artifactNumToKeepStr: '1']],
     [$class: 'SchedulerPreference', preferEvenload: true],
     [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],
     [$class: 'ParametersDefinitionProperty', parameterDefinitions: [


### PR DESCRIPTION
NXBT-1744 fix discardoldbuild jenkinsfile 
The changes made before have not been applied during the build. The Builddiscarder/logrotator classes have to be inline. 