### PR TITLE
NXDRIVE-1214: Fix lastest failures following the Python client integration

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2,6 +2,7 @@
 Release date: `2018-??-??`
 
 Changes in command line arguments:
+
 - Removed `proxy-exceptions`
 - Removed `proxy-type`: Pass the scheme directly in the `proxy-server` url
 
@@ -14,9 +15,9 @@ Changes in command line arguments:
 - [NXDRIVE-1183](https://jira.nuxeo.com/browse/NXDRIVE-1183): Make server UI selection smarter
 
 #### Minor changes
-- Jenkins:Added the `PYTEST_ADDOPTS` parameter to the Drive-tests job
+- Jenkins: Added the `PYTEST_ADDOPTS` parameter to the Drive-tests job
 - Jenkins: Removed the `ENABLE_PROFILER` parameter from the Drive-tests job
-- Packaging: Added `nuxeo` 2.0.0
+- Packaging: Added `nuxeo` 2.0.1
 - Packaging: Updated `pytest` from 3.5.1 to 3.6.0
 
 

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -184,9 +184,11 @@ class Remote(Nuxeo):
                     check_suspended=check_suspended)
             finally:
                 lock_path(file_out, locker)
+                del resp
             return file_out
         else:
             result = resp.content
+            del resp
             return result
 
     def upload(
@@ -216,6 +218,7 @@ class Remote(Nuxeo):
                 if mime_type:
                     blob.mimetype = mime_type
                 upload_result = batch.upload(blob)
+                blob.fd.close()
 
                 upload_duration = int(time.time() - tick)
                 action.transfer_duration = upload_duration

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -223,14 +223,14 @@ class Remote(Nuxeo):
                 tx_timeout = max(TX_TIMEOUT, upload_duration * 2)
                 log.trace(
                     'Using %d seconds [max(%d, 2 * upload time=%d)] as '
-                    'Nuxeo transaction timeout for batch execution of %s '
-                    'with file %s', tx_timeout, TX_TIMEOUT, upload_duration,
+                    'Nuxeo transaction timeout for batch execution of %r '
+                    'with file %r', tx_timeout, TX_TIMEOUT, upload_duration,
                     command, file_path)
 
                 if upload_duration > 0:
-                    log.trace('Speed for %d o is %ds: %f o/s',
-                              os.stat(file_path).st_size, upload_duration,
-                              os.stat(file_path).st_size / upload_duration)
+                    size = os.stat(file_path).st_size
+                    log.trace('Speed for %d bytes is %d sec: %f bytes/sec',
+                              size, upload_duration, size / upload_duration)
 
                 if command:
                     headers = {'Nuxeo-Transaction-Timeout': str(tx_timeout)}

--- a/nxdrive/engine/dao/sqlite.py
+++ b/nxdrive/engine/dao/sqlite.py
@@ -221,8 +221,8 @@ class ConfigurationDAO(QObject):
         log.debug('Disposing SQLite database %r', self.get_db())
         for con in self._connections:
             con.close()
-        self._connections = []
-        self._conn = None
+        del self._connections
+        del self._conn
 
     def _get_write_connection(self):
         if self.share_connection or self.in_tx:

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -354,7 +354,7 @@ class Engine(QObject):
         try:
             if self.remote:
                 self.remote.revoke_token()
-        except Unauthorized:
+        except HTTPError:
             # Token already revoked
             pass
         except:

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -58,7 +58,6 @@ class Engine(QObject):
     rootMoved = pyqtSignal(str)
     noSpaceLeftOnDevice = pyqtSignal()
     invalidAuthentication = pyqtSignal()
-    invalidClientsCache = pyqtSignal()
     newConflict = pyqtSignal(object)
     newReadonly = pyqtSignal(object, object)
     deleteReadonly = pyqtSignal(object)
@@ -361,10 +360,9 @@ class Engine(QObject):
         except:
             log.exception('Unbind error')
 
-        self.dispose_db()
-        log.debug('Remove DB file %r', self._get_db_file())
         self.manager.osi.unregister_folder_link(self.local_folder)
 
+        self.dispose_db()
         try:
             os.remove(self._get_db_file())
         except (IOError, OSError) as exc:
@@ -874,7 +872,7 @@ class Engine(QObject):
         return Processor(self, item_getter, **kwargs)
 
     def dispose_db(self):
-        if self._dao is not None:
+        if self._dao:
             self._dao.dispose()
 
     def get_user_full_name(self, userid, cache_only=False):

--- a/nxdrive/engine/watcher/remote_watcher.py
+++ b/nxdrive/engine/watcher/remote_watcher.py
@@ -433,17 +433,16 @@ class RemoteWatcher(EngineWorker):
         child_pair = self._dao.get_state_from_id(row_id, from_write=True)
         return child_pair, True
 
-    @staticmethod
-    def _handle_readonly(local_client, doc_pair):
+    def _handle_readonly(self, doc_pair):
         # Don't use readonly on folder for win32 and on Locally Edited
         if doc_pair.folderish and os.sys.platform == 'win32':
             return
         if doc_pair.is_readonly():
             log.debug('Setting %r as readonly', doc_pair.local_path)
-            local_client.set_readonly(doc_pair.local_path)
+            self.engine.local.set_readonly(doc_pair.local_path)
         else:
             log.debug('Unsetting %r as readonly', doc_pair.local_path)
-            local_client.unset_readonly(doc_pair.local_path)
+            self.engine.local.unset_readonly(doc_pair.local_path)
 
     def _partial_full_scan(self, path):
         log.debug('Continue full scan of %r', path)
@@ -752,8 +751,7 @@ class RemoteWatcher(EngineWorker):
                         if lock_update:
                             doc_pair = self._dao.get_state_from_id(doc_pair.id)
                             try:
-                                self._handle_readonly(
-                                    self.local, doc_pair)
+                                self._handle_readonly(doc_pair)
                             except (OSError, IOError) as exc:
                                 log.trace('Cannot handle readonly for %r (%r)',
                                           doc_pair, exc)

--- a/nxdrive/engine/watcher/remote_watcher.py
+++ b/nxdrive/engine/watcher/remote_watcher.py
@@ -54,10 +54,6 @@ class RemoteWatcher(EngineWorker):
         metrics['next_polling'] = self._next_check
         return dict(metrics.items() + self._metrics.items())
 
-    @pyqtSlot()
-    def _reset_clients(self):
-        pass
-
     def _execute(self):
         first_pass = True
         try:

--- a/nxdrive/engine/workers.py
+++ b/nxdrive/engine/workers.py
@@ -198,12 +198,7 @@ class EngineWorker(Worker):
     def __init__(self, engine, dao, thread=None, **kwargs):
         super(EngineWorker, self).__init__(thread=thread, **kwargs)
         self.engine = engine
-        self.engine.invalidClientsCache.connect(self._reset_clients)
         self._dao = dao
-
-    @pyqtSlot()
-    def _reset_clients(self):
-        pass
 
     def giveup_error(self, doc_pair, error, exception=None):
         details = str(exception) if exception else None

--- a/nxdrive/updater/base.py
+++ b/nxdrive/updater/base.py
@@ -162,12 +162,11 @@ class BaseUpdater(PollWorker):
 
         url = self.update_site + '/versions.yml'
         try:
-            req = requests.get(url)
-            req.raise_for_status()
+            with requests.get(url) as resp:
+                resp.raise_for_status()
+                content = resp.text
         except Exception as exc:
             raise UpdateError('Impossible to get %r: %s' % (url, exc))
-        else:
-            content = req.text
 
         try:
             versions = yaml.safe_load(content)

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -460,17 +460,17 @@ def guess_server_url(url, login_page=Options.startup_page, timeout=5):
         try:
             rfc3987.parse(new_url, rule='URI')
             log.trace('Testing URL %r', new_url)
-            ret = requests.get(new_url + '/' + login_page, timeout=timeout)
-            ret.raise_for_status()
+            full_url = new_url + '/' + login_page
+            with requests.get(full_url, timeout=timeout) as resp:
+                resp.raise_for_status()
+                if resp.status_code == 200:
+                    return new_url
         except requests.HTTPError as exc:
             if exc.response.status_code == 401:
                 # When there is only Web-UI installed, the code is 401.
                 return new_url
         except (ValueError, requests.ConnectionError):
             pass
-        else:
-            if ret.status_code == 200:
-                return new_url
 
     if not url.lower().startswith('http'):
         return None

--- a/nxdrive/wui/application.py
+++ b/nxdrive/wui/application.py
@@ -570,6 +570,8 @@ class Application(SimpleApplication):
         except ValueError:
             log.exception('[%s] Invalid release notes', version)
             return
+        finally:
+            del content
 
         try:
             html = markdown(data['body'])

--- a/nxdrive/wui/settings.py
+++ b/nxdrive/wui/settings.py
@@ -247,9 +247,10 @@ class WebSettingsApi(WebDriveApi):
                 'User-Agent': (self._manager.app_name
                                + '/' + self._manager.version),
             }
-            response = requests.get(url, headers=headers,
-                                    timeout=STARTUP_PAGE_CONNECTION_TIMEOUT)
-            status = response.status_code
+            timeout = STARTUP_PAGE_CONNECTION_TIMEOUT
+            with requests.get(
+                    url, headers=headers, timeout=timeout) as resp:
+                status = resp.status_code
         except:
             log.exception('Error while trying to connect to Nuxeo Drive'
                           ' startup page with URL %s', url)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ appdirs==1.4.3
 faulthandler==3.1  # TODO: Remove when NXDRIVE-691 is done
 Js2Py==0.59; python_version == '2.7'
 markdown==2.6.11
-https://github.com/nuxeo/nuxeo-python-client/archive/master.zip
+nuxeo==2.0.1
 psutil==5.4.4
 pyaml==17.12.1
 pycryptodomex==3.6.1

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,10 +3,10 @@ import logging
 import os
 
 import nuxeo.constants
+import nuxeo.operations
 from nuxeo.exceptions import HTTPError
 
-from nxdrive.client import LocalClient
-from nxdrive.client import NuxeoDocumentInfo, Remote, safe_filename
+from nxdrive.client import LocalClient, NuxeoDocumentInfo, Remote, safe_filename
 from nxdrive.engine.engine import Engine
 from nxdrive.logging_config import configure
 from nxdrive.manager import Manager
@@ -44,8 +44,22 @@ def configure_logger():
 configure_logger()
 log = logging.getLogger(__name__)
 
+# Operations cache
+OPS_CACHE = None
 
-class RemoteTest(Remote):
+
+class RemoteBase(Remote):
+    def __init__(self, *args, **kwargs):
+        super(RemoteBase, self).__init__(*args, **kwargs)
+
+        # Save bandwith by caching operations details
+        global OPS_CACHE
+        if not OPS_CACHE:
+            OPS_CACHE = self.operations.operations
+            nuxeo.operations.API.ops = OPS_CACHE
+
+
+class RemoteTest(RemoteBase):
 
     _download_remote_error = None
     _upload_remote_error = None

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,12 +5,30 @@ import os
 import nuxeo.constants
 from nuxeo.exceptions import HTTPError
 
+from nxdrive.client import LocalClient
 from nxdrive.client import NuxeoDocumentInfo, Remote, safe_filename
+from nxdrive.engine.engine import Engine
 from nxdrive.logging_config import configure
+from nxdrive.manager import Manager
+from nxdrive.osi.darwin.darwin import DarwinIntegration
 from nxdrive.utils import make_tmp_file
 
 # Automatically check all operations done with the Python client
 nuxeo.constants.CHECK_PARAMS = True
+
+# Remove features for tests
+LocalClient.has_folder_icon = lambda *args: True
+Engine.add_to_favorites = lambda *args: None
+DarwinIntegration._cleanup = lambda *args: None
+DarwinIntegration._init = lambda *args: None
+DarwinIntegration.send_sync_status = lambda *args: None
+DarwinIntegration.watch_folder = lambda *args: None
+DarwinIntegration.unwatch_folder = lambda *args: None
+Manager._create_findersync_listener = lambda *args: None
+Manager._create_updater = lambda *args: None
+Manager._create_server_config_updater = lambda *args: None
+Manager._handle_os = lambda: None
+Manager.send_sync_status = lambda *args: None
 
 
 def configure_logger():
@@ -19,10 +37,6 @@ def configure_logger():
     configure(console_level='TRACE',
               command_name='test',
               force_configure=True,
-              use_file_handler=True,
-              log_filename=os.path.join(
-                  os.environ.get('WORKSPACE', ''),
-                  'tmp', 'testing.log'),
               formatter=formatter)
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -19,14 +19,14 @@ from PyQt4 import QtCore
 from nuxeo.exceptions import HTTPError
 from requests import ConnectionError
 
-from nxdrive.client import LocalClient, Remote
+from nxdrive.client import LocalClient
 from nxdrive.engine.watcher.local_watcher import WIN_MOVE_RESOLUTION_PERIOD
 from nxdrive.manager import Manager
 from nxdrive.options import Options
 from nxdrive.osi import AbstractOSIntegration
 from nxdrive.utils import safe_long_path, unset_path_readonly
 from nxdrive.wui.translator import Translator
-from . import DocRemote
+from . import DocRemote, RemoteBase
 from .conftest import root_remote
 
 # Default remote watcher delay used for tests
@@ -295,13 +295,13 @@ class UnitTestCase(TestCase):
 
         # File system client to be used to create remote test documents
         # and folders
-        self.remote_1 = Remote(
+        self.remote_1 = RemoteBase(
                 pytest.nuxeo_url, self.user_1, u'nxdrive-test-device-1',
                 pytest.version, password=self.password_1,
                 base_folder=self.workspace_1,
                 upload_tmp_dir=self.upload_tmp_dir)
 
-        self.remote_2 = Remote(
+        self.remote_2 = RemoteBase(
                 pytest.nuxeo_url, self.user_2, u'nxdrive-test-device-2',
                 pytest.version, password=self.password_2,
                 base_folder=self.workspace_2,

--- a/tests/common.py
+++ b/tests/common.py
@@ -315,6 +315,16 @@ class UnitTestCase(TestCase):
             self.addCleanup(self._unregister, self.workspace_2)
 
     def tearDownApp(self):
+        try:
+            self.engine_1.remote.client._session.close()
+        except AttributeError:
+            pass
+
+        try:
+            self.engine_2.remote.client._session.close()
+        except AttributeError:
+            pass
+
         attrs = (
             'engine_1',
             'engine_2',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,10 @@ def cleanup_attrs(request):
         attr_orig = set(request.instance.__dict__.keys())
         yield
         for attr in set(request.instance.__dict__.keys()) - attr_orig:
+            if attr.startswith('engine_'):
+                engine = getattr(request.instance, attr)
+                if engine.remote:
+                    engine.remote.client._session.close()
             delattr(request.instance, attr)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,78 @@
 # coding: utf-8
+import os
+
+import pytest
+
+import nxdrive
 
 pytest_plugins = 'tests.pytest_random'
+
+
+def pytest_namespace():
+    """
+    This namespace is used to store global variables for
+    tests. They can be accessed with `pytest.<variable_name>`
+    e.g. `pytest.nuxeo_url`
+    """
+    return {
+        'nuxeo_url': os.getenv('NXDRIVE_TEST_NUXEO_URL',
+                               'http://localhost:8080/nuxeo').split('#')[0],
+        'user': os.getenv('NXDRIVE_TEST_USER', 'Administrator'),
+        'password': os.getenv('NXDRIVE_TEST_PASSWORD', 'Administrator'),
+        'version': nxdrive.__version__,
+    }
+
+
+@pytest.hookimpl(trylast=True, hookwrapper=True)
+def pytest_runtest_makereport():
+    """
+    Delete captured logs if the test is not in failure.
+    It will help keeping the memory usage at a descent level.
+    """
+
+    # Execute the test
+    outcome = yield
+
+    # Get the report
+    report = outcome.get_result()
+
+    if report.passed:
+        # Remove captured logs to free memory
+        report.sections = []
+        outcome.force_result(report)
+
+
+@pytest.fixture(autouse=True)
+def cleanup_attrs(request):
+    """
+    Delete any attribute added in the test.
+    It will help keeping the memory usage at a descent level.
+    """
+    if not request.instance:
+        yield
+    else:
+        attr_orig = set(request.instance.__dict__.keys())
+        yield
+        for attr in set(request.instance.__dict__.keys()) - attr_orig:
+            delattr(request.instance, attr)
+
+
+@pytest.fixture(scope='session')
+def root_remote():
+    """ The root remote client (administrator). """
+    from . import DocRemote
+
+    return DocRemote(
+        pytest.nuxeo_url,
+        pytest.user,
+        'nxdrive-test-administrator-device',
+        pytest.version,
+        password=pytest.password,
+        base_folder='/',
+        timeout=60)
+
+
+@pytest.fixture(autouse=True)
+def announce(request, root_remote):
+    """ Log the current test on the server. """
+    root_remote.log_on_server('>>> testing: ' + request.node.nodeid)

--- a/tests/test_bind_server.py
+++ b/tests/test_bind_server.py
@@ -27,12 +27,6 @@ class BindServerTest(unittest.TestCase):
         self.nxdrive_conf_folder = os.path.join(self.local_test_folder,
                                                 u'nuxeo-drive-conf')
 
-        self.nuxeo_url = os.environ.get('NXDRIVE_TEST_NUXEO_URL',
-                                        'http://localhost:8080/nuxeo')
-        self.user = os.environ.get('NXDRIVE_TEST_USER', 'Administrator')
-        self.password = os.environ.get('NXDRIVE_TEST_PASSWORD',
-                                       'Administrator')
-
     def tearDown(self):
         Manager._singleton = None
 
@@ -46,5 +40,5 @@ class BindServerTest(unittest.TestCase):
 
         with pytest.raises(FolderAlreadyUsed):
             self.manager.bind_server(
-                self.nxdrive_conf_folder, self.nuxeo_url, self.user,
-                self.password, start_engine=False)
+                self.nxdrive_conf_folder, pytest.nuxeo_url, pytest.user,
+                pytest.password, start_engine=False)

--- a/tests/test_darwin.py
+++ b/tests/test_darwin.py
@@ -4,9 +4,9 @@ import pytest
 from nxdrive.osi import AbstractOSIntegration
 
 
-def is_folder_registered(os, name):
-    lst = os._get_favorite_list()
-    return os._find_item_in_list(lst, name) is not None
+def is_folder_registered(osi, name):
+    lst = osi._get_favorite_list()
+    return osi._find_item_in_list(lst, name) is not None
 
 
 @pytest.mark.skipif(not AbstractOSIntegration.is_mac(), reason='macOS only.')
@@ -14,12 +14,12 @@ def test_folder_registration():
     name = 'TestCazz'
 
     # Unregister first; to ensure favorite bar is cleaned.
-    os = AbstractOSIntegration.get(None)
-    os.unregister_folder_link(name)
-    assert not is_folder_registered(os, name)
+    osi = AbstractOSIntegration.get(None)
+    osi.unregister_folder_link(name)
+    assert not is_folder_registered(osi, name)
 
-    os.register_folder_link('.', name)
-    assert is_folder_registered(os, name)
+    osi.register_folder_link('.', name)
+    assert is_folder_registered(osi, name)
 
-    os.unregister_folder_link(name)
-    assert not is_folder_registered(os, name)
+    osi.unregister_folder_link(name)
+    assert not is_folder_registered(osi, name)

--- a/tests/test_direct_edit.py
+++ b/tests/test_direct_edit.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 import os
 
+import pytest
+
 from nuxeo.exceptions import HTTPError
 from nuxeo.models import User
 
@@ -57,7 +59,7 @@ class TestDirectEdit(UnitTestCase):
         user = 'Administrator'
         get_engine = self.direct_edit._get_engine
         
-        assert get_engine(self.nuxeo_url, self.user_1)
+        assert get_engine(pytest.nuxeo_url, self.user_1)
 
         self.manager_1._engine_types['NXDRIVETESTURL'] = MockUrlTestEngine
 
@@ -111,7 +113,7 @@ class TestDirectEdit(UnitTestCase):
         self.remote_document_client_2.lock(doc_id)
         self.direct_edit.directEditLocked.connect(
             self._test_locked_file_signal)
-        self.direct_edit._prepare_edit(self.nuxeo_url, doc_id)
+        self.direct_edit._prepare_edit(pytest.nuxeo_url, doc_id)
         assert self._received
 
     def test_self_locked_file(self):
@@ -129,7 +131,7 @@ class TestDirectEdit(UnitTestCase):
 
         self.manager_1.open_local_file = open_local_file
         if url is None:
-            self.direct_edit._prepare_edit(self.nuxeo_url, doc_id)
+            self.direct_edit._prepare_edit(pytest.nuxeo_url, doc_id)
         else:
             self.direct_edit.handle_url(url)
         assert self.local.exists(local_path)
@@ -157,7 +159,7 @@ class TestDirectEdit(UnitTestCase):
             pass
 
         self.manager_1.open_local_file = open_local_file
-        self.direct_edit._prepare_edit(self.nuxeo_url, doc_id)
+        self.direct_edit._prepare_edit(pytest.nuxeo_url, doc_id)
         assert self.local.exists(local_path)
         self.wait_sync(timeout=2, fail_if_timeout=False)
         self.direct_edit.stop()
@@ -209,7 +211,7 @@ class TestDirectEdit(UnitTestCase):
         assert username == 'unknown'
 
     def test_download_url_with_spaces(self):
-        scheme, host = self.nuxeo_url.split('://')
+        scheme, host = pytest.nuxeo_url.split('://')
         filename = u'My file with spaces.txt'
         doc_id = self.remote.make_file('/', filename, 'Some content.')
 
@@ -222,7 +224,7 @@ class TestDirectEdit(UnitTestCase):
         self._direct_edit_update(doc_id, filename, 'Test', url)
 
     def test_download_url_with_accents(self):
-        scheme, host = self.nuxeo_url.split('://')
+        scheme, host = pytest.nuxeo_url.split('://')
         filename = u'éèáä.txt'
         doc_id = self.remote.make_file('/', filename, 'Some content.')
 

--- a/tests/test_group_changes.py
+++ b/tests/test_group_changes.py
@@ -16,6 +16,7 @@ class TestGroupChanges(UnitTestCase):
     """
 
     def setUp(self):
+        super(TestGroupChanges, self).setUp()
         remote = self.root_remote
 
         # Create test workspace
@@ -57,6 +58,7 @@ class TestGroupChanges(UnitTestCase):
             base_folder=self.workspace_path)
 
     def tearDown(self):
+        super(TestGroupChanges, self).tearDown()
         remote = self.root_remote
 
         # Delete test workspace

--- a/tests/test_group_changes.py
+++ b/tests/test_group_changes.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from logging import getLogger
 
+import pytest
 from nuxeo.models import Document, Group
 
 from . import DocRemote
@@ -52,9 +53,9 @@ class TestGroupChanges(UnitTestCase):
         assert 'grandParentGroup' in group_names
 
         self.admin_remote = DocRemote(
-            self.nuxeo_url, self.admin_user,
+            pytest.nuxeo_url, pytest.user,
             'nxdrive-test-administrator-device',
-            self.version, password=self.password,
+            pytest.version, password=pytest.password,
             base_folder=self.workspace_path)
 
     def tearDown(self):
@@ -193,10 +194,10 @@ class TestGroupChanges(UnitTestCase):
 
     def _register_sync_root_user1(self, sync_root_id):
         user1_remote = DocRemote(
-            self.nuxeo_url,
+            pytest.nuxeo_url,
             self.user_1,
             'nxdrive-test-device-1',
-            self.version,
+            pytest.version,
             password=self.password_1,
             base_folder=sync_root_id,
             upload_tmp_dir=self.upload_tmp_dir)

--- a/tests/test_local_move_and_rename.py
+++ b/tests/test_local_move_and_rename.py
@@ -558,9 +558,9 @@ class TestLocalMoveAndRename(UnitTestCase):
         # Use the Administrator to be able to introspect the container of the
         # test workspace.
         remote = DocRemote(
-            self.nuxeo_url, self.admin_user,
-            'nxdrive-test-administrator-device', self.version,
-            password=self.password, base_folder=self.workspace)
+            pytest.nuxeo_url, pytest.user,
+            'nxdrive-test-administrator-device', pytest.version,
+            password=pytest.password, base_folder=self.workspace)
         folder_1_uid = remote.get_info(u'/Original Folder 1').uid
 
         # Create new clients to be able to introspect the test sync root
@@ -587,8 +587,8 @@ class TestLocalMoveAndRename(UnitTestCase):
 
         # Simulate server error
         self.engine_1.remote = RemoteTest(
-            self.nuxeo_url, self.user_1,
-            u'nxdrive-test-administrator-device', self.version,
+            pytest.nuxeo_url, self.user_1,
+            u'nxdrive-test-administrator-device', pytest.version,
             password=self.password_1)
         error = HTTPError('', 500, 'Mock server error', {}, None)
         self.engine_1.remote.make_server_call_raise(error)

--- a/tests/test_local_storage_issue.py
+++ b/tests/test_local_storage_issue.py
@@ -40,8 +40,8 @@ class TestLocalStorageSpaceIssue(UnitTestCase):
 
         # Synchronize simulating a "No space left on device" error
         self.engine_1.remote = RemoteTest(
-            self.nuxeo_url, self.user_1,
-            u'nxdrive-test-administrator-device', self.version,
+            pytest.nuxeo_url, self.user_1,
+            u'nxdrive-test-administrator-device', pytest.version,
             password=self.password_1)
         error = IOError('No space left on device')
         self.engine_1.remote.make_download_raise(error)

--- a/tests/test_long_path.py
+++ b/tests/test_long_path.py
@@ -21,6 +21,8 @@ FOLDER_D = 'D' * 50
 
 class TestLongPath(UnitTestCase):
     def setUp(self):
+        super(TestLongPath, self).setUp()
+
         self.remote_1 = self.remote_document_client_1
         log.info('Create a folder AAAA... (90 chars) in server')
         self.folder_a = self.remote_1.make_folder('/', FOLDER_A)
@@ -30,6 +32,7 @@ class TestLongPath(UnitTestCase):
 
     def tearDown(self):
         self.remote_1.delete(self.folder_a, use_trash=False)
+        super(TestLongPath, self).tearDown()
 
     def test_long_path(self):
         self.engine_1.start()

--- a/tests/test_long_path.py
+++ b/tests/test_long_path.py
@@ -3,6 +3,8 @@ import os
 import sys
 from logging import getLogger
 
+import pytest
+
 from nxdrive.utils import safe_long_path
 from .common import UnitTestCase
 
@@ -86,7 +88,7 @@ class TestLongPath(UnitTestCase):
         self.manager_1.unbind_all()
         self.engine_1 = self.manager_1.bind_server(
             self.local_nxdrive_folder_1,
-            self.nuxeo_url,
+            pytest.nuxeo_url,
             self.user_2,
             self.password_2,
             start_engine=False)

--- a/tests/test_mac_local_client.py
+++ b/tests/test_mac_local_client.py
@@ -4,6 +4,11 @@ import pytest
 from nxdrive.osi import AbstractOSIntegration
 from .common import UnitTestCase
 
+try:
+    import xattr
+except ImportError:
+    pass
+
 
 @pytest.mark.skipif(
     not AbstractOSIntegration.is_mac(),
@@ -19,24 +24,17 @@ class TestMacSpecific(UnitTestCase):
                                content=u'Some Content 1'.encode('utf-8'))
 
         # Emulate the Finder in use flag
-        OSX_FINDER_INFO_ENTRY_SIZE = 32
-        key = (OSX_FINDER_INFO_ENTRY_SIZE)*[0]
-        key[0] = 0x62
-        key[1] = 0x72
-        key[2] = 0x6F
-        key[3] = 0x6B
-        key[4] = 0x4D
-        key[5] = 0x41
-        key[6] = 0x43
-        key[7] = 0x53
-        import xattr
+        key = [0] * 32  # OSX_FINDER_INFO_ENTRY_SIZE
+        key[:8] = 0x62, 0x72, 0x6F, 0x6B, 0x4D, 0x41, 0x43, 0x53
+
         xattr.setxattr(
-            self.local_1.abspath(u'/File.txt'), xattr.XATTR_FINDERINFO_NAME,
+            self.local_1.abspath(u'/File.txt'),
+            xattr.XATTR_FINDERINFO_NAME,
             bytes(bytearray(key)))
 
         # The file should not be synced and there have no remote id
         self.wait_sync(wait_for_async=True, fail_if_timeout=False, timeout=10)
-        assert self.local_1.get_remote_id(u'/File.txt') is None
+        assert not self.local_1.get_remote_id(u'/File.txt')
 
         # Remove the Finder flag
         self.local_1.remove_remote_id(
@@ -44,4 +42,4 @@ class TestMacSpecific(UnitTestCase):
 
         # The sync process should now handle the file and sync it
         self.wait_sync(wait_for_async=True, fail_if_timeout=False, timeout=10)
-        assert self.local_1.get_remote_id(u'/File.txt') is not None
+        assert self.local_1.get_remote_id(u'/File.txt')

--- a/tests/test_manager_dao.py
+++ b/tests/test_manager_dao.py
@@ -20,15 +20,6 @@ class ManagerDAOTest(unittest.TestCase):
             os.makedirs(self.tmpdir)
 
         self.test_folder = tempfile.mkdtemp(u'-nxdrive-tests', dir=self.tmpdir)
-        self.nuxeo_url = os.environ.get('NXDRIVE_TEST_NUXEO_URL',
-                                        'http://localhost:8080/nuxeo')
-        self.admin_user = os.environ.get('NXDRIVE_TEST_USER', 'Administrator')
-        # Handle the # in url
-        if '#' in self.nuxeo_url:
-            # Remove the engine type for the rest of the test
-            self.nuxeo_url = self.nuxeo_url.split('#')[0]
-        if not self.nuxeo_url.endswith('/'):
-            self.nuxeo_url += '/'
 
     def tearDown(self):
         Manager._singleton = None

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -164,7 +164,8 @@ def test_setters():
 def test_site_update_url():
     for url in (Options.update_site_url,
                 Options.beta_update_site_url):
-        requests.get(url).raise_for_status()
+        with requests.get(url) as resp:
+            resp.raise_for_status()
 
 
 @Options.mock()

--- a/tests/test_remote_move_and_rename.py
+++ b/tests/test_remote_move_and_rename.py
@@ -545,8 +545,8 @@ class TestRemoteMoveAndRename(UnitTestCase):
 
         # Get remote client with Workspaces as base folder and local client
         remote = DocRemote(
-            self.nuxeo_url, self.user_1, 'nxdrive-test-device-1',
-            self.version, password=self.password_1, base_folder=workspaces,
+            pytest.nuxeo_url, self.user_1, 'nxdrive-test-device-1',
+            pytest.version, password=self.password_1, base_folder=workspaces,
             upload_tmp_dir=self.upload_tmp_dir)
         local = self.local_1
 

--- a/tests/test_synchronization.py
+++ b/tests/test_synchronization.py
@@ -147,8 +147,8 @@ class TestSynchronization(UnitTestCase):
         # Simulate bad responses
         remote_orig = self.engine_1.remote
         self.engine_1.remote = RemoteTest(
-            self.nuxeo_url, self.user_1,
-            u'nxdrive-test-administrator-device', self.version,
+            pytest.nuxeo_url, self.user_1,
+            u'nxdrive-test-administrator-device', pytest.version,
             password=self.password_1)
         errors = [HTTPError(status=401, message='Mock'),
                   HTTPError(status=403, message='Mock')]
@@ -333,8 +333,8 @@ class TestSynchronization(UnitTestCase):
 
         # Simulate a server failure on file download
         self.engine_1.remote = RemoteTest(
-            self.nuxeo_url, self.user_1,
-            u'nxdrive-test-administrator-device', self.version,
+            pytest.nuxeo_url, self.user_1,
+            u'nxdrive-test-administrator-device', pytest.version,
             password=self.password_1)
         error = HTTPError(status=500, message='Mock download error')
         self.engine_1.remote.make_download_raise(error)
@@ -388,8 +388,8 @@ class TestSynchronization(UnitTestCase):
 
         # Find various ways to simulate a network failure
         self.engine_1.remote = RemoteTest(
-            self.nuxeo_url, self.user_1,
-            u'nxdrive-test-administrator-device', self.version,
+            pytest.nuxeo_url, self.user_1,
+            u'nxdrive-test-administrator-device', pytest.version,
             password=self.password_1)
         errors = [ConnectionError('Mock connection error'),
                   socket.error('Mock socket error'),
@@ -675,8 +675,8 @@ class TestSynchronization(UnitTestCase):
         remote = self.remote_document_client_1
 
         self.engine_1.remote = RemoteTest(
-            self.nuxeo_url, self.user_1,
-            u'nxdrive-test-administrator-device', self.version,
+            pytest.nuxeo_url, self.user_1,
+            u'nxdrive-test-administrator-device', pytest.version,
             password=self.password_1)
         self.engine_1.remote.make_download_raise(
             HTTPError(status=400, message='Mock'))
@@ -992,9 +992,9 @@ class TestSynchronization(UnitTestCase):
             return kwargs.get('filename').endswith('2.txt')
 
         # Simulate a server conflict on file upload
-        engine.remote = RemoteTest(self.nuxeo_url, self.user_1,
+        engine.remote = RemoteTest(pytest.nuxeo_url, self.user_1,
                                    u'nxdrive-test-administrator-device',
-                                   self.version, password=self.password_1)
+                                   pytest.version, password=self.password_1)
         error = HTTPError(status=409, message='Mock Conflict')
         engine.remote.make_upload_raise(error)
         engine.remote.raise_on = _raise_for_second_file_only


### PR DESCRIPTION
GNU/Linux: OK.
Windows: OK.
macOS: tests OK, but we still have the noisy `select: Invalid argument`. I will provide a second PR for that.

Why merging now? To let other work to be done based on fixes provided by this PR.
Also, I want to see how it works with other waiting PR to be merged + NXDRIVE-1212 where we will disable all server side converters. Currently, tests are taking too long on this OS with converters enabled.