### PR TITLE
NXDRIVE-1171: Prevent Drive crash on URL open failure

### DIFF
--- a/nxdrive/manager.py
+++ b/nxdrive/manager.py
@@ -344,12 +344,15 @@ class Manager(QObject):
         file_path = force_decode(file_path)
         log.debug("Launching editor on %r", file_path)
         if WINDOWS:
-            if select:
-                win32api.ShellExecute(
-                    None, "open", "explorer.exe", f"/select,{file_path}", None, 1
-                )
-            else:
-                os.startfile(file_path)
+            try:
+                if select:
+                    win32api.ShellExecute(
+                        None, "open", "explorer.exe", f"/select,{file_path}", None, 1
+                    )
+                else:
+                    os.startfile(file_path)
+            except OSError as exc:
+                log.error(f"Failed to open {file_path}: {exc}")
         elif MAC:
             args = ["open"]
             if select:


### PR DESCRIPTION
`Manager.open_local_file()` would raise an `OSError` even if the browser is successfully opened. This happens when using Opera on Windows 7 for instance. So we just log the error and let Drive continue.