### PR TITLE
NXDRIVE-1354: Bring Settings window to the top after login in the browser

### DIFF
--- a/nxdrive/engine/tracker.py
+++ b/nxdrive/engine/tracker.py
@@ -31,10 +31,10 @@ class Tracker(Worker):
         self._manager = manager
         self._thread.started.connect(self.run)
         self.uid = uid
+        self.app_name = APP_NAME.replace(" ", "")
         self._tracker = UATracker.create(
             uid, client_id=self._manager.device_id, user_agent=self.user_agent
         )
-        self.app_name = APP_NAME.replace(" ", "")
         self._tracker.set("appName", self.app_name)
         self._tracker.set("appVersion", self._manager.version)
         self._tracker.set("encoding", sys.getfilesystemencoding())

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -257,6 +257,7 @@ class Application(QApplication):
     def _show_window(self, window: "QWindow") -> None:
         window.show()
         window.raise_()
+        window.requestActivate()
 
     def _destroy_dialog(self) -> None:
         sender = self.sender()
@@ -506,6 +507,7 @@ class Application(QApplication):
         self.filters_dlg = FiltersDialog(self, engine)
         self.filters_dlg.destroyed.connect(self.destroyed_filters_dialog)
         self.filters_dlg.show()
+        self._show_window(self.settings_window)
 
     def show_file_status(self) -> None:
         from ..gui.status_dialog import StatusDialog

--- a/nxdrive/gui/folders_dialog.py
+++ b/nxdrive/gui/folders_dialog.py
@@ -17,6 +17,12 @@ class FiltersDialog(QDialog):
     ) -> None:
         super().__init__(parent)
         self.setAttribute(Qt.WA_DeleteOnClose)
+
+        # The window doesn't raise on Windows when the app is not in focus,
+        # so after the login in the browser, we open the filters window with
+        # the "stay on top" hint to make sure it comes back to the front
+        # instead of just having a blinking icon in the taskbar.
+        self.setWindowFlags(Qt.WindowStaysOnTopHint)
         self.setWindowTitle(Translator.get("FILTERS_WINDOW_TITLE"))
 
         self.vertical_layout = QVBoxLayout(self)


### PR DESCRIPTION
Also, initialize `Tracker.app_name` variable earlier so it exists when accessing `Tracker.user_agent` afterwards.