### PR TITLE
NXDRIVE-1259: Fix a bug in utils.safe_filename()

### DIFF
--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -396,7 +396,7 @@ def if_frozen(func) -> callable:
 
 
 def safe_filename(
-    name: str, replacement: str = "-", pattern: Pattern = re.compile(r'(["|*/:<>?\\]+)')
+    name: str, replacement: str = "-", pattern: Pattern = re.compile(r'(["|*/:<>?\\])')
 ) -> str:
     """ Replace invalid character in candidate filename. """
     return re.sub(pattern, replacement, name)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -178,7 +178,15 @@ def test_simplify_url(url, result):
 
 
 @pytest.mark.parametrize(
-    "invalid, valid", [('a/b\\c*d:e<f>g?h"i|j.doc', "a-b-c-d-e-f-g-h-i-j.doc")]
+    "invalid, valid",
+    [
+        ('a/b\\c*d:e<f>g?h"i|j.doc', "a-b-c-d-e-f-g-h-i-j.doc"),
+        ("/*@?<>", "--@---"),
+        ("/*?<>", "-----"),
+        ("/ * @ ? < >", "- - @ - - -"),
+        ("/ * ? < >", "- - - - -"),
+        ("/*  ?<>", "--  ---"),
+    ],
 )
 def test_safe_filename(invalid, valid):
     assert nxdrive.utils.safe_filename(invalid) == valid

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,7 @@
 # coding: utf-8
+import os
+
+
 import pytest
 
 import nxdrive.utils
@@ -201,8 +204,6 @@ def test_safe_filename(invalid, valid):
     ],
 )
 def test_short_name(data, too_long):
-    import os
-
     short_name = nxdrive.utils.short_name
     force_decode = nxdrive.utils.force_decode
 


### PR DESCRIPTION
The RegExp was replacing elements by groups, selecting consecutives characters by only one dash.
Added regression tests and fixed the pattern.

Another patch will be needed but done only for the next version. This is a regression bugfix.