### PR TITLE
NXDRIVE-1136: Change systray icon on update

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -15,6 +15,7 @@ Release date: `2018-??-??`
 - [NXDRIVE-1108](https://jira.nuxeo.com/browse/NXDRIVE-1108): Standardize and rename context menu entry
 - [NXDRIVE-1123](https://jira.nuxeo.com/browse/NXDRIVE-1123): Access right-click action on folders on Windows
 - [NXDRIVE-1124](https://jira.nuxeo.com/browse/NXDRIVE-1124): Right click menu entry on files: "Copy share-link"
+- [NXDRIVE-1136](https://jira.nuxeo.com/browse/NXDRIVE-1136): Change systray icon on update
 - [NXDRIVE-1149](https://jira.nuxeo.com/browse/NXDRIVE-1149): New language: Indonesian
 
 ### Packaging / Build

--- a/nuxeo-drive-client/nxdrive/engine/dao/sqlite.py
+++ b/nuxeo-drive-client/nxdrive/engine/dao/sqlite.py
@@ -955,9 +955,13 @@ class EngineDAO(ConfigurationDAO):
 
     def get_global_size(self):
         c = self._get_read_connection(factory=self._state_factory).cursor()
-        return c.execute("SELECT SUM(size) as sum"
-                         "  FROM States"
-                         " WHERE pair_state = 'synchronized'").fetchone().sum
+        total = c.execute("SELECT SUM(size) as sum"
+                          "  FROM States"
+                          " WHERE folderish = 0"
+                          "   AND pair_state = 'synchronized'").fetchone().sum
+        # `total` may be `None` if there is not synced files,
+        # so we ensure to have an int at the end
+        return total or 0
 
     def get_unsynchronizeds(self):
         c = self._get_read_connection(factory=self._state_factory).cursor()

--- a/nuxeo-drive-client/nxdrive/engine/dao/sqlite.py
+++ b/nuxeo-drive-client/nxdrive/engine/dao/sqlite.py
@@ -275,14 +275,11 @@ class ConfigurationDAO(QObject):
         with self._lock:
             con = self._get_write_connection()
             c = con.cursor()
-            if value:
-                c.execute('UPDATE OR IGNORE Configuration'
-                          '             SET value = ?'
-                          '           WHERE name = ?', (value, name))
-                c.execute('INSERT OR IGNORE INTO Configuration (value, name) '
-                          'VALUES (?, ?)', (value, name))
-            else:
-                self._delete_config(c, name)
+            c.execute('UPDATE OR IGNORE Configuration'
+                      '             SET value = ?'
+                      '           WHERE name = ?', (value, name))
+            c.execute('INSERT OR IGNORE INTO Configuration (value, name) '
+                      'VALUES (?, ?)', (value, name))
             if self.auto_commit:
                 con.commit()
 

--- a/nuxeo-drive-client/nxdrive/manager.py
+++ b/nuxeo-drive-client/nxdrive/manager.py
@@ -401,13 +401,8 @@ class Manager(QtCore.QObject):
         self.started.connect(tracker._thread.start)
         return tracker
 
-    def get_tracker_id(self):
-        if self.get_tracking() and self._tracker is not None:
-            return self._tracker.uid
-        return ""
-
     def _get_db(self):
-        return os.path.join(normalized_path(self.nxdrive_home), "manager.db")
+        return os.path.join(normalized_path(self.nxdrive_home), 'manager.db')
 
     def get_dao(self):  # TODO: Remove
         return self._dao
@@ -680,17 +675,19 @@ class Manager(QtCore.QObject):
         """
         Avoid sending statistics when testing or if the user does not allow it.
         """
-
         return (self._dao.get_config('tracking', '1') == '1'
                 and not os.environ.get('WORKSPACE'))
 
     def set_tracking(self, value):
-        self._dao.update_config("tracking", value)
+        self._dao.update_config('tracking', value)
         if value:
             self._create_tracker()
-        elif self._tracker is not None:
+        elif self._tracker:
             self._tracker._thread.quit()
             self._tracker = None
+
+    def get_tracker_id(self):
+        return self._tracker.uid if self._tracker else ''
 
     def validate_proxy_settings(self, proxy_settings):
         conn = None


### PR DESCRIPTION
The update icon will take precedence over other states to force the user to update.

Also:
* Do not remove the config from the database if the value is False
* Fix file size computation in `Engine` metrics to prevent:
```
Traceback (most recent call last):
  File "nxdrive\engine\tracker.py", line 113, in send_event
  File "site-packages\UniversalAnalytics\Tracker.py", line 262, in send
  File "site-packages\UniversalAnalytics\Tracker.py", line 171, in payload
  File "site-packages\UniversalAnalytics\Tracker.py", line 163, in coerceParameter
TypeError: int() argument must be a string or a number, not 'NoneType'
```