### PR TITLE
NXDRIVE-1405: Handle local INI system-wide configuration

### DIFF
--- a/docs/changes/4.0.1.md
+++ b/docs/changes/4.0.1.md
@@ -15,6 +15,7 @@
 - [NXDRIVE-1250](https://jira.nuxeo.com/browse/NXDRIVE-1250): Create the Windows sub-installer for additionnal features
 - [NXDRIVE-1389](https://jira.nuxeo.com/browse/NXDRIVE-1389): Upgrade Python from 3.6.6 to 3.6.7
 - [NXDRIVE-1404](https://jira.nuxeo.com/browse/NXDRIVE-1404): Create a Windows installer for system wide installation
+- [NXDRIVE-1405](https://jira.nuxeo.com/browse/NXDRIVE-1405): Handle local INI system-wide configuration
 - [NXDRIVE-1419](https://jira.nuxeo.com/browse/NXDRIVE-1419): Remove hotfixes requirements from versions.yml
 
 ## Docs
@@ -29,11 +30,15 @@
 
 ## Technical Changes
 
+- Added `get_value()` to `CLIHandler`
+- Added `conf_name` keyword argument to `CLIHandler.load_config()`
 - Added `ConfigurationDAO.get_locks()`
 - Removed `DocRemote.get_repository_names()`
 - Removed `raise_if_missing` keyword argument from `LocalClient.get_info()`
 - Added `LocalClient.try_get_info()`
 - Changed `ManagerDAO.get_locked_paths()` return type to `List[str]`
+- Added `file` and `section` keyword arguments to `MetaOptions.set()`
+- Added `file` and `section` keyword arguments to `MetaOptions.update()`
 - Added `Remote.stream_attach()`
 - Removed `Remote.conflicted_name()`
 - Removed `raise_if_missing` keyword argument from `Remote.get_fs_info()`


### PR DESCRIPTION
- Enhance `MetaOptions` to display the faultive file and section.
- Pre-configure the logging to catch early configuration errors.
- Unskip `test_site_update_url()` from `test_options.py`.
- Code clean-up in `test_commandline.py` and `test_options.py`.