### PR TITLE
NXDRIVE-1008: Document deleted server side when unfiltering and opened elsewhere

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -3,6 +3,7 @@ Release date: `2018-??-??`
 
 ### Core
 - [NXDRIVE-941](https://jira.nuxeo.com/browse/NXDRIVE-941): Use a context manager for Lock
+- [NXDRIVE-1008](https://jira.nuxeo.com/browse/NXDRIVE-1008): Document deleted server side when unfiltering and opended elsewhere
 - [NXDRIVE-1009](https://jira.nuxeo.com/browse/NXDRIVE-1009): Some folders not deleted on client when file is open
 - [NXDRIVE-1062](https://jira.nuxeo.com/browse/NXDRIVE-1062): Fix encoding for string comparisons on macOS
 - [NXDRIVE-1085](https://jira.nuxeo.com/browse/NXDRIVE-1085): Review the Auto-Lock feature

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -3,7 +3,7 @@ Release date: `2018-??-??`
 
 ### Core
 - [NXDRIVE-941](https://jira.nuxeo.com/browse/NXDRIVE-941): Use a context manager for Lock
-- [NXDRIVE-1008](https://jira.nuxeo.com/browse/NXDRIVE-1008): Document deleted server side when unfiltering and opended elsewhere
+- [NXDRIVE-1008](https://jira.nuxeo.com/browse/NXDRIVE-1008): Document deleted server side when unfiltering and opened elsewhere
 - [NXDRIVE-1009](https://jira.nuxeo.com/browse/NXDRIVE-1009): Some folders not deleted on client when file is open
 - [NXDRIVE-1062](https://jira.nuxeo.com/browse/NXDRIVE-1062): Fix encoding for string comparisons on macOS
 - [NXDRIVE-1085](https://jira.nuxeo.com/browse/NXDRIVE-1085): Review the Auto-Lock feature

--- a/nuxeo-drive-client/nxdrive/data/ui5/i18n.js
+++ b/nuxeo-drive-client/nxdrive/data/ui5/i18n.js
@@ -391,9 +391,11 @@ LABELS={
     "USERNAME": "Username",
     "WEB_AUTHENTICATION_WINDOW_TITLE": "Nuxeo Drive - Web Authentication",
     "WELCOME_MESSAGE": "Set your account and synchronize your files with the Nuxeo Platform.",
-    "WINDOWS_ERROR": "Windows Error",
-    "WINDOWS_ERROR_OPENED_FILE": "Another software is blocking any action on the file „{{ name }}“. Please, close it.",
-    "WINDOWS_ERROR_OPENED_FOLDER": "Another software is blocking any action on the folder „{{ name }}“ or its children. Please, close it."
+    "WINDOWS_ERROR_TITLE": "Document error",
+    "WINDOWS_ERROR_OPENED_FILE": "The file „{{ name }}“ is open by another software. Please close it before Nuxeo Drive can process the deletion from your local storage.",
+    "WINDOWS_ERROR_OPENED_FOLDER": "The folder „{{ name }}“ or its children is locked by another software. Please close it before Nuxeo Drive can process the deletion from your local storage.",
+    "DELETION_ERROR_TITLE": "Document deletion error",
+    "DELETION_ERROR_MSG": "The document „{{ name }}“ cannot be unsynchronised because its full path is too long."
   },
   "es": {
     "ABOUT": "Acerca de",

--- a/nuxeo-drive-client/nxdrive/engine/engine.py
+++ b/nuxeo-drive-client/nxdrive/engine/engine.py
@@ -102,7 +102,8 @@ class Engine(QObject):
     _start = pyqtSignal()
     _stop = pyqtSignal()
     _scanPair = pyqtSignal(str)
-    errorOpenedFile = pyqtSignal(object, bool)
+    errorOpenedFile = pyqtSignal(object)
+    fileDeletionErrorTooLong = pyqtSignal(object)
     syncStarted = pyqtSignal(object)
     syncCompleted = pyqtSignal()
     # Sent when files are in blacklist but the rest is ok

--- a/nuxeo-drive-client/nxdrive/engine/watcher/local_watcher.py
+++ b/nuxeo-drive-client/nxdrive/engine/watcher/local_watcher.py
@@ -1019,6 +1019,8 @@ class LocalWatcher(EngineWorker):
                     if doc_pair:
                         self._schedule_win_folder_scan(doc_pair)
             return
+        except ThreadInterrupt:
+            raise
         except:
             log.exception('Watchdog exception')
 

--- a/nuxeo-drive-client/tests/test_local_client.py
+++ b/nuxeo-drive-client/tests/test_local_client.py
@@ -298,6 +298,18 @@ class TestLocalClientNative(StubLocalClient, UnitTestCase):
     def get_local_client(self, path):
         return LocalClient(path)
 
+    @pytest.mark.xfail(
+        sys.platform == 'win32', raises=OSError,
+        reason='Explorer cannot deal with very long paths')
+    def test_deep_folders(self):
+        """
+        It should fail on Windows:
+            WindowsError: [Error 206] The filename or extension is too long
+        Explorer cannot deal with very long paths.
+        """
+
+        super(TestLocalClientNative, self).test_deep_folders()
+
     def test_remote_changing_case_accentued_folder(self):
         """
         NXDRIVE-1061: Remote rename of an accentued folder on Windows fails.

--- a/nuxeo-drive-client/tests/test_synchronization.py
+++ b/nuxeo-drive-client/tests/test_synchronization.py
@@ -1,7 +1,10 @@
 # coding: utf-8
 import socket
 import time
+import sys
 import urllib2
+
+import pytest
 
 from nxdrive.client import LocalClient
 from nxdrive.client.remote_filtered_file_system_client import \
@@ -472,6 +475,7 @@ class TestSynchronization(UnitTestCase):
         self.assertEqual(remote_children[0].filename, 'Some File.doc')
         self.assertEqual(remote_1.get_content('/Some File.doc'), 'Remote new content.')
 
+    @pytest.mark.skipif(sys.platform == 'win32', reason='NXDRIVE-1118')
     def test_synchronize_deep_folders(self):
         # Increase Automation execution timeout for NuxeoDrive.GetChangeSummary
         # because of the recursive parent FileSystemItem adaptation

--- a/tools/jenkins/tests.groovy
+++ b/tools/jenkins/tests.groovy
@@ -188,7 +188,7 @@ timeout(240) {
     timestamps {
         parallel builders
 
-        if (env.ENABLE_SONAR && currentBuild.result == 'SUCCESS') {
+        if (env.ENABLE_SONAR && currentBuild.result != 'UNSTABLE') {
             node('SLAVE') {
                 stage('SonarQube Analysis') {
                     try {
@@ -222,16 +222,16 @@ timeout(240) {
                                 withEnv(["WORKSPACE=${pwd()}"]) {
                                     sh """
                                     ${mvnHome}/bin/mvn -f ftest/pom.xml sonar:sonar \
-                                    -Dsonar.login=${SONARCLOUD_PWD} \
-                                    -Dsonar.branch.name=${env.BRANCH_NAME} \
-                                    -Dsonar.projectKey=org.nuxeo:nuxeo-drive-client \
-                                    -Dsonar.projectBaseDir="${env.WORKSPACE}" \
-                                    -Dsonar.projectVersion="${drive_version}" \
-                                    -Dsonar.sources=../nuxeo-drive-client/nxdrive \
-                                    -Dsonar.tests=../nuxeo-drive-client/tests \
-                                    -Dsonar.python.coverage.reportPath=coverage.xml \
-                                    -Dsonar.python.pylint.reportPath=pylint-report.txt \
-                                    -Dsonar.exclusions=ftest/pom.xml
+                                        -Dsonar.login=${SONARCLOUD_PWD} \
+                                        -Dsonar.branch.name=${env.BRANCH_NAME} \
+                                        -Dsonar.projectKey=org.nuxeo:nuxeo-drive-client \
+                                        -Dsonar.projectBaseDir="${env.WORKSPACE}" \
+                                        -Dsonar.projectVersion="${drive_version}" \
+                                        -Dsonar.sources=../nuxeo-drive-client/nxdrive \
+                                        -Dsonar.tests=../nuxeo-drive-client/tests \
+                                        -Dsonar.python.coverage.reportPath=coverage.xml \
+                                        -Dsonar.python.pylint.reportPath=pylint-report.txt \
+                                        -Dsonar.exclusions=ftest/pom.xml
                                     """
                                 }
                             }


### PR DESCRIPTION
An unexpected behavior with long paths is the inability to move to trash. Send2Trash uses an old API  that cannot deal with such files. So we are currently ignoring actions on them and NXDRIVE-1118 will try to fix it.