### PR TITLE
NXDRIVE-1186: Fix several small issues

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -65,6 +65,7 @@ Changes in command line arguments:
 - Packaging: Added `pyaml` 17.12.1
 - Packaging: Added `requests` 2.18.4
 - Packaging: Removed `cffi`, will be installed with `xattr`
+- Packaging: Removed `yappi`, useless on CI
 - Packaging: Updated `Js2Py` from 0.58 to 0.59
 - Packaging: Updated `pycryptodomex` from 3.5.1 to 3.6.0
 - Packaging: Updated `pypac` from 0.4.0 to 0.8.1

--- a/nxdrive/client/local_client.py
+++ b/nxdrive/client/local_client.py
@@ -636,12 +636,6 @@ FolderType=Generic
         if not os.path.exists(os_path):
             return
 
-        if sys.platform == 'win32':
-            # Send2Trash uses a SHFileOperation on Windows, which fails on
-            # any path prefixed with "\\?\" (from official documentation).
-            # So removing that prefix.
-            os_path = os_path.lstrip('\\\\?\\')
-
         log.trace('Trashing %r', os_path)
 
         # Send2Trash needs bytes

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -289,7 +289,7 @@ class Processor(EngineWorker):
                                  doc_pair.remote_ref)
                         self._engine.errorOpenedFile.emit(doc_pair)
                         self._postpone_pair(doc_pair, 'Used by another process')
-                    elif error in (111, 121, 124, 206):
+                    elif error in (111, 121, 124, 206, 1223):
                         """
                         WindowsError: [Error 111] ??? (seems related to deep
                         tree)
@@ -307,12 +307,15 @@ class Processor(EngineWorker):
                         WindowsError: [Error 206] The filename or extension is
                         too long.
                         Cause: even the full short path is too long
+
+                        OSError: Couldn't perform operation. Error code: 1223
+                        Seems related to long paths
                         """
                         self._dao.remove_filter(doc_pair.remote_parent_path
                                                 + '/'
                                                 + doc_pair.remote_ref)
                         self._engine.fileDeletionErrorTooLong.emit(doc_pair)
-                    elif getattr(exc, 'trash_issue'):
+                    elif getattr(exc, 'trash_issue', False):
                         """
                         Special value to handle trash issues from filters on
                         Windows when there is one or more files opened by

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -2,4 +2,3 @@ mock==2.0.0
 pytest==3.5.0
 pytest-cov==2.5.1
 pytest-timeout==1.2.1
-yappi==0.98


### PR DESCRIPTION
* Removed yappi requirement
* Handle OSError(1223), seems related to long paths error on Windows
* Fix AttributeError: 'exceptions.WindowsError' object has no attribute 'trash_issue' in Processor._execute()
* Code clean-up in LocalClient.delete()