### PR TITLE
NXDRIVE-1319: Missing OpenGL DLLs after packaging on Windows

### DIFF
--- a/ndrive.spec
+++ b/ndrive.spec
@@ -45,14 +45,15 @@ excludes = [
     "yappi",
 ]
 
+binaries = []
 data = [(data, "data")]
 version = get_version(os.path.join(nxdrive, "__init__.py"))
 properties_rc = None
 
 if sys.platform == "win32":
     # Set executable properties
-    properties_tpl = tools + "\windows\properties_tpl.rc"
-    properties_rc = tools + "\windows\properties.rc"
+    properties_tpl = tools + "\\windows\\properties_tpl.rc"
+    properties_rc = tools + "\\windows\\properties.rc"
     if os.path.isfile(properties_rc):
         os.remove(properties_rc)
 
@@ -66,9 +67,17 @@ if sys.platform == "win32":
     # Missing modules when packaged
     hiddenimports.append("win32timezone")
 
+    # Missing OpenGL DLLs (NXDRIVE-1311)
+    from PyInstaller.utils.hooks import pyqt5_library_info
+
+    dst_dll_path = os.path.join("PyQt5", "Qt", "bin")
+    for dll in {"libEGL.dll", "libGLESv2.dll"}:
+        dll_file_path = os.path.join(pyqt5_library_info.location["BinariesPath"], dll)
+        binaries.append((dll_file_path, dst_dll_path))
 
 a = Analysis(
     [os.path.join(nxdrive, "__main__.py")],
+    binaries=binaries,
     datas=data,
     excludes=excludes,
     hiddenimports=hiddenimports,

--- a/nxdrive/manager.py
+++ b/nxdrive/manager.py
@@ -13,7 +13,7 @@ from PyQt5.QtCore import QObject, QT_VERSION_STR, pyqtSignal, pyqtSlot
 try:
     from PyQt5.sip import SIP_VERSION_STR  # PyQt 5.11+
 except ImportError:
-    from sip import SIP_VERSION_STR  # PyQt 5.10
+    from sip import SIP_VERSION_STR  # PyQt 5.10 (NXDRIVE-1311)
 
 from . import __version__
 from .client.local_client import LocalClient


### PR DESCRIPTION
They are shipped starting with Qt 5.11.