### PR TITLE
NXDRIVE-1262: Do not rely on XCode on macOS

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,6 @@ repos:
     - id: end-of-file-fixer
     - id: check-docstring-first
     - id: debug-statements
-    - id: name-tests-test
     - id: requirements-txt-fixer
     - id: check-ast
     - id: no-commit-to-branch

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -22,6 +22,7 @@ Changes in command line arguments:
 - [NXDRIVE-1241](https://jira.nuxeo.com/browse/NXDRIVE-1241): Set the --consider-ssl-errors argument default value to True
 - [NXDRIVE-1242](https://jira.nuxeo.com/browse/NXDRIVE-1242): Use type annotations everywhere
 - [NXDRIVE-1256](https://jira.nuxeo.com/browse/NXDRIVE-1256): Fix the missing synchronization folder icon on Windows
+- [NXDRIVE-1262](https://jira.nuxeo.com/browse/NXDRIVE-1262): Do not rely on XCode on macOS
 - [NXDRIVE-1279](https://jira.nuxeo.com/browse/NXDRIVE-1279): Use flake8 for another clean-up round
 
 ### GUI

--- a/nxdrive/client/local_client.py
+++ b/nxdrive/client/local_client.py
@@ -251,7 +251,9 @@ class LocalClient:
             fname = os.path.join(self.abspath(ref), "desktop.ini")
             with suppress(FileNotFoundError):
                 with open(fname) as handler:
-                    version = re.findall(r"nuxeo-drive-([0-9.]+).win32\\", handler.read())
+                    version = re.findall(
+                        r"nuxeo-drive-([0-9.]+).win32\\", handler.read()
+                    )
                     if version:
                         return version[0]
                 return True

--- a/tests/test_local_creations.py
+++ b/tests/test_local_creations.py
@@ -185,7 +185,7 @@ class TestLocalCreations(UnitTestCase):
         engine.start()
         self.wait_sync(wait_for_async=True)
 
-        filename = "/{}".format(filename)
+        filename = f"/{filename}"
         assert local.exists(filename)
         assert os.stat(local.abspath(filename)).st_mtime < remote_mtime
 
@@ -194,33 +194,32 @@ class TestLocalCreations(UnitTestCase):
         remote = self.remote_1
         local = self.local_1
         engine = self.engine_1
+        sleep_time = 3
 
-        workspace_id = "defaultSyncRootFolderItemFactory#default#{}".format(
-            self.workspace
-        )
-
+        workspace_id = f"defaultSyncRootFolderItemFactory#default#{self.workspace}"
         filename = "abc.txt"
         file_id = remote.make_file(workspace_id, filename, content=b"1234").uid
         after_ctime = time.time()
 
-        time.sleep(3)
-        filename = "a" + filename
+        time.sleep(sleep_time)
+        filename = f"a{filename}"
         remote.rename(file_id, filename)
         after_mtime = time.time()
 
         engine.start()
         self.wait_sync(wait_for_async=True)
 
-        filename = "/{}".format(filename)
+        filename = f"/{filename}"
         assert local.exists(filename)
         local_mtime = os.stat(local.abspath(filename)).st_mtime
 
+        # Note: GNU/Linux does not have a creation time
         if MAC or WINDOWS:
             if MAC:
                 local_ctime = os.stat(local.abspath(filename)).st_birthtime
             else:
                 local_ctime = os.stat(local.abspath(filename)).st_ctime
             assert local_ctime < after_ctime
-            assert local_ctime + 3 <= local_mtime
+            assert local_ctime + sleep_time <= local_mtime
 
         assert local_mtime < after_mtime


### PR DESCRIPTION
The trick is to use `touch -mt ...` to be allowed to change ctime and mtime (see https://stackoverflow.com/a/27182823/1117028 for explanations) and then update the mtime if required.