### PR TITLE
NXDRIVE-903: Clean-up

### DIFF
--- a/docs/technical_changes.md
+++ b/docs/technical_changes.md
@@ -65,10 +65,11 @@
 - Removed `FolderTreeview.set_client()`
 - Removed `LocalClient.DEDUPED_BASENAME_PATTERN`
 - Removed `LocalClient.root`
+- Removed `LocalClient.check_writable()`
 - Removed `LocalClient.duplicate_file()`
 - Removed `LocalClient.duplication_enabled()`
 - Removed `LocalClient.get_parent_ref()`
-- Removed `LocalClient.check_writable()`
+- Removed `LocalClient.is_inside()`
 - Removed `LocalClient.unset_folder_icon()`
 - Removed `LocalWatcher.get_windows_folder_scan_delay()`
 - Removed `LocalWatcher.set_windows_folder_scan_delay()`

--- a/nxdrive/client/local_client.py
+++ b/nxdrive/client/local_client.py
@@ -77,10 +77,7 @@ class FileInfo(object):
         self.name = os.path.basename(path)
 
     def __repr__(self):
-        return self.__unicode__().encode('ascii', 'ignore')
-
-    def __unicode__(self):
-        return u'FileInfo[%s, remote_ref=%s]' % (self.filepath, self.remote_ref)
+        return 'FileInfo<path=%r, remote_ref=%r>' % (self.filepath, self.remote_ref)
 
     def get_digest(self, digest_func=None):
         # type: (Optional[callable]) -> Union[Text, None]
@@ -120,6 +117,7 @@ class LocalClient(BaseClient):
 
     def __init__(self, base_folder, **kwargs):
         self._case_sensitive = kwargs.pop('case_sensitive', None)
+        self.is_case_sensitive()
 
         # Function to check during long-running processing like digest
         # computation if the synchronization thread needs to be suspended
@@ -142,7 +140,7 @@ class LocalClient(BaseClient):
 
         if self._case_sensitive is None:
             path = tempfile.mkdtemp(prefix='.caseTest_')
-            self._case_sensitive = not os.path.exists(path.upper())
+            self._case_sensitive = not os.path.isdir(path.upper())
             os.rmdir(path)
         return self._case_sensitive
 
@@ -261,7 +259,7 @@ class LocalClient(BaseClient):
         else:
             return False
 
-        return os.path.exists(meta_file)
+        return os.path.isfile(meta_file)
 
     def set_folder_icon(self, ref, icon):
         if icon is None:
@@ -289,7 +287,7 @@ FolderType=Generic
         # Create the desktop.ini file inside the ReadOnly shared folder.
         os_path = self.abspath(ref)
         created_ini_file_path = os.path.join(os_path, 'desktop.ini')
-        if not os.path.exists(created_ini_file_path):
+        if not os.path.isfile(created_ini_file_path):
             try:
                 with open(created_ini_file_path, 'w') as create_file:
                     create_file.write(desktop_ini_content)
@@ -347,7 +345,7 @@ FolderType=Generic
             xattr.setxattr(target_folder, xattr.XATTR_FINDERINFO_NAME, has_icon_xdata)
             # Create the 'Icon\r' file
             meta_file = os.path.join(target_folder, "Icon\r")
-            if os.path.exists(meta_file):
+            if os.path.isfile(meta_file):
                 os.remove(meta_file)
             open(meta_file, "w").close()
             # Configure 'com.apple.FinderInfo' for the Icon file
@@ -436,7 +434,7 @@ FolderType=Generic
         os_path = self.abspath(ref)
         if not os.path.exists(os_path):
             if raise_if_missing:
-                err = 'Could not find file into {!r}: ref={!r}, os_path={!r}'
+                err = 'Could not find doc into {!r}: ref={!r}, os_path={!r}'
                 raise NotFound(err.format(self.base_folder, ref, os_path))
             return None
 
@@ -625,7 +623,7 @@ FolderType=Generic
         with open(self.abspath(ref), 'wb') as f:
             f.write(content)
 
-        for name, value in xattrs.iteritems():
+        for name, value in xattrs.items():
             if value is not None:
                 self.set_remote_id(ref, value, name=name)
 
@@ -705,7 +703,7 @@ FolderType=Generic
         source_os_path = self.abspath(ref)
         parent = ref.rsplit(u'/', 1)[0]
         old_name = ref.rsplit(u'/', 1)[1]
-        parent = u'/' if parent == '' else parent
+        parent = parent or u'/'
         locker = self.unlock_ref(source_os_path, is_abs=True)
         try:
             # Check if only case renaming
@@ -740,7 +738,7 @@ FolderType=Generic
         if ref == u'/':
             raise ValueError('Cannot move the toplevel folder.')
 
-        name = name if name is not None else ref.rsplit(u'/', 1)[1]
+        name = name or ref.rsplit(u'/', 1)[1]
         filename = self.abspath(ref)
         target_os_path, new_name = self._abspath_deduped(new_parent_ref, name)
         locker = self.unlock_ref(filename, is_abs=True)
@@ -773,6 +771,10 @@ FolderType=Generic
             try:
                 mtime = int(mtime)
             except ValueError:
+                # Threading bugfix
+                # Fixed in Python 3, see https://bugs.python.org/issue9260
+                # TODO: Remove with NXDRIVE-691
+                import _strptime
                 mtime = mktime(strptime(mtime, '%Y-%m-%d %H:%M:%S'))
             os.utime(filename, (mtime, mtime))
 
@@ -799,11 +801,6 @@ FolderType=Generic
                     win32con.FILE_ATTRIBUTE_NORMAL,
                     None)
                 win32file.SetFileTime(winfile, ctime)
-
-    def is_inside(self, abspath):
-        # type: (Text) -> bool
-
-        return abspath.startswith(self.base_folder)
 
     def get_path(self, abspath):
         # type: (Text) -> Text

--- a/nxdrive/commandline.py
+++ b/nxdrive/commandline.py
@@ -511,7 +511,7 @@ class CliHandler(object):
         return 0
 
     def unbind_server(self, options):
-        for uid, engine in self.manager.get_engines().iteritems():
+        for uid, engine in self.manager.get_engines().items():
             if engine.local_folder == options.local_folder:
                 self.manager.unbind_engine(uid)
                 return 0

--- a/nxdrive/engine/dao/sqlite.py
+++ b/nxdrive/engine/dao/sqlite.py
@@ -908,14 +908,13 @@ class EngineDAO(ConfigurationDAO):
         return self.get_count("pair_state = 'conflicted'")
 
     def get_error_count(self, threshold=3):
-        return self.get_count('error_count > {}'.format(str(threshold)))
+        return self.get_count('error_count > {}'.format(threshold))
 
     def get_syncing_count(self, threshold=3):
         count = self.get_count("    pair_state != 'synchronized' "
                                "AND pair_state != 'conflicted' "
                                "AND pair_state != 'unsynchronized' "
-                               "AND error_count < {}".format(
-                                   str(threshold)))
+                               "AND error_count < {}".format(threshold))
         if self._items_count != count:
             log.trace('Cache Syncing count incorrect should be %d was %d',
                       count, self._items_count)

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -67,7 +67,7 @@ class Engine(QObject):
     newReadonly = pyqtSignal(object, object)
     deleteReadonly = pyqtSignal(object)
     newLocked = pyqtSignal(object, object, object)
-    newSync = pyqtSignal(object, object)
+    newSync = pyqtSignal(object)
     newError = pyqtSignal(object)
     newQueueItem = pyqtSignal(object)
     offline = pyqtSignal()
@@ -156,6 +156,10 @@ class Engine(QObject):
         # Pause in case of no more space on the device
         self.noSpaceLeftOnDevice.connect(self.suspend)
 
+    def __repr__(self):
+        fmt = '{name}<name={cls.name!r}, uid={cls.uid!r}, type={cls.type!r}>'
+        return fmt.format(name=type(self).__name__, cls=self)
+
     @pyqtSlot(object)
     def _check_sync_start(self, row_id):
         if not self._sync_started:
@@ -174,14 +178,13 @@ class Engine(QObject):
             self.start()
 
     def stop_processor_on(self, path):
-        for worker in self.get_queue_manager().get_processors_on(
-                path, exact_match=True):
+        for worker in self.get_queue_manager().get_processors_on(path):
             log.trace('Quitting processor: %r as requested to stop on %r',
                       worker, path)
             worker.quit()
 
     def set_local_folder(self, path):
-        log.debug("Update local folder to '%s'", path)
+        log.debug('Update local folder to %r', path)
         self.local_folder = path
         self._local_watcher.stop()
         self._create_local_watcher()
@@ -356,13 +359,15 @@ class Engine(QObject):
 
         self.dispose_db()
         log.debug('Remove DB file %r', self._get_db_file())
-        try:
-            os.remove(self._get_db_file())
-        except (IOError, OSError) as exc:
-            if exc.errno != 2:  # File not found, already removed
-                log.exception('Database removal error')
-
         self._manager.osi.unregister_folder_link(self.local_folder)
+
+        # Keep the database for tests
+        if not os.environ.get('WORKSPACE', False):
+            try:
+                os.remove(self._get_db_file())
+            except (IOError, OSError) as exc:
+                if exc.errno != 2:  # File not found, already removed
+                    log.exception('Database removal error')
 
     def check_fs_marker(self):
         tag = 'drive-fs-test'
@@ -477,9 +482,10 @@ class Engine(QObject):
     def create_thread(self, worker=None, name=None, start_connect=True):
         if worker is None:
             worker = Worker(self, name=name)
-        # If subclass of Processor then connect the newSync signal
+
         if isinstance(worker, Processor):
             worker.pairSync.connect(self.newSync)
+
         thread = worker.get_thread()
         if start_connect:
             thread.started.connect(worker.run)

--- a/nxdrive/engine/next/simple_watcher.py
+++ b/nxdrive/engine/next/simple_watcher.py
@@ -41,6 +41,10 @@ class SimpleWatcher(LocalWatcher):
     def get_scan_delay(self):
         return self._scan_delay
 
+    def is_inside(self, abspath):
+        # type: (Text) -> bool
+        return abspath.startswith(self.client.base_folder)
+
     def is_pending_scan(self, ref):
         return ref in self._to_scan
 
@@ -54,7 +58,7 @@ class SimpleWatcher(LocalWatcher):
         doc_pair = self._dao.get_state_from_local(rel_path)
         # Add for security src_path and dest_path parent - not sure it is needed
         self._push_to_scan(os.path.dirname(rel_path))
-        if self.client.is_inside(dst_path):
+        if self.is_inside(dst_path):
             dst_rel_path = self.client.get_path(dst_path)
             self._push_to_scan(os.path.dirname(dst_rel_path))
         if (doc_pair is None):
@@ -153,7 +157,7 @@ class SimpleWatcher(LocalWatcher):
                 # Need to create a list of to scan as
                 # the dictionary cannot grow while iterating
                 local_scan = []
-                for path, last_event_time in self._to_scan.iteritems():
+                for path, last_event_time in self._to_scan.items():
                     if last_event_time < threshold_time:
                         local_scan.append(path)
                 for path in local_scan:
@@ -176,7 +180,7 @@ class SimpleWatcher(LocalWatcher):
         to_deletes = copy.copy(self._delete_files)
         # Enforce the scan of all folders
         # to check if the file hasn't moved there
-        for path, _ in self._to_scan.iteritems():
+        for path, _ in self._to_scan.items():
             self._scan_path(path)
         for deleted in to_deletes:
             if deleted not in self._delete_files:

--- a/nxdrive/engine/watcher/local_watcher.py
+++ b/nxdrive/engine/watcher/local_watcher.py
@@ -252,12 +252,14 @@ class LocalWatcher(EngineWorker):
 
     @pyqtSlot(str)
     def scan_pair(self, local_path):
-        info = self.client.get_info(local_path)
         to_pause = not self._engine.get_queue_manager().is_paused()
         if to_pause:
             self._suspend_queue()
+
+        info = self.client.get_info(local_path)
         self._scan_recursive(info, recursive=False)
         self._scan_handle_deleted_files()
+
         if to_pause:
             self._engine.get_queue_manager().resume()
 
@@ -719,6 +721,7 @@ class LocalWatcher(EngineWorker):
                             local_info.last_modification_time.timetuple())
                         self._folder_scan_events[rel_path] = t, doc_pair
             return
+
         acquired_pair = None
         try:
             acquired_pair = dao.acquire_state(self._thread_id, doc_pair.id)
@@ -857,12 +860,12 @@ class LocalWatcher(EngineWorker):
 
             if force_decode(dst_path) in (
                     filename, force_decode(evt.src_path.strip())):
-                log.debug('Ignoring move from %r to normalized name: %r',
+                log.debug('Ignoring move from %r to normalized %r',
                           evt.src_path, dst_path)
                 return
-
-        log.debug('Handling watchdog event [%s] on %r',
-                  evt.event_type, evt.src_path)
+        else:
+            log.debug('Handling watchdog event [%s] on %r',
+                      evt.event_type, evt.src_path)
 
         try:
             src_path = normalize(evt.src_path)
@@ -928,6 +931,7 @@ class LocalWatcher(EngineWorker):
                 rel_path = client.get_path(src_path)
                 local_info = client.get_info(rel_path, raise_if_missing=False)
                 doc_pair = dao.get_state_from_local(rel_path)
+
                 # If the file exists but not the pair
                 if local_info is not None and doc_pair is None:
                     # Check if it is a pair that we loose track of
@@ -938,6 +942,7 @@ class LocalWatcher(EngineWorker):
                                 and not client.exists(doc_pair.local_path)):
                             log.debug('Pair re-moved detected for %r',
                                       doc_pair)
+
                             # Can be a move inside a folder that has also moved
                             self._handle_watchdog_event_on_known_pair(
                                 doc_pair, evt, rel_path)
@@ -947,6 +952,7 @@ class LocalWatcher(EngineWorker):
                     if rel_parent_path == '':
                         rel_parent_path = '/'
                     dao.insert_local_state(local_info, rel_parent_path)
+
                     # An event can be missed inside a new created folder as
                     # watchdog will put listener after it
                     if local_info.folderish:
@@ -956,6 +962,7 @@ class LocalWatcher(EngineWorker):
                             if doc_pair:
                                 self._schedule_win_folder_scan(doc_pair)
                 return
+
             # if the pair is modified and not known consider as created
             if evt.event_type not in ('created', 'modified'):
                 log.debug('Unhandled case: %r %r %r', evt, rel_path, file_name)

--- a/nxdrive/engine/watcher/remote_watcher.py
+++ b/nxdrive/engine/watcher/remote_watcher.py
@@ -564,13 +564,11 @@ class RemoteWatcher(EngineWorker):
             remote_path = '/'
             self._dao.add_path_to_scan(remote_path)
             self._dao.update_config('remote_need_full_scan', remote_path)
-            del summary['fileSystemChanges']  # Fix reference leak
             return
 
         if not summary['fileSystemChanges']:
             self._metrics['empty_polls'] += 1
             self.noChangesFound.emit()
-            del summary['fileSystemChanges']  # Fix reference leak
             return
 
         # Fetch all events and consider the most recent first
@@ -579,7 +577,6 @@ class RemoteWatcher(EngineWorker):
                                 reverse=True)
 
         n_changes = len(sorted_changes)
-        del summary['fileSystemChanges']  # Fix reference leak
         self._metrics['last_changes'] = n_changes
         self._metrics['empty_polls'] = 0
         self.changesFound.emit(n_changes)
@@ -667,73 +664,91 @@ class RemoteWatcher(EngineWorker):
                         log.debug('Marking doc_pair %r as deleted', doc_pair_repr)
                         self._dao.delete_remote_state(doc_pair)
                     else:
-                        # Make new_info consistent with actual doc pair parent path for a doc member of a
-                        # collection (typically the Locally Edited one) that is also under a sync root.
-                        # Indeed, in this case, when adapted as a FileSystemItem, its parent path will be the one
-                        # of the sync root because it takes precedence over the collection,
-                        # see AbstractDocumentBackedFileSystemItem constructor.
+                        """
+                        Make new_info consistent with actual doc pair parent
+                        path for a doc member of a collection (typically the
+                        Locally Edited one) that is also under a sync root.
+                        Indeed, in this case, when adapted as a FileSystemItem,
+                        its parent path will be the one of the sync root because
+                        it takes precedence over the collection, see 
+                        AbstractDocumentBackedFileSystemItem constructor.
+                        """
                         consistent_new_info = new_info
                         if remote_parent_factory == COLLECTION_SYNC_ROOT_FACTORY_NAME:
-                            new_info_parent_uid = doc_pair.remote_parent_ref
-                            new_info_path = doc_pair.remote_parent_path + '/' + remote_ref
                             consistent_new_info = RemoteFileInfo(
-                                new_info.name,
-                                new_info.uid,
-                                new_info_parent_uid,
-                                new_info_path,
-                                new_info.folderish,
-                                new_info.last_modification_time,
-                                new_info.last_contributor,
-                                new_info.digest,
-                                new_info.digest_algorithm,
-                                new_info.download_url,
-                                new_info.can_rename,
-                                new_info.can_delete,
-                                new_info.can_update,
-                                new_info.can_create_child,
-                                new_info.lock_owner,
-                                new_info.lock_created,
-                                new_info.can_scroll_descendants,
+                                name=new_info.name,
+                                uid=new_info.uid,
+                                parent_uid=doc_pair.remote_parent_ref,
+                                path=doc_pair.remote_parent_path + '/' + remote_ref,
+                                folderish=new_info.folderish,
+                                last_modification_time=new_info.last_modification_time,
+                                creation_time=new_info.creation_time,
+                                last_contributor=new_info.last_contributor,
+                                digest=new_info.digest,
+                                digest_algorithm=new_info.digest_algorithm,
+                                download_url=new_info.download_url,
+                                can_rename=new_info.can_rename,
+                                can_delete=new_info.can_delete,
+                                can_update= new_info.can_update,
+                                can_create_child=new_info.can_create_child,
+                                lock_owner=new_info.lock_owner,
+                                lock_created=new_info.lock_created,
+                                can_scroll_descendants=new_info.can_scroll_descendants,
                             )
-                        # Perform a regular document update on a document
-                        # that has been updated, renamed or moved
-                        log.debug('Refreshing remote state info for '
-                                  'doc_pair=%r, event_id=%r, new_info=%r '
-                                  '(force_recursion=%d)', doc_pair_repr,
-                                  event_id, new_info, event_id == 'securityUpdated')
 
-                        # Force remote state update in case of a locked / unlocked event since lock info is not
-                        # persisted, so not part of the dirty check
+                        # Force remote state update in case of a locked/unlocked
+                        # event since lock info is not persisted, so not part
+                        # of the dirty check
                         lock_update = event_id in ('documentLocked',
                                                    'documentUnlocked')
-                        if doc_pair.remote_state != 'created':
-                            if (new_info.digest != doc_pair.remote_digest
-                                    or safe_filename(new_info.name) != doc_pair.remote_name
-                                    or new_info.parent_uid != doc_pair.remote_parent_ref
-                                    or event_id == 'securityUpdated'
-                                    or lock_update):
-                                doc_pair.remote_state = 'modified'
+
+                        # Perform a regular document update on a document
+                        # that has been updated, renamed or moved
+
+                        if doc_pair.remote_state != 'created' and any((
+                                new_info.digest != doc_pair.remote_digest,
+                                safe_filename(new_info.name) != doc_pair.remote_name,
+                                new_info.parent_uid != doc_pair.remote_parent_ref,
+                                event_id == 'securityUpdated',
+                                lock_update)):
+                            doc_pair.remote_state = 'modified'
+
+                        log.debug(
+                            'Refreshing remote state info for doc_pair=%r,'
+                            ' event_id=%r, new_info=%r (force_recursion=%d)',
+                            doc_pair, event_id, new_info,
+                            event_id == 'securityUpdated')
+
                         remote_parent_path = os.path.dirname(new_info.path)
+
                         # TODO Add modify local_path and local_parent_path if needed
-                        self._dao.update_remote_state(doc_pair, new_info, remote_parent_path=remote_parent_path,
-                                                      force_update=lock_update)
+                        self._dao.update_remote_state(
+                            doc_pair, new_info,
+                            remote_parent_path=remote_parent_path,
+                            force_update=lock_update)
+
                         if doc_pair.folderish:
-                            log.trace('Force scan recursive on %r : %d', doc_pair, event_id == 'securityUpdated')
-                            self._force_remote_scan(doc_pair, consistent_new_info, remote_path=new_info.path,
-                                                    force_recursion=event_id == 'securityUpdated',
-                                                    moved=event_id == 'documentMoved')
+                            log.trace('Force scan recursive on %r: %r',
+                                      doc_pair, event_id == 'securityUpdated')
+                            self._force_remote_scan(
+                                doc_pair, consistent_new_info,
+                                remote_path=new_info.path,
+                                force_recursion=event_id == 'securityUpdated',
+                                moved=event_id == 'documentMoved')
+
                         if lock_update:
                             doc_pair = self._dao.get_state_from_id(doc_pair.id)
                             try:
                                 self._handle_readonly(
                                     self._local_client, doc_pair)
                             except (OSError, IOError) as exc:
-                                log.trace('Cannot handle readonly for %r (%r)', doc_pair, exc)
-                                del exc  # Fix reference leak
+                                log.trace('Cannot handle readonly for %r (%r)',
+                                          doc_pair, exc)
 
                 pair = self._dao.get_state_from_id(doc_pair.id)
                 self._engine._manager.osi.send_sync_status(
                     pair, self._local_client.abspath(pair.local_path))
+
                 updated = True
                 refreshed.add(remote_ref)
 
@@ -742,7 +757,6 @@ class RemoteWatcher(EngineWorker):
                 created = False
                 parent_pairs = self._dao.get_states_from_remote(new_info.parent_uid)
                 for parent_pair in parent_pairs:
-
                     child_pair, new_pair = self._find_remote_child_match_or_create(parent_pair, new_info)
                     if new_pair:
                         log.debug('Marked doc_pair %r as remote creation',
@@ -751,7 +765,7 @@ class RemoteWatcher(EngineWorker):
                     if child_pair and child_pair.folderish and new_pair:
                         log.debug('Remote recursive scan of the content of %r',
                                   child_pair.remote_name)
-                        remote_path = child_pair.remote_parent_path + "/" + new_info.uid
+                        remote_path = child_pair.remote_parent_path + '/' + new_info.uid
                         self._force_remote_scan(child_pair, new_info, remote_path)
 
                     created = True
@@ -759,7 +773,8 @@ class RemoteWatcher(EngineWorker):
                     break
 
                 if not created:
-                    log.debug("Could not match changed document to a bound local folder: %r", new_info)
+                    log.debug('Could not match changed document to a bound '
+                              'local folder: %r', new_info)
 
         # Sort by path the deletion to only mark parent
         sorted_deleted = sorted(delete_queue, key=lambda x: x.local_path)
@@ -769,18 +784,23 @@ class RemoteWatcher(EngineWorker):
             skip = False
             for processed in delete_processed:
                 path = processed.local_path
+
                 if path[-1] != '/':
                     path += '/'
+
                 if delete_pair.local_path.startswith(path):
                     skip = True
                     break
+
             if skip:
                 continue
+
             # Verify the file is really deleted
             if self._client.get_fs_item(delete_pair.remote_ref) is not None:
                 continue
+
             delete_processed.append(delete_pair)
-            log.debug("Marking doc_pair '%r' as deleted", delete_pair)
+            log.debug('Marking doc_pair %r as deleted', delete_pair)
             self._dao.delete_remote_state(delete_pair)
 
     def filtered(self, info):

--- a/nxdrive/wui/application.py
+++ b/nxdrive/wui/application.py
@@ -306,7 +306,7 @@ class Application(SimpleApplication):
 
     def show_file_status(self):
         from ..gui.status_dialog import StatusDialog
-        for _, engine in self.manager.get_engines().iteritems():
+        for _, engine in self.manager.get_engines().items():
             self.status = StatusDialog(engine.get_dao())
             self.status.show()
             break
@@ -378,7 +378,7 @@ class Application(SimpleApplication):
     def init_checks(self):
         if Options.debug:
             self.show_debug_window()
-        for _, engine in self.manager.get_engines().iteritems():
+        for _, engine in self.manager.get_engines().items():
             self._connect_engine(engine)
         self.manager.newEngine.connect(self._connect_engine)
         self.manager.notification_service.newNotification.connect(self._new_notification)

--- a/tests/common.py
+++ b/tests/common.py
@@ -115,7 +115,7 @@ class RemoteDocumentClientForTests(RemoteDocumentClient):
             'nonUniform': 'true',
             'transactionTimeout': tx_timeout
         }
-        for param, value in params.iteritems():
+        for param, value in params.items():
             url += param + '=' + str(value) + '&'
         headers = self._get_common_headers()
         headers.update({'Nuxeo-Transaction-Timeout': tx_timeout})

--- a/tests/mac_local_client.py
+++ b/tests/mac_local_client.py
@@ -5,6 +5,7 @@ user actions.
 """
 
 import os
+import time
 
 import Cocoa
 
@@ -48,6 +49,7 @@ class MacLocalClient(LocalClient):
 
         error = None
         result = self.fm.moveItemAtPath_toPath_error_(src, dst, error)
+        time.sleep(0.05)
         self._process_result(result)
 
     def rename(self, srcref, to_name):

--- a/tests/test_nxdrive_903.py
+++ b/tests/test_nxdrive_903.py
@@ -31,16 +31,12 @@ from __future__ import unicode_literals
 
 import os.path
 
-from .common_unit_test import RandomBug, UnitTestCase
+from .common_unit_test import UnitTestCase
 
 
 class Test(UnitTestCase):
 
-    @RandomBug('NXDRIVE-903', target='windows', mode='BYPASS')
-    @RandomBug('NXDRIVE-903', target='mac', mode='BYPASS')
     def test_nxdrive_903(self):
-        """ On Windows, some files are postponed. Ignore the test if so. """
-
         remote = self.remote_document_client_1
         local_1, local_2 = self.local_client_1,  self.local_client_2
         engine_1, engine_2 = self.engine_1, self.engine_2
@@ -89,7 +85,7 @@ class Test(UnitTestCase):
             for file_ in files[folder]:
                 name = os.path.basename(file_)
                 new_name = os.path.splitext(name)[0] + '-renamed.txt'
-                new_file = local_1.rename(new_folder + '/' +  name, new_name)
+                new_file = local_1.rename(new_folder + '/' + name, new_name)
                 new_files[new_folder].append(new_file.path)
         self.wait_sync()
 
@@ -103,6 +99,9 @@ class Test(UnitTestCase):
         # Steps 19 -> 21
         engine_2.resume()
         self.wait_sync(wait_for_async=True, wait_for_engine_2=True)
+
+        # Ensure there is no postponed nor documents in error
+        assert not engine_2.get_dao().get_error_count(threshold=0)
 
         # Get a list of all synchronized folders to have a better view of
         # what is synced as expected

--- a/tests/win_local_client.py
+++ b/tests/win_local_client.py
@@ -12,6 +12,7 @@ For MTA, you still must use SHFileOperation.
 """
 
 import os
+import time
 
 from win32com.shell import shell, shellcon
 
@@ -48,8 +49,8 @@ class WindowsLocalClient(LocalClient):
     def abspath(self, ref):
         # Remove \\?\
         abs_path = super(WindowsLocalClient, self).abspath(ref)
-        if len(abs_path) >= 260:
-            log.warning(('The path is longer than 260 characters and '
+        if len(abs_path) >= 255:
+            log.warning(('The path is longer than 255 characters and '
                          'WindowsLocalClient is about the remove the long path '
                          'prefix. So the test is likely to fail.'))
         return abs_path[4:]
@@ -60,6 +61,7 @@ class WindowsLocalClient(LocalClient):
         new_path = os.path.join(os.path.dirname(path), to_name)
         res = shell.SHFileOperation((0, shellcon.FO_RENAME, path, new_path,
                                      shellcon.FOF_NOCONFIRMATION, None, None))
+        time.sleep(0.1)
         if res[0] != 0:
             raise IOError(res, locals())
         return MockFile(os.path.join(parent, to_name))


### PR DESCRIPTION
* Fixed a subtle threading bug with `time.strptime()`
* Fixed a `RemoteFileInfo` instanciation bug into `RemoteWatcher._update_remote_states()`
* Added `Engine.__repr__()`
* Better `repr(FileInfo)`
* Remove unused `LocalClient.is_inside()`
* Vars clean-up in various `Processor` methods
* Vars clean-up in `RemoteWatcher._update_remote_states()`
* Refactor `Tracker` events sending
* Use `os.path.is*()` instead of general `os.path.exists()`
* Keep the testing database in `Engine.unbind()`
* Replace use of `dict.iteritems()` with `dict.items()` to ease future Python 3 transition
* Give time for test_nxdrive_903.py to perform renames