### PR TITLE
NXDRIVE-1236: Fix datetime.fromtimestamp() erronously throws an OSError on Windows

### DIFF
--- a/docs/changes/4.0.1.md
+++ b/docs/changes/4.0.1.md
@@ -11,3 +11,4 @@
 ## Packaging / Build
 
 - [NXDRIVE-1250](https://jira.nuxeo.com/browse/NXDRIVE-1250): Create the Windows sub-installer for additionnal features
+- [NXDRIVE-1389](https://jira.nuxeo.com/browse/NXDRIVE-1389): Upgrade Python from 3.6.6 to 3.6.7

--- a/docs/changes/4.0.1.md
+++ b/docs/changes/4.0.1.md
@@ -2,6 +2,7 @@
 
 ## Core
 
+- [NXDRIVE-1236](https://jira.nuxeo.com/browse/NXDRIVE-1236): Fix datetime.fromtimestamp() erronously throws an OSError on Windows
 - [NXDRIVE-1401](https://jira.nuxeo.com/browse/NXDRIVE-1401): Clean up usage of deprecated server-side Automation operations
 
 ## GUI

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -46,7 +46,7 @@ Executing the script without argument will setup.update the isolated environment
 
 ### Dependencies:
 
-- [Python 3.6.6](https://www.python.org/ftp/python/3.6.6/python-3.6.6.exe) or newer.
+- [Python 3.6.7](https://www.python.org/ftp/python/3.6.7/python-3.6.7.exe) or newer.
 - [Inno Setup 5.5.9 (u)](http://www.jrsoftware.org/download.php/is-unicode.exe) to create the installer.
 
 ### Troubleshooting

--- a/nxdrive/client/local_client.py
+++ b/nxdrive/client/local_client.py
@@ -428,16 +428,8 @@ FolderType=Generic
         try:
             mtime = datetime.utcfromtimestamp(stat_info.st_mtime)
         except (ValueError, OverflowError, OSError) as e:
-            log.error(
-                str(e)
-                + "file path: %s. st_mtime value: %s" % (os_path, stat_info.st_mtime)
-            )
-            if WINDOWS:
-                # TODO: NXDRIVE-1236 Remove those ugly fixes
-                # TODO: when https://bugs.python.org/issue29097 is fixed
-                mtime = datetime.utcfromtimestamp(86400)
-            else:
-                mtime = datetime.utcfromtimestamp(0)
+            log.error(f"{e} file path: {os_path}. st_mtime value: {stat_info.st_mtime}")
+            mtime = datetime.utcfromtimestamp(0)
 
         # TODO Do we need to load it everytime ?
         remote_ref = self.get_remote_id(ref)

--- a/nxdrive/objects.py
+++ b/nxdrive/objects.py
@@ -68,14 +68,8 @@ class RemoteFileInfo(SlotInfo):
         """Convert Automation file system item description to RemoteFileInfo"""
         folderish = fs_item["folder"]
 
-        # TODO: NXDRIVE-1236 Remove those ugly fixes
-        # TODO: when https://bugs.python.org/issue29097 is fixed
-        last_update = fs_item["lastModificationDate"] // 1000
-        last_update = max(86400, last_update)
-        last_update = datetime.fromtimestamp(last_update)
-        creation = fs_item["creationDate"] // 1000
-        creation = max(86400, creation)
-        creation = datetime.fromtimestamp(creation)
+        last_update = datetime.fromtimestamp(fs_item["lastModificationDate"] // 1000)
+        creation = datetime.fromtimestamp(fs_item["creationDate"] // 1000)
 
         last_contributor = fs_item.get("lastContributor")
 

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -11,9 +11,7 @@ from .common import clean_dir
 
 class FakeOSIntegration(AbstractOSIntegration):
     def get_system_configuration(self):
-        args = dict()
-        args["log_level_console"] = "SYSTEM_TEST"
-        return args
+        return {"log_level_console": "SYSTEM_TEST"}
 
 
 def getOSIntegration(manager):
@@ -72,7 +70,7 @@ delay = 3
     @Options.mock()
     def test_update_site_url(self):
         Options.nxdrive_home = tempfile.mkdtemp("config", dir=self.tmpdir)
-        argv = ["ndrive", "console", "--update-site-url", "DEBUG_TEST"]
+        argv = ["console", "--update-site-url", "DEBUG_TEST"]
         options = self.cmd.parse_cli([])
         assert options.update_site_url == Options.update_site_url
 
@@ -87,7 +85,7 @@ delay = 3
         AbstractOSIntegration.get = staticmethod(getOSIntegration)
         try:
             self.clean_ini()
-            argv = ["ndrive", "console", "--log-level-console", "WARNING"]
+            argv = ["console", "--log-level-console", "WARNING"]
             # Default value
             options = self.cmd.parse_cli([])
             assert options.log_level_console == "SYSTEM_TEST"
@@ -102,7 +100,7 @@ delay = 3
     def test_default_override(self):
         Options.nxdrive_home = tempfile.mkdtemp("config", dir=self.tmpdir)
         self.clean_ini()
-        argv = ["ndrive", "console", "--log-level-console=WARNING"]
+        argv = ["console", "--log-level-console=WARNING"]
 
         # Default value
         options = self.cmd.parse_cli([])

--- a/tools/posix/deploy_jenkins_slave.sh
+++ b/tools/posix/deploy_jenkins_slave.sh
@@ -61,7 +61,7 @@ check_import() {
 check_vars() {
     # Check required variables
     if [ "${PYTHON_DRIVE_VERSION:=unset}" = "unset" ]; then
-        export PYTHON_DRIVE_VERSION="3.6.6"  # XXX_PYTHON
+        export PYTHON_DRIVE_VERSION="3.6.7"  # XXX_PYTHON
     elif [ "${WORKSPACE:=unset}" = "unset" ]; then
         echo "WORKSPACE not defined. Aborting."
         exit 1

--- a/tools/windows/deploy_jenkins_slave.ps1
+++ b/tools/windows/deploy_jenkins_slave.ps1
@@ -81,7 +81,7 @@ function check_import($import) {
 function check_vars {
 	# Check required variables
 	if (-Not ($Env:PYTHON_DRIVE_VERSION)) {
-		$Env:PYTHON_DRIVE_VERSION = '3.6.6'  # XXX_PYTHON
+		$Env:PYTHON_DRIVE_VERSION = '3.6.7'  # XXX_PYTHON
 	} elseif (-Not ($Env:WORKSPACE)) {
 		Write-Output ">>> WORKSPACE not defined. Aborting."
 		ExitWithCode 1


### PR DESCRIPTION
NXDRIVE-1389: Upgrade Python from 3.6.6 to 3.6.7