### PR TITLE
NXDRIVE-1105: Avoid unwanted file deletions on Windows 7

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -10,6 +10,7 @@ Release date: `2018-??-??`
 - [NXDRIVE-1091](https://jira.nuxeo.com/browse/NXDRIVE-1091): Create the tooltip decorator
 - [NXDRIVE-1098](https://jira.nuxeo.com/browse/NXDRIVE-1098): Auto-Lock does not work when there are orphans
 - [NXDRIVE-1104](https://jira.nuxeo.com/browse/NXDRIVE-1104): Set invalid credentials on 401,403 errors only
+- [NXDRIVE-1105](https://jira.nuxeo.com/browse/NXDRIVE-1105): Avoid unwanted file deletions on Windows 7
 - [NXDRIVE-1114](https://jira.nuxeo.com/browse/NXDRIVE-1114): Add server information to analytics
 
 ### GUI

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -3,6 +3,7 @@ Release date: `2018-??-??`
 
 ### Core
 - [NXDRIVE-941](https://jira.nuxeo.com/browse/NXDRIVE-941): Use a context manager for Lock
+- [NXDRIVE-1009](https://jira.nuxeo.com/browse/NXDRIVE-1009): Some folders not deleted on client when file is open
 - [NXDRIVE-1062](https://jira.nuxeo.com/browse/NXDRIVE-1062): Fix encoding for string comparisons on macOS
 - [NXDRIVE-1085](https://jira.nuxeo.com/browse/NXDRIVE-1085): Review the Auto-Lock feature
 - [NXDRIVE-1087](https://jira.nuxeo.com/browse/NXDRIVE-1087): Remove backward compatibility code for Nuxeo <= 5.8

--- a/nuxeo-drive-client/nxdrive/__init__.py
+++ b/nuxeo-drive-client/nxdrive/__init__.py
@@ -12,6 +12,7 @@ Contributors:
     Antoine Taillefer
     Rémi Cattiau
     Mickaël Schoentgen <mschoentgen@nuxeo.com>
+    Léa Klein <lklein@nuxeo.com>
     and https://github.com/nuxeo/nuxeo-drive/graphs/contributors
 
 Versionning

--- a/nuxeo-drive-client/nxdrive/client/local_client.py
+++ b/nuxeo-drive-client/nxdrive/client/local_client.py
@@ -721,6 +721,7 @@ FolderType=Generic
     def delete_final(self, ref):
         # type: (Text) -> None
 
+        global error
         error = None
 
         def onerror(func, path, exc_info):

--- a/nuxeo-drive-client/nxdrive/client/local_client.py
+++ b/nuxeo-drive-client/nxdrive/client/local_client.py
@@ -722,7 +722,6 @@ FolderType=Generic
         # type: (Text) -> None
 
         error = None
-        global error
 
         def onerror(func, path, exc_info):
             """ Assign the error only once. """

--- a/nuxeo-drive-client/nxdrive/data/ui5/i18n.js
+++ b/nuxeo-drive-client/nxdrive/data/ui5/i18n.js
@@ -390,7 +390,9 @@ LABELS={
     "URL": "URL",
     "USERNAME": "Username",
     "WEB_AUTHENTICATION_WINDOW_TITLE": "Nuxeo Drive - Web Authentication",
-    "WELCOME_MESSAGE": "Set your account and synchronize your files with the Nuxeo Platform."
+    "WELCOME_MESSAGE": "Set your account and synchronize your files with the Nuxeo Platform.",
+    "WINDOWS_ERROR": "Windows Error",
+    "WINDOWS_ERROR_OPENED_FILE": "Another software is blocking any action on the document „{{ name }}“. Please, close it."
   },
   "es": {
     "ABOUT": "Acerca de",

--- a/nuxeo-drive-client/nxdrive/data/ui5/i18n.js
+++ b/nuxeo-drive-client/nxdrive/data/ui5/i18n.js
@@ -392,7 +392,8 @@ LABELS={
     "WEB_AUTHENTICATION_WINDOW_TITLE": "Nuxeo Drive - Web Authentication",
     "WELCOME_MESSAGE": "Set your account and synchronize your files with the Nuxeo Platform.",
     "WINDOWS_ERROR": "Windows Error",
-    "WINDOWS_ERROR_OPENED_FILE": "Another software is blocking any action on the document „{{ name }}“. Please, close it."
+    "WINDOWS_ERROR_OPENED_FILE": "Another software is blocking any action on the file „{{ name }}“. Please, close it.",
+    "WINDOWS_ERROR_OPENED_FOLDER": "Another software is blocking any action on the folder „{{ name }}“ or its children. Please, close it."
   },
   "es": {
     "ABOUT": "Acerca de",

--- a/nuxeo-drive-client/nxdrive/engine/engine.py
+++ b/nuxeo-drive-client/nxdrive/engine/engine.py
@@ -102,6 +102,7 @@ class Engine(QObject):
     _start = pyqtSignal()
     _stop = pyqtSignal()
     _scanPair = pyqtSignal(str)
+    errorOpenedFile = pyqtSignal(object)
     syncStarted = pyqtSignal(object)
     syncCompleted = pyqtSignal()
     # Sent when files are in blacklist but the rest is ok

--- a/nuxeo-drive-client/nxdrive/engine/engine.py
+++ b/nuxeo-drive-client/nxdrive/engine/engine.py
@@ -102,7 +102,7 @@ class Engine(QObject):
     _start = pyqtSignal()
     _stop = pyqtSignal()
     _scanPair = pyqtSignal(str)
-    errorOpenedFile = pyqtSignal(object)
+    errorOpenedFile = pyqtSignal(object, bool)
     syncStarted = pyqtSignal(object)
     syncCompleted = pyqtSignal()
     # Sent when files are in blacklist but the rest is ok

--- a/nuxeo-drive-client/nxdrive/engine/processor.py
+++ b/nuxeo-drive-client/nxdrive/engine/processor.py
@@ -281,6 +281,27 @@ class Processor(EngineWorker):
                 except CorruptedFile as exc:
                     self.increase_error(doc_pair, 'CORRUPT', exception=exc)
                     continue
+                except OSError as exc:
+                    # Try to handle different kind of Windows error
+                    errno = getattr(exc, 'winerror', exc.errno)
+                    if errno == 2:
+                        """
+                        WindowsError: [Error 2] The specified file is not found
+                        """
+                        log.debug('The document does not exist anymore: %r', doc_pair)
+                        self._dao.remove_state(doc_pair)
+                    elif errno == 32:
+                        """
+                        WindowsError: [Error 32] The process cannot access the
+                        file because it is being used by another process
+                        """
+                        log.debug('Delaying WindowsError on %r', doc_pair)
+                        self._engine.errorOpenedFile.emit(doc_pair.local_path)
+                        self._postpone_pair(doc_pair, 'Used by another process')
+                    else:
+                        self._handle_pair_handler_exception(
+                            doc_pair, handler_name, exc)
+                    continue
                 except Exception as exc:
                     self._handle_pair_handler_exception(
                         doc_pair, handler_name, exc)
@@ -425,9 +446,10 @@ class Processor(EngineWorker):
     def _postpone_pair(self, doc_pair, reason='', interval=None):
         """ Wait 60 sec for it. """
 
-        log.trace("Postpone creation of local file(%s): %r", reason, doc_pair)
+        log.trace('Postpone action on document(%s): %r', reason, doc_pair)
         doc_pair.error_count = 1
-        self._engine.get_queue_manager().push_error(doc_pair, exception=None, interval=interval)
+        self._engine.get_queue_manager().push_error(
+            doc_pair, exception=None, interval=interval)
 
     def _synchronize_locally_resolved(self, doc_pair, local_client, remote_client):
         """ NXDRIVE-766: processes a locally resolved conflict. """
@@ -832,7 +854,6 @@ class Processor(EngineWorker):
                     log.debug('No local impact of metadata update on'
                               ' document %r.', doc_pair.remote_name)
                 else:
-                    updated_info = None
                     file_or_folder = 'folder' if doc_pair.folderish else 'file'
                     if doc_pair.folderish:
                         self._engine.set_local_folder_lock(doc_pair.local_path)
@@ -844,7 +865,7 @@ class Processor(EngineWorker):
                         old_path = doc_pair.local_path
                         new_path = new_parent_pair.local_path + '/' + moved_name
                         if old_path == new_path:
-                            log.debug('WRONG GUESS FOR MOVE: %r', doc_pair)
+                            log.debug('Wrong guess for move: %r', doc_pair)
                             self._is_remote_move(doc_pair)
                             self._dao.synchronize_state(doc_pair)
 
@@ -889,20 +910,17 @@ class Processor(EngineWorker):
                         self._refresh_local_state(doc_pair, updated_info)
             self._handle_readonly(local_client, doc_pair)
             self._dao.synchronize_state(doc_pair)
-        except (IOError, OSError) as e:
-            log.warning(
-                'Delaying local update of remotely modified content %r due to'
-                'concurrent file access (probably opened by another process).',
-                doc_pair)
-            raise OSError(repr(e), locals())
         finally:
-            try:
-                os.remove(self.tmp_file)
-            except (TypeError, OSError):
-                pass
             if doc_pair.folderish:
                 # Release folder lock in any case
                 self._engine.release_folder_lock()
+
+        if not self.tmp_file:
+            return
+        try:
+            os.remove(self.tmp_file)
+        except OSError:
+            pass
 
     def _synchronize_remotely_created(self, doc_pair, local_client, remote_client):
         name = doc_pair.remote_name
@@ -1034,16 +1052,6 @@ class Processor(EngineWorker):
                     local_client.delete_final(doc_pair.local_path)
             self._dao.remove_state(doc_pair)
             self._search_for_dedup(doc_pair)
-        except (IOError, OSError) as e:
-            # Under Windows deletion can be impossible while another
-            # process is accessing the same file (e.g. word processor)
-            # TODO: be more specific as detecting this case:
-            # shall we restrict to the case e.errno == 13 ?
-            log.warning(
-                'Delaying local deletion of remotely deleted item %r due to'
-                ' concurrent file access (probably opened by another process).',
-                doc_pair)
-            raise e
         finally:
             if doc_pair.folderish:
                 self._engine.release_folder_lock()

--- a/nuxeo-drive-client/nxdrive/engine/processor.py
+++ b/nuxeo-drive-client/nxdrive/engine/processor.py
@@ -295,8 +295,9 @@ class Processor(EngineWorker):
                         WindowsError: [Error 32] The process cannot access the
                         file because it is being used by another process
                         """
-                        log.debug('Delaying WindowsError on %r', doc_pair)
-                        self._engine.errorOpenedFile.emit(doc_pair.local_path)
+                        log.info('Document used by another software, delaying'
+                                 ' action on %r', doc_pair)
+                        self._engine.errorOpenedFile.emit(doc_pair.local_path, doc_pair.folderish)
                         self._postpone_pair(doc_pair, 'Used by another process')
                     else:
                         self._handle_pair_handler_exception(

--- a/nuxeo-drive-client/nxdrive/engine/processor.py
+++ b/nuxeo-drive-client/nxdrive/engine/processor.py
@@ -288,7 +288,8 @@ class Processor(EngineWorker):
                         """
                         WindowsError: [Error 2] The specified file is not found
                         """
-                        log.debug('The document does not exist anymore: %r', doc_pair)
+                        log.debug('The document does not exist anymore: %r',
+                                  doc_pair)
                         self._dao.remove_state(doc_pair)
                     elif errno == 32:
                         """
@@ -297,7 +298,8 @@ class Processor(EngineWorker):
                         """
                         log.info('Document used by another software, delaying'
                                  ' action on %r', doc_pair)
-                        self._engine.errorOpenedFile.emit(doc_pair.local_path, doc_pair.folderish)
+                        self._engine.errorOpenedFile.emit(
+                            doc_pair.local_path, doc_pair.folderish)
                         self._postpone_pair(doc_pair, 'Used by another process')
                     else:
                         self._handle_pair_handler_exception(

--- a/nuxeo-drive-client/nxdrive/notification.py
+++ b/nuxeo-drive-client/nxdrive/notification.py
@@ -75,9 +75,9 @@ class Notification(object):
         self.uid = uid
         if uid is not None:
             if engine_uid is not None:
-                self.uid = self.uid + '_' + engine_uid
+                self.uid += '_' + engine_uid
             if not self.is_unique():
-                self.uid = self.uid + '_' + str(int(time.time()))
+                self.uid += '_' + str(int(time.time()))
         else:
             self.uid = uuid
 
@@ -126,9 +126,6 @@ class Notification(object):
         if engine_uid:
             result += '_' + engine_uid
         return result
-
-    def get_type(self):
-        return self._type
 
     def get_replacements(self):
         return self._replacements
@@ -261,7 +258,6 @@ class LockNotification(Notification):
             'LOCK',
             title=Translator.get('LOCK_NOTIFICATION_TITLE', values),
             description=Translator.get('LOCK_NOTIFICATION_DESCRIPTION', values),
-            level=Notification.LEVEL_INFO,
             flags=(Notification.FLAG_VOLATILE
                    | Notification.FLAG_BUBBLE
                    | Notification.FLAG_DISCARD_ON_TRIGGER
@@ -400,7 +396,6 @@ class DirectEditUpdatedNotification(Notification):
             'DIRECT_EDIT_UPDATED',
             title=Translator.get('UPDATED', values),
             description=Translator.get('DIRECT_EDIT_UPDATED_FILE', values),
-            level=Notification.LEVEL_INFO,
             flags=(Notification.FLAG_VOLATILE
                    | Notification.FLAG_BUBBLE
                    | Notification.FLAG_DISCARD_ON_TRIGGER

--- a/nuxeo-drive-client/nxdrive/notification.py
+++ b/nuxeo-drive-client/nxdrive/notification.py
@@ -409,12 +409,13 @@ class DirectEditUpdatedNotification(Notification):
 
 
 class ErrorOpenedFile(Notification):
-    def __init__(self, path):
+    def __init__(self, path, is_folder):
         values = {'name': path}
+        msg = ('FILE', 'FOLDER')[is_folder]
         super(ErrorOpenedFile, self).__init__(
             'WINDOWS_ERROR',
             title=Translator.get('WINDOWS_ERROR'),
-            description=Translator.get('WINDOWS_ERROR_OPENED_FILE', values),
+            description=Translator.get('WINDOWS_ERROR_OPENED_%s' % msg, values),
             level=Notification.LEVEL_ERROR,
             flags=(Notification.FLAG_UNIQUE
                    | Notification.FLAG_VOLATILE
@@ -461,8 +462,8 @@ class DefaultNotificationService(NotificationService):
         engine.online.connect(self._validAuthentication)
         engine.errorOpenedFile.connect(self._errorOpenedFile)
 
-    def _errorOpenedFile(self, local_path):
-        self.send_notification(ErrorOpenedFile(unicode(local_path)))
+    def _errorOpenedFile(self, local_path, is_folder):
+        self.send_notification(ErrorOpenedFile(unicode(local_path), is_folder))
 
     def _lockDocument(self, filename):
         self.send_notification(LockNotification(filename))

--- a/nuxeo-drive-client/tests/test_remote_move_and_rename.py
+++ b/nuxeo-drive-client/tests/test_remote_move_and_rename.py
@@ -640,13 +640,8 @@ class TestSyncRemoteMoveAndRename(UnitTestCase):
             assert local.exists('/Test folder/testFile.pdf')
             assert not local.exists('/testFile.pdf')
 
-        # The source file is accessed by another processor, so we cannot do anything
-        states_in_error = self.engine_1.get_dao().get_errors()
-        assert len(states_in_error) == 1
-
-        # Reset the error and wait'n see!
-        for state in states_in_error:
-            self.engine_1.get_dao().reset_error(state)
+        # The source file is accessed by another processor, but no error
+        assert not self.engine_1.get_dao().get_errors()
 
         self.wait_sync(wait_for_async=True)
         assert local.exists('/testFile.pdf')
@@ -706,13 +701,8 @@ class TestSyncRemoteMoveAndRename(UnitTestCase):
             assert local.exists('/Test folder/testFile.pdf')
             assert not local.exists('/Test folder/testFile2.pdf')
 
-        # The source file is accessed by another processor, so we cannot do anything
-        states_in_error = self.engine_1.get_dao().get_errors()
-        assert len(states_in_error) == 1
-
-        # Reset the error and wait'n see!
-        for state in states_in_error:
-            self.engine_1.get_dao().reset_error(state)
+        # The source file is accessed by another processor, but no errors
+        assert not self.engine_1.get_dao().get_errors()
 
         self.wait_sync(wait_for_async=True)
         assert local.exists('/Test folder/testFile2.pdf')

--- a/nuxeo-drive-client/tests/test_windows.py
+++ b/nuxeo-drive-client/tests/test_windows.py
@@ -95,13 +95,10 @@ class TestWindows(UnitTestCase):
         if sys.platform == 'win32':
             # As local file are locked, a WindowsError should occur during the
             # local update process, therefore:
-            # - Temporary download file (.part) should be created locally but
-            #   not renamed then removed
             # - Opened local files should still exist and not have been
             #   modified
             # - Synchronization should not fail: doc pairs should be
             #   blacklisted and other remote modifications should be locally synchronized
-            self.assertNxPart('/', 'test_update.docx')
             self.assertTrue(local.exists('/test_update.docx'))
             self.assertEqual(local.get_content('/test_update.docx'),
                              'Some content to update.')
@@ -116,7 +113,6 @@ class TestWindows(UnitTestCase):
             self.wait_sync(enforce_errors=False, fail_if_timeout=False)
             # Blacklisted files should be ignored as delay (60 seconds by
             # default) is not expired, nothing should have changed
-            self.assertNxPart('/', 'test_update.docx')
             self.assertTrue(local.exists('/test_update.docx'))
             self.assertEqual(local.get_content('/test_update.docx'),
                              'Some content to update.')
@@ -137,7 +133,6 @@ class TestWindows(UnitTestCase):
             self.assertTrue(local.exists('/test_update.docx'))
             self.assertEqual(local.get_content('/test_update.docx'),
                              'Updated content.')
-            self.assertNxPart('/', 'test_update.docx')
             self.assertFalse(local.exists('/test_delete.docx'))
         else:
             self.assertTrue(local.exists('/test_update.docx'))


### PR DESCRIPTION
So, when a folder/file is blocked because of another process using it, we delay the action for 60 secondes and notify the user. There will be no error and the action will be done when the user will close the software using that document or one of its children.

That commit may fix others issues from the epic https://jira.nuxeo.com/browse/NXDRIVE-1089, will check then.

Also:
- NXDRIVE-1009: Some folders not deleted on client when file is open
- Ease future transition to Qt 5 in `notifications.py`