### PR TITLE
NXDRIVE-970: Easy the future work by removing application name for th…

### DIFF
--- a/nxdrive/commandline.py
+++ b/nxdrive/commandline.py
@@ -12,6 +12,7 @@ from logging import getLogger
 from typing import List, Union
 
 from . import __version__
+from .constants import APP_NAME
 from .logging_config import configure
 from .options import Options
 from .utils import force_encode, get_default_nuxeo_drive_folder, normalized_path
@@ -68,7 +69,7 @@ class CliHandler:
         common_parser.add_argument(
             "--nxdrive-home",
             default=Options.nxdrive_home,
-            help="Folder to store the Nuxeo Drive configuration",
+            help=f"Folder to store the {APP_NAME} configuration",
         )
 
         common_parser.add_argument(
@@ -184,12 +185,12 @@ class CliHandler:
             "--version",
             action="version",
             version=self.get_version(),
-            help="Print the current version of the Nuxeo Drive client",
+            help=f"Print the current version of the {APP_NAME} client",
         )
 
         parser = ArgumentParser(
             parents=[common_parser],
-            description="Command line interface for Nuxeo Drive operations.",
+            description=f"Command line interface for {APP_NAME} operations.",
             usage=USAGE,
         )
 

--- a/nxdrive/engine/tracker.py
+++ b/nxdrive/engine/tracker.py
@@ -11,7 +11,7 @@ from PyQt5.QtCore import QTimer, pyqtSlot
 from UniversalAnalytics import Tracker as UATracker
 
 from .workers import Worker
-from ..constants import MAC, WINDOWS
+from ..constants import APP_NAME, MAC, WINDOWS
 from ..objects import NuxeoDocumentInfo
 
 if MAC:
@@ -34,7 +34,8 @@ class Tracker(Worker):
         self._tracker = UATracker.create(
             uid, client_id=self._manager.device_id, user_agent=self.user_agent
         )
-        self._tracker.set("appName", "NuxeoDrive")
+        self.app_name = APP_NAME.replace(" ", "")
+        self._tracker.set("appName", self.app_name)
         self._tracker.set("appVersion", self._manager.version)
         self._tracker.set("encoding", sys.getfilesystemencoding())
         self._tracker.set("language", self.current_locale)
@@ -95,7 +96,7 @@ class Tracker(Worker):
     def user_agent(self) -> str:
         """ Format a custom user agent. """
 
-        return "NuxeoDrive/{} ({})".format(self._manager.version, self.current_os)
+        return f"{self.app_name}/{self._manager.version} ({self.current_os})"
 
     def send_event(self, **kwargs: Any) -> None:
         engine = list(self._manager.get_engines().values())[0]

--- a/nxdrive/gui/api.py
+++ b/nxdrive/gui/api.py
@@ -15,7 +15,7 @@ from PyQt5.QtCore import QObject, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import QMessageBox
 
 from ..client.proxy import get_proxy
-from ..constants import STARTUP_PAGE_CONNECTION_TIMEOUT, TOKEN_PERMISSION
+from ..constants import APP_NAME, STARTUP_PAGE_CONNECTION_TIMEOUT, TOKEN_PERMISSION
 from ..engine.activity import Action, FileAction
 from ..engine.dao.sqlite import StateRow
 from ..engine.engine import Engine
@@ -715,9 +715,8 @@ class QMLDriveApi(QObject):
                 status = resp.status_code
         except:
             log.exception(
-                "Error while trying to connect to Nuxeo Drive"
-                " startup page with URL %s",
-                url,
+                f"Error while trying to connect to {APP_NAME}"
+                f" startup page with URL {url}"
             )
             raise StartupPageConnectionError()
         log.debug("Status code for %s = %d", url, status)

--- a/nxdrive/gui/status_dialog.py
+++ b/nxdrive/gui/status_dialog.py
@@ -13,6 +13,7 @@ from PyQt5.QtWidgets import (
 )
 
 from .folders_treeview import Overlay
+from ..constants import APP_NAME
 from ..objects import NuxeoDocumentInfo
 
 __all__ = ("StatusDialog",)
@@ -138,7 +139,7 @@ class StatusDialog(QDialog):
         self.setLayout(layout)
         self.tree_view = StatusTreeview(self, self._dao)
         self.tree_view.resizeColumnToContents(0)
-        self.setWindowTitle("Nuxeo Drive File Status")
+        self.setWindowTitle(f"{APP_NAME} File Status")
         layout.addWidget(self.tree_view)
 
 

--- a/nxdrive/manager.py
+++ b/nxdrive/manager.py
@@ -710,9 +710,7 @@ class Manager(QObject):
     def get_metadata_infos(self, file_path: str, edit: bool = False) -> str:
         remote_ref = LocalClient.get_path_remote_id(file_path)
         if remote_ref is None:
-            raise ValueError(
-                "Could not find file %r as Nuxeo Drive managed" % file_path
-            )
+            raise ValueError(f"Could not find file {file_path!r} as {APP_NAME} managed")
 
         root_id = self.get_root_id(file_path)
         root_values = root_id.split("|")


### PR DESCRIPTION
…e APP_NAME constant.

This is a little patch to ease the future work on themes and Edge Cache, as it will be rebased on Drive 4. And so, if we can remove hard coded "Nuxeo Drive" text, it is for the better.

We will have to think about translations that still have hard coded "Nuxeo Drive".