### PR TITLE
NXDRIVE-1356: Fix removed filters not appearing back when unchecked

### DIFF
--- a/docs/technical_changes.md
+++ b/docs/technical_changes.md
@@ -17,7 +17,7 @@
 - Removed `CustomMemoryHandler.flush()`
 - Removed `DriveSystrayIcon.use_old_menu`
 - Added `Engine.init_remote()`
-- Changed `Engine(..., remote_doc_client_factory, remote_fs_client_factory, remote_filtered_fs_client_factory` to `Engine(..., remote_cls, filtered_remote_cls, local_cls)`
+- Changed `Engine(..., remote_doc_client_factory, remote_fs_client_factory, remote_filtered_fs_client_factory` to `Engine(..., remote_cls, local_cls)`
 - Removed `Engine.get_abspath()`
 - Added `duration` keyword argument to `Engine.get_last_files()`
 - Added `Engine.get_last_files_count()`

--- a/docs/technical_changes.md
+++ b/docs/technical_changes.md
@@ -62,6 +62,8 @@
 - Added `duration` keyword argument to `QMLDriveApi.get_last_files()`
 - Added `QMLDriveApi.get_last_files_count()`
 - Removed `QueueManager.queueEmpty()`
+- Added `filtered` keyword argument `Remote.get_fs_children()` with `True` as default value.
+- Added `filtered` keyword argument `Remote.is_filtered()` with `True` as default value.
 - Added `Remote.set_proxy()`
 - Moved `Remote.conflicted_name()` to `RemoteBase`
 - Moved `Remote.doc_to_info()` to `NuxeoDocumentInfo.from_dict()`
@@ -101,6 +103,7 @@
 - Removed application.py::`SimpleApplication`
 - Added client/proxy.py
 - Added client/remote_client.py
+- Removed client/remote_client.py::`FilteredRemote`
 - Moved client/common.py::`DuplicationDisabledError` exception to exceptions.py
 - Moved client/common.py::`COLLECTION_SYNC_ROOT_FACTORY_NAME` constant to engine/watcher/remote_watcher.py
 - Moved client/common.py::`NotFound` exception to exceptions.py

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -322,7 +322,9 @@ class Remote(Nuxeo):
             command="NuxeoDrive.FileSystemItemExists", id=fs_item_id
         )
 
-    def get_fs_children(self, fs_item_id: str, filtered=True) -> List[RemoteFileInfo]:
+    def get_fs_children(
+        self, fs_item_id: str, filtered: bool = True
+    ) -> List[RemoteFileInfo]:
         children = self.operations.execute(
             command="NuxeoDrive.GetChildren", id=fs_item_id
         )
@@ -354,7 +356,7 @@ class Remote(Nuxeo):
             ],
         }
 
-    def is_filtered(self, path: str, filtered=True) -> bool:
+    def is_filtered(self, path: str, filtered: bool = True) -> bool:
         if filtered:
             return self._dao.is_filter(path)
         return False

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -18,7 +18,7 @@ from .watcher.local_watcher import LocalWatcher
 from .watcher.remote_watcher import RemoteWatcher
 from .workers import Worker
 from ..client.local_client import LocalClient
-from ..client.remote_client import FilteredRemote, Remote
+from ..client.remote_client import Remote
 from ..constants import MAC, WINDOWS
 from ..exceptions import (
     InvalidDriveException,
@@ -83,7 +83,6 @@ class Engine(QObject):
         binder: Binder = None,
         processors: int = 5,
         remote_cls: Type[Remote] = Remote,
-        filtered_remote_cls: Type[FileAction] = FilteredRemote,
         local_cls: Type[LocalWatcher] = LocalClient,
     ) -> None:
         super().__init__()
@@ -91,7 +90,6 @@ class Engine(QObject):
         self.version = manager.version
 
         self.remote_cls = remote_cls
-        self.filtered_remote_cls = filtered_remote_cls
         self.local_cls = local_cls
         self.remote = None
 
@@ -735,7 +733,7 @@ class Engine(QObject):
             "dao": self._dao,
             "proxy": self.manager.proxy,
         }
-        self.remote = self.filtered_remote_cls(*args, **kwargs)
+        self.remote = self.remote_cls(*args, **kwargs)
 
     def bind(self, binder: Binder) -> None:
         check_credentials = not binder.no_check

--- a/nxdrive/gui/folders_treeview.py
+++ b/nxdrive/gui/folders_treeview.py
@@ -7,7 +7,7 @@ from PyQt5.QtCore import QModelIndex, QObject, QVariant, Qt, pyqtSignal, pyqtSlo
 from PyQt5.QtGui import QMovie, QPalette, QStandardItem, QStandardItemModel
 from PyQt5.QtWidgets import QDialog, QLabel, QTreeView, QWidget
 
-from ..client.remote_client import FilteredRemote
+from ..client.remote_client import Remote
 from ..objects import Filters, RemoteFileInfo
 from ..utils import find_icon
 
@@ -123,7 +123,7 @@ class Client:
 
 
 class FilteredFsClient(Client):
-    def __init__(self, fs_client: FilteredRemote, filters: Filters = None) -> None:
+    def __init__(self, fs_client: Remote, filters: Filters = None) -> None:
         self.fs_client = fs_client
         filters = filters or []
         self.filters = [filter_obj.path for filter_obj in filters]
@@ -145,7 +145,7 @@ class FilteredFsClient(Client):
         self, parent: FileInfo = None
     ) -> Generator[Union[FsFileInfo, FsRootFileInfo], None, None]:
         if parent:
-            for info in self.fs_client.get_fs_children(parent.get_id()):
+            for info in self.fs_client.get_fs_children(parent.get_id(), filtered=False):
                 yield FsFileInfo(info, parent, self.get_item_state(info.path))
             return
 


### PR DESCRIPTION
Having a different class and two remote client instances just for a filter seemed excessive. Now the `Remote` client filters by default, but when populating the filters window, passes an argument to deactivate the filtering.