### PR TITLE
 NXDRIVE-1203: Files appears as "not synced" when restarting Nuxeo Drive

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -37,7 +37,6 @@ Changes in command line arguments:
 - [NXDRIVE-1158](https://jira.nuxeo.com/browse/NXDRIVE-1158): Restore the context menu "Edit metadata"
 - [NXDRIVE-1166](https://jira.nuxeo.com/browse/NXDRIVE-1166): Display a notification on new update on GNU/Linux
 - [NXDRIVE-1175](https://jira.nuxeo.com/browse/NXDRIVE-1175): New language: Hebrew
-- [NXDRIVE-1203](https://jira.nuxeo.com/browse/NXDRIVE-1203): Files appears as "not synced" when restarting nuxeo drive
 
 ### Packaging / Build
 - [NXDRIVE-136](https://jira.nuxeo.com/browse/NXDRIVE-136): Activate code signing on macOS (valid until 2023-03-10)

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -37,6 +37,7 @@ Changes in command line arguments:
 - [NXDRIVE-1158](https://jira.nuxeo.com/browse/NXDRIVE-1158): Restore the context menu "Edit metadata"
 - [NXDRIVE-1166](https://jira.nuxeo.com/browse/NXDRIVE-1166): Display a notification on new update on GNU/Linux
 - [NXDRIVE-1175](https://jira.nuxeo.com/browse/NXDRIVE-1175): New language: Hebrew
+- [NXDRIVE-1203](https://jira.nuxeo.com/browse/NXDRIVE-1203): Files appears as "not synced" when restarting nuxeo drive
 
 ### Packaging / Build
 - [NXDRIVE-136](https://jira.nuxeo.com/browse/NXDRIVE-136): Activate code signing on macOS (valid until 2023-03-10)

--- a/docs/technical_changes.md
+++ b/docs/technical_changes.md
@@ -50,6 +50,7 @@
 - Removed `Engine.get_last_sync()`
 - Removed `Engine.get_next_file()`
 - Removed `Engine.get_previous_file()`
+- Added `Engine.local_folder_bs`
 - Removed `Engine.resolve_with_duplicate()`
 - Added `Engine.set_ui()`
 - Changed `EngineDAO.__init__(self, db, state_factory=StateRow)` to `state_factory=None`

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -106,6 +106,9 @@ class Engine(QObject):
         # Remove remote client cache on proxy update
         self._manager.proxyUpdated.connect(self.invalidate_client_cache)
         self.local_folder = definition.local_folder
+        # Keep folder path with backslash to find the right engine when
+        # FinderSync is asking for the status of a file
+        self.local_folder_bs = self._normalize_url(self.local_folder)
         self.uid = definition.uid
         self.name = definition.name
         self._stopped = True
@@ -183,6 +186,7 @@ class Engine(QObject):
     def set_local_folder(self, path):
         log.debug("Update local folder to '%s'", path)
         self.local_folder = path
+        self.local_folder_bs = self._normalize_url(self.local_folder)
         self._local_watcher.stop()
         self._create_local_watcher()
         self._manager.update_engine_path(self.uid, path)

--- a/nxdrive/manager.py
+++ b/nxdrive/manager.py
@@ -1065,7 +1065,7 @@ class Manager(QtCore.QObject):
             # Only send status if we picked the right
             # engine and if we're not targeting the root
             path = unicodedata.normalize('NFC', force_decode(path))
-            if (path.startswith(engine.local_folder)
+            if (path.startswith(engine.local_folder_bs)
                     and not os.path.samefile(path, engine.local_folder)):
                 r_path = path.replace(engine.local_folder, '')
                 dao = self._engines[engine.uid]._dao


### PR DESCRIPTION
The badge lookup was done in the wrong engine. Fixed the comparison to ensure a correct lookup.