### PR TITLE
NXDRIVE-1286: Ignore documents when the system cannot find the file

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -24,6 +24,7 @@ Changes in command line arguments:
 - [NXDRIVE-1256](https://jira.nuxeo.com/browse/NXDRIVE-1256): Fix the missing synchronization folder icon on Windows
 - [NXDRIVE-1262](https://jira.nuxeo.com/browse/NXDRIVE-1262): Do not rely on XCode on macOS
 - [NXDRIVE-1279](https://jira.nuxeo.com/browse/NXDRIVE-1279): Use flake8 for another clean-up round
+- [NXDRIVE-1286](https://jira.nuxeo.com/browse/NXDRIVE-1286): Ignore documents when the system cannot find the file
 
 ### GUI
 - [NXDRIVE-600](https://jira.nuxeo.com/browse/NXDRIVE-600): Use the generic JSP to acquire a token

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -333,9 +333,10 @@ class Processor(EngineWorker):
                     # Try to handle different kind of Windows error
                     error = getattr(exc, "winerror", exc.errno)
 
-                    if error == 2:
+                    if error in {2, 3}:
                         """
                         WindowsError: [Error 2] The specified file is not found
+                        WindowsError: [Error 3] The system cannot find the file specified
                         """
                         log.debug("The document does not exist anymore: %r", doc_pair)
                         self._dao.remove_state(doc_pair)

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -256,7 +256,7 @@ class Processor(EngineWorker):
                     # in the current synchronization
                     doc_pair.local_parent_path = parent_pair.local_path
 
-                handler_name = "_synchronize_" + doc_pair.pair_state
+                handler_name = f"_synchronize_{doc_pair.pair_state}"
                 sync_handler = getattr(self, handler_name, None)
                 if not sync_handler:
                     log.debug(
@@ -303,11 +303,10 @@ class Processor(EngineWorker):
                     continue
                 except (
                     ConnectionError,
-                    socket.error,
+                    socket.error,  # SSLError
                     PairInterrupt,
                     ParentNotSynced,
                 ) as exc:
-                    # socket.error for SSLError
                     log.error(
                         "%s on %r, wait 1s and requeue", type(exc).__name__, doc_pair
                     )
@@ -354,7 +353,7 @@ class Processor(EngineWorker):
                         )
                         self.engine.errorOpenedFile.emit(doc_pair)
                         self._postpone_pair(doc_pair, "Used by another process")
-                    elif error in (111, 121, 124, 206, 1223):
+                    elif error in {111, 121, 124, 206, 1223}:
                         """
                         WindowsError: [Error 111] ??? (seems related to deep
                         tree)


### PR DESCRIPTION
We were missing a Windows specific error (code n° 3) when the system did not find a specified file.