### PR TITLE
NXDRIVE-1419: Remove hotfixes requirements from versions.yml

### DIFF
--- a/docs/changes/4.0.1.md
+++ b/docs/changes/4.0.1.md
@@ -13,6 +13,7 @@
 
 - [NXDRIVE-1250](https://jira.nuxeo.com/browse/NXDRIVE-1250): Create the Windows sub-installer for additionnal features
 - [NXDRIVE-1389](https://jira.nuxeo.com/browse/NXDRIVE-1389): Upgrade Python from 3.6.6 to 3.6.7
+- [NXDRIVE-1419](https://jira.nuxeo.com/browse/NXDRIVE-1419): Remove hotfixes requirements from versions.yml
 
 ## Docs
 

--- a/tools/scripts/check_update_process.py
+++ b/tools/scripts/check_update_process.py
@@ -48,14 +48,19 @@ def create_versions(dst, version):
     print(">>> Computed the checksum:", checksum)
 
     print(">>> Crafting versions.yml")
-    yml = f"""
-"{version}":
+    """
+    Note that we removed the following section with NXDRIVE-1419:
+
     min_all:
         "7.10": "7.10-HF47"
-        "8.10": "8.10-HF37"
+        "8.10": "8.10-HF38"
         "9.10": "9.10-HF20"
         "10.3": "10.3-SNAPSHOT"
-        "10.10": "10.10"
+        "10.10": "10.10-SNAPSHOT"
+    """
+    yml = f"""
+"{version}":
+    min: "7.10"
     type: release
     checksum:
         algo: sha256

--- a/tools/versions.py
+++ b/tools/versions.py
@@ -35,16 +35,20 @@ def create(version):
     # Create the version file
     output = "{}.yml".format(version)
 
-    # We set 10.3-SNAPSHOT to allow presales to test the current dev version.
-    # Same for the future 10.10 to not block updates when it will be available.
-    yml = """{}:
-    min: "7.10"
+    """
+    We set 10.3-SNAPSHOT to allow presales to test the current dev version.
+    Same for the future 10.10 to not block updates when it will be available.
+    Note that we removed the following section with NXDRIVE-1419:
+
     min_all:
         "7.10": "7.10-HF47"
         "8.10": "8.10-HF38"
         "9.10": "9.10-HF20"
         "10.3": "10.3-SNAPSHOT"
         "10.10": "10.10-SNAPSHOT"
+    """
+    yml = """{}:
+    min: "7.10"
     type: {}
     checksum:
         algo: sha256


### PR DESCRIPTION
I already removed the `min_all` key of the 4.0.0 version from https://community.nuxeo.com/static/drive-updates/versions.yml.