### PR TITLE
NXDRIVE-1239: DirectEdit should work after network loss

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -15,6 +15,7 @@ Changes in command line arguments:
 - [NXDRIVE-1068](https://jira.nuxeo.com/browse/NXDRIVE-1068): Move proxy support to a dedicated module (**breaking change**)
 - [NXDRIVE-1201](https://jira.nuxeo.com/browse/NXDRIVE-1201): Adapt Drive for new Trash API behavior
 - [NXDRIVE-1210](https://jira.nuxeo.com/browse/NXDRIVE-1210): Sanitize exported objects
+- [NXDRIVE-1239](https://jira.nuxeo.com/browse/NXDRIVE-1239): DirectEdit should work after network loss
 - [NXDRIVE-1240](https://jira.nuxeo.com/browse/NXDRIVE-1240): Use black for a big code clean-up
 - [NXDRIVE-1241](https://jira.nuxeo.com/browse/NXDRIVE-1241): Set the --consider-ssl-errors argument default value to True
 - [NXDRIVE-1242](https://jira.nuxeo.com/browse/NXDRIVE-1242): Use type annotations everywhere

--- a/nxdrive/direct_edit.py
+++ b/nxdrive/direct_edit.py
@@ -293,9 +293,6 @@ class DirectEdit(Worker):
         if not engine:
             return None
 
-        # Get document info, used in self._handle_*_queue()
-        self.remote = engine.remote
-
         # Avoid any link with the engine, remote_doc are not cached so we
         # can do that
         info = self._get_info(engine, doc_id, user)
@@ -411,7 +408,7 @@ class DirectEdit(Worker):
             try:
                 uid, _, _, _ = self._extract_edit_info(ref)
                 if action == "lock":
-                    self.remote.lock(uid)
+                    engine.remote.lock(uid)
                     self.local.set_remote_id(dir_path, b"1", name="nxdirecteditlock")
                     # Emit the lock signal only when the lock is really set
                     self._send_lock_status(ref)
@@ -419,7 +416,7 @@ class DirectEdit(Worker):
                     continue
 
                 try:
-                    self.remote.unlock(uid)
+                    engine.remote.unlock(uid)
                 except NotFound:
                     purge = True
                 else:
@@ -482,7 +479,7 @@ class DirectEdit(Worker):
                 # TO_REVIEW Should check if server-side blob has changed ?
                 # Update the document, should verify
                 # the remote hash NXDRIVE-187
-                remote_info = self.remote.get_info(uid)
+                remote_info = engine.remote.get_info(uid)
                 if remote_info.digest != digest:
                     # Conflict detect
                     log.trace(
@@ -500,7 +497,7 @@ class DirectEdit(Worker):
 
                 os_path = self.local.abspath(ref)
                 log.debug("Uploading file %r", os_path)
-                self.remote.stream_update(
+                engine.remote.stream_update(
                     uid, os_path, fs=False, apply_versioning_policy=True
                 )
 

--- a/nxdrive/engine/blacklist_queue.py
+++ b/nxdrive/engine/blacklist_queue.py
@@ -1,9 +1,11 @@
 # coding: utf-8
 import time
+from logging import  getLogger
 from threading import Lock
 from typing import Generator
 
 __all__ = ("BlacklistQueue",)
+log = getLogger(__name__)
 
 
 class BlacklistItem:
@@ -38,6 +40,7 @@ class BlacklistQueue:
         self._lock = Lock()
 
     def push(self, id_obj: str, obj: str) -> None:
+        log.trace('Blacklisting %r', obj)
         item = BlacklistItem(item_id=id_obj, item=obj, next_try=self._delay)
         with self._lock:
             self._queue[item.uid] = item

--- a/tests/test_direct_edit.py
+++ b/tests/test_direct_edit.py
@@ -12,6 +12,10 @@ from . import LocalTest
 from .common import UnitTestCase
 
 
+def open_local_file(*args, **kwargs):
+    pass
+
+
 class MockUrlTestEngine(Engine):
     def __init__(self, url):
         self._url = url
@@ -41,6 +45,32 @@ class TestDirectEdit(UnitTestCase):
         self.direct_edit.stop()
         super().tearDownApp()
 
+    def _direct_edit_update(
+        self, doc_id: str, filename: str, content: bytes, url: str = None
+    ):
+        # Download file
+        local_path = "/%s/%s" % (doc_id, filename)
+
+        with patch.object(self.manager_1, "open_local_file", new=open_local_file):
+            if url is None:
+                self.direct_edit._prepare_edit(pytest.nuxeo_url, doc_id)
+            else:
+                self.direct_edit.handle_url(url)
+            assert self.local.exists(local_path)
+            self.wait_sync(fail_if_timeout=False)
+            self.local.delete_final(local_path)
+
+            # Update file content
+            self.local.update_content(local_path, content)
+            self.wait_sync()
+            assert self.remote.get_blob(self.remote.get_info(doc_id)) == content
+
+            # Update file content twice
+            content += b" updated"
+            self.local.update_content(local_path, content)
+            self.wait_sync()
+            assert self.remote.get_blob(self.remote.get_info(doc_id)) == content
+
     def test_binder(self):
         engine = list(self.manager_1._engines.items())[0][1]
         binder = engine.get_binder()
@@ -52,6 +82,70 @@ class TestDirectEdit(UnitTestCase):
         assert binder.username
         assert binder.initialized
         assert binder.local_folder
+
+    def test_cleanup(self):
+        filename = "Mode op\xe9ratoire.txt"
+        doc_id = self.remote.make_file("/", filename, content=b"Some content.")
+        # Download file
+        local_path = "/%s/%s" % (doc_id, filename)
+
+        with patch.object(self.manager_1, "open_local_file", new=open_local_file):
+            self.direct_edit._prepare_edit(pytest.nuxeo_url, doc_id)
+            assert self.local.exists(local_path)
+            self.wait_sync(timeout=2, fail_if_timeout=False)
+            self.direct_edit.stop()
+
+            # Update file content
+            self.local.update_content(local_path, b"Test")
+            # Create empty folder (NXDRIVE-598)
+            self.local.make_folder("/", "emptyfolder")
+
+            # Verify the cleanup dont delete document
+            self.direct_edit._cleanup()
+            assert self.local.exists(local_path)
+            assert self.remote.get_blob(self.remote.get_info(doc_id)) != b"Test"
+
+            # Verify it reupload it
+            self.direct_edit.start()
+            self.wait_sync(timeout=2, fail_if_timeout=False)
+            assert self.local.exists(local_path)
+            assert self.remote.get_blob(self.remote.get_info(doc_id)) == b"Test"
+
+            # Verify it is cleanup if sync
+            self.direct_edit.stop()
+            self.direct_edit._cleanup()
+            assert not self.local.exists(local_path)
+
+    def test_filename_encoding(self):
+        filename = "Mode op\xe9ratoire.txt"
+        doc_id = self.remote.make_file("/", filename, content=b"Some content.")
+        self._direct_edit_update(doc_id, filename, b"Test")
+
+    def test_locked_file(self):
+        def locked_file_signal(self):
+            nonlocal received
+            received = True
+
+        received = False
+        filename = "Mode operatoire.txt"
+        doc_id = self.remote.make_file("/", filename, content=b"Some content.")
+        self.remote_document_client_2.lock(doc_id)
+        self.direct_edit.directEditLocked.connect(locked_file_signal)
+        self.direct_edit._prepare_edit(pytest.nuxeo_url, doc_id)
+        assert received
+
+    def test_note_edit(self):
+        remote = self.remote_1
+        info = remote.get_filesystem_root_info()
+        workspace_id = remote.get_fs_children(info.uid)[0].uid
+        content = "Content of file 1 Avec des accents h\xe9h\xe9.".encode()
+        file_id = remote.make_file(
+            workspace_id, "Mode op\xe9ratoire.txt", content=content
+        ).uid
+        doc_id = file_id.split("#")[-1]
+        self._direct_edit_update(
+            doc_id, "Mode op\xe9ratoire.txt", b"Atol de PomPom Gali"
+        )
 
     def test_url_resolver(self):
         user = "Administrator"
@@ -85,106 +179,62 @@ class TestDirectEdit(UnitTestCase):
         assert get_engine("https://localhost:443/nuxeo/", user=user)
         assert get_engine("https://localhost/nuxeo", user=user)
 
-    def test_note_edit(self):
-        remote = self.remote_1
-        info = remote.get_filesystem_root_info()
-        workspace_id = remote.get_fs_children(info.uid)[0].uid
-        content = "Content of file 1 Avec des accents h\xe9h\xe9.".encode()
-        file_id = remote.make_file(
-            workspace_id, "Mode op\xe9ratoire.txt", content=content
-        ).uid
-        doc_id = file_id.split("#")[-1]
-        self._direct_edit_update(
-            doc_id, "Mode op\xe9ratoire.txt", b"Atol de PomPom Gali"
-        )
-
-    def test_filename_encoding(self):
-        filename = "Mode op\xe9ratoire.txt"
-        doc_id = self.remote.make_file("/", filename, content=b"Some content.")
-        self._direct_edit_update(doc_id, filename, b"Test")
-
-    def _test_locked_file_signal(self):
-        self._received = True
-
-    def test_locked_file(self):
-        self._received = False
-        filename = "Mode operatoire.txt"
-        doc_id = self.remote.make_file("/", filename, "Some content.")
-        self.remote_document_client_2.lock(doc_id)
-        self.direct_edit.directEditLocked.connect(self._test_locked_file_signal)
-        self.direct_edit._prepare_edit(pytest.nuxeo_url, doc_id)
-        assert self._received
-
     def test_self_locked_file(self):
         filename = "Mode operatoire.txt"
         doc_id = self.remote.make_file("/", filename, content=b"Some content.")
         self.remote.lock(doc_id)
         self._direct_edit_update(doc_id, filename, b"Test")
 
-    def _direct_edit_update(
-        self, doc_id: str, filename: str, content: bytes, url: str = None
-    ):
-        # Download file
-        local_path = "/%s/%s" % (doc_id, filename)
-
-        def open_local_file(*args, **kwargs):
-            pass
-
-        with patch.object(self.manager_1, "open_local_file", new=open_local_file):
-            if url is None:
-                self.direct_edit._prepare_edit(pytest.nuxeo_url, doc_id)
-            else:
-                self.direct_edit.handle_url(url)
-            assert self.local.exists(local_path)
-            self.wait_sync(fail_if_timeout=False)
-            self.local.delete_final(local_path)
-
-            # Update file content
-            self.local.update_content(local_path, content)
-            self.wait_sync()
-            assert self.remote.get_blob(self.remote.get_info(doc_id)) == content
-
-            # Update file content twice
-            content += b" updated"
-            self.local.update_content(local_path, content)
-            self.wait_sync()
-            assert self.remote.get_blob(self.remote.get_info(doc_id)) == content
-
-    def test_direct_edit_cleanup(self):
-        filename = "Mode op\xe9ratoire.txt"
+    def test_url_with_spaces(self):
+        scheme, host = pytest.nuxeo_url.split("://")
+        filename = "My file with spaces.txt"
         doc_id = self.remote.make_file("/", filename, content=b"Some content.")
-        # Download file
-        local_path = "/%s/%s" % (doc_id, filename)
 
-        def open_local_file(*args, **kwargs):
-            pass
+        url = (
+            "nxdrive://edit/{scheme}/{host}"
+            "/user/{user}"
+            "/repo/default"
+            "/nxdocid/{doc_id}"
+            "/filename/{filename}"
+            "/downloadUrl/nxfile/default/{doc_id}"
+            "/file:content/{filename}"
+        ).format(
+            scheme=scheme, host=host, user=self.user_1, doc_id=doc_id, filename=filename
+        )
 
-        with patch.object(self.manager_1, "open_local_file", new=open_local_file):
-            self.direct_edit._prepare_edit(pytest.nuxeo_url, doc_id)
-            assert self.local.exists(local_path)
-            self.wait_sync(timeout=2, fail_if_timeout=False)
-            self.direct_edit.stop()
+        self._direct_edit_update(doc_id, filename, b"Test", url)
 
-            # Update file content
-            self.local.update_content(local_path, b"Test")
-            # Create empty folder (NXDRIVE-598)
-            self.local.make_folder("/", "emptyfolder")
+    def test_url_with_accents(self):
+        scheme, host = pytest.nuxeo_url.split("://")
+        filename = "éèáä.txt"
+        doc_id = self.remote.make_file("/", filename, content=b"Some content.")
 
-            # Verify the cleanup dont delete document
-            self.direct_edit._cleanup()
-            assert self.local.exists(local_path)
-            assert self.remote.get_blob(self.remote.get_info(doc_id)) != b"Test"
+        url = (
+            "nxdrive://edit/{scheme}/{host}"
+            "/user/{user}"
+            "/repo/default"
+            "/nxdocid/{doc_id}"
+            "/filename/{filename}"
+            "/downloadUrl/nxfile/default/{doc_id}"
+            "/file:content/{filename}"
+        ).format(
+            scheme=scheme, host=host, user=self.user_1, doc_id=doc_id, filename=filename
+        )
 
-            # Verify it reupload it
-            self.direct_edit.start()
-            self.wait_sync(timeout=2, fail_if_timeout=False)
-            assert self.local.exists(local_path)
-            assert self.remote.get_blob(self.remote.get_info(doc_id)) == b"Test"
+        self._direct_edit_update(doc_id, filename, b"Test", url)
 
-            # Verify it is cleanup if sync
-            self.direct_edit.stop()
-            self.direct_edit._cleanup()
-            assert not self.local.exists(local_path)
+    def test_url_missing_username(self):
+        """ The username must be in the URL. """
+        url = (
+            "nxdrive://edit/https/server.cloud.nuxeo.com/nuxeo"
+            "/repo/default"
+            "/nxdocid/xxxxxxxx-xxxx-xxxx-xxxx"
+            "/filename/lebron-james-beats-by-dre-powerb.psd"
+            "/downloadUrl/nxfile/default/xxxxxxxx-xxxx-xxxx-xxxx"
+            "/file:content/lebron-james-beats-by-dre-powerb.psd"
+        )
+        with pytest.raises(ValueError):
+            self._direct_edit_update("", "", b"", url)
 
     def test_user_name(self):
         # user_1 is drive_user_1, no more informations
@@ -204,8 +254,7 @@ class TestDirectEdit(UnitTestCase):
                 )
             )
         except HTTPError as exc:
-            if exc.status != 409:
-                raise
+            assert exc.status != 409
             user = remote.users.get("john")
 
         try:
@@ -217,54 +266,3 @@ class TestDirectEdit(UnitTestCase):
         # Unknown user
         username = self.engine_1.get_user_full_name("unknown")
         assert username == "unknown"
-
-    def test_download_url_with_spaces(self):
-        scheme, host = pytest.nuxeo_url.split("://")
-        filename = "My file with spaces.txt"
-        doc_id = self.remote.make_file("/", filename, content=b"Some content.")
-
-        url = (
-            "nxdrive://edit/{scheme}/{host}"
-            "/user/{user}"
-            "/repo/default"
-            "/nxdocid/{doc_id}"
-            "/filename/{filename}"
-            "/downloadUrl/nxfile/default/{doc_id}"
-            "/file:content/{filename}"
-        ).format(
-            scheme=scheme, host=host, user=self.user_1, doc_id=doc_id, filename=filename
-        )
-
-        self._direct_edit_update(doc_id, filename, b"Test", url)
-
-    def test_download_url_with_accents(self):
-        scheme, host = pytest.nuxeo_url.split("://")
-        filename = "éèáä.txt"
-        doc_id = self.remote.make_file("/", filename, content=b"Some content.")
-
-        url = (
-            "nxdrive://edit/{scheme}/{host}"
-            "/user/{user}"
-            "/repo/default"
-            "/nxdocid/{doc_id}"
-            "/filename/{filename}"
-            "/downloadUrl/nxfile/default/{doc_id}"
-            "/file:content/{filename}"
-        ).format(
-            scheme=scheme, host=host, user=self.user_1, doc_id=doc_id, filename=filename
-        )
-
-        self._direct_edit_update(doc_id, filename, b"Test", url)
-
-    def test_download_url_missing_username(self):
-        """ The username must be in the URL. """
-        url = (
-            "nxdrive://edit/https/server.cloud.nuxeo.com/nuxeo"
-            "/repo/default"
-            "/nxdocid/xxxxxxxx-xxxx-xxxx-xxxx"
-            "/filename/lebron-james-beats-by-dre-powerb.psd"
-            "/downloadUrl/nxfile/default/xxxxxxxx-xxxx-xxxx-xxxx"
-            "/file:content/lebron-james-beats-by-dre-powerb.psd"
-        )
-        with pytest.raises(ValueError):
-            self._direct_edit_update("", "", b"", url)


### PR DESCRIPTION
Actually there is no fix needed. The error is effective on Drive < 3.1 only.
So I added a test case and applied some changes to help triggering the manual error (+ debugging log)