### PR TITLE
NXDRIVE-1434: Fix the "consider-ssl-errors" option implementation

### DIFF
--- a/docs/changes/4.0.1.md
+++ b/docs/changes/4.0.1.md
@@ -5,6 +5,7 @@
 - [NXDRIVE-1236](https://jira.nuxeo.com/browse/NXDRIVE-1236): Fix datetime.fromtimestamp() erronously throws an OSError on Windows
 - [NXDRIVE-1259](https://jira.nuxeo.com/browse/NXDRIVE-1259): Be more consistent with file/folder renaming
 - [NXDRIVE-1401](https://jira.nuxeo.com/browse/NXDRIVE-1401): Clean up usage of deprecated server-side Automation operations
+- [NXDRIVE-1434](https://jira.nuxeo.com/browse/NXDRIVE-1434): Fix the "consider-ssl-errors" option implementation
 
 ## GUI
 

--- a/nxdrive/client/proxy.py
+++ b/nxdrive/client/proxy.py
@@ -6,6 +6,7 @@ import requests
 from pypac import get_pac
 from pypac.resolver import ProxyResolver
 
+from ..options import Options
 from ..utils import decrypt, encrypt, force_decode
 
 if TYPE_CHECKING:
@@ -179,8 +180,10 @@ def save_proxy(proxy: Proxy, dao: "EngineDAO", token: str = None) -> None:
 
 def validate_proxy(proxy: Proxy, url: str) -> bool:
     try:
-        requests.get(url, proxies=proxy.settings(url=url))
-        return True
+        with requests.get(
+            url, proxies=proxy.settings(url=url), verify=Options.consider_ssl_errors
+        ):
+            return True
     except:
         log.exception("Invalid proxy.")
         return False

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -60,6 +60,7 @@ class Remote(Nuxeo):
         **kwargs: Any,
     ) -> None:
         auth = TokenAuth(token) if token else (user_id, password)
+        kwargs["verify"] = Options.consider_ssl_errors
         self.kwargs = kwargs
 
         super().__init__(

--- a/nxdrive/commandline.py
+++ b/nxdrive/commandline.py
@@ -132,7 +132,7 @@ class CliHandler:
             "--consider-ssl-errors",
             default=Options.consider_ssl_errors,
             action="store_true",
-            help="Do not ignore SSL errors in Qt network manager requests",
+            help="Ensure HTTPS certificates are valid. Highly unadvised to disable this option.",
         )
 
         common_parser.add_argument(
@@ -373,9 +373,11 @@ class CliHandler:
             filtered_args.append(arg)
 
         parser = self.make_cli_parser(add_subparsers=has_command)
+
         # Change default value according to config.ini
         self.load_config(parser)
         options = parser.parse_args(filtered_args)
+
         if options.debug:
             # Automatically check all operations done with the Python client
             import nuxeo.constants

--- a/nxdrive/gui/api.py
+++ b/nxdrive/gui/api.py
@@ -727,8 +727,9 @@ class QMLDriveApi(QObject):
             with requests.get(
                 url,
                 headers=headers,
-                timeout=timeout,
                 proxies=self._manager.proxy.settings(url=url),
+                timeout=timeout,
+                verify=Options.consider_ssl_errors,
             ) as resp:
                 status = resp.status_code
         except:

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -847,24 +847,22 @@ class Application(QApplication):
             version += " beta"
 
         try:
-            content = requests.get(url)
+            # No need for the `verify=Options.consider_ssl_errors` here as GitHub will never use
+            # a bad certificate.
+            with requests.get(url) as resp:
+                data = resp.json()
         except requests.HTTPError as exc:
             if exc.response.status_code == 404:
                 log.error(f"[{version}] Release does not exist")
             else:
                 log.exception(f"[{version}] Network error while fetching release notes")
             return
-        except:
-            log.exception(f"[{version}] Unknown error while fetching release notes")
-            return
-
-        try:
-            data = content.json()
         except ValueError:
             log.exception(f"[{version}] Invalid release notes")
             return
-        finally:
-            del content
+        except:
+            log.exception(f"[{version}] Unknown error while fetching release notes")
+            return
 
         try:
             html = markdown(data["body"])

--- a/nxdrive/manager.py
+++ b/nxdrive/manager.py
@@ -88,9 +88,6 @@ class Manager(QObject):
         self.notification_service = DefaultNotificationService(self)
         self.osi = AbstractOSIntegration.get(self)
 
-        if not Options.consider_ssl_errors:
-            self._bypass_https_verification()
-
         self.direct_edit_folder = os.path.join(
             normalized_path(self.nxdrive_home), "edit"
         )
@@ -166,27 +163,6 @@ class Manager(QObject):
         # Create the FinderSync listener thread
         if MAC:
             self._create_findersync_listener()
-
-    @staticmethod
-    def _bypass_https_verification() -> None:
-        """
-        Let's bypass HTTPS verification since many servers
-        unfortunately have invalid certificates.
-        See https://www.python.org/dev/peps/pep-0476/ and NXDRIVE-506.
-        """
-
-        import ssl
-
-        log.warning(
-            "--consider-ssl-errors option is False, "
-            "will not verify HTTPS certificates"
-        )
-        log.info(
-            "Handle target environment that does not support HTTPS "
-            "verification: globally disable verification by "
-            "monkeypatching the ssl module though highly discouraged"
-        )
-        ssl._create_default_https_context = ssl._create_unverified_context
 
     def get_metrics(self) -> Metrics:
         return {

--- a/nxdrive/updater/base.py
+++ b/nxdrive/updater/base.py
@@ -158,6 +158,8 @@ class BaseUpdater(PollWorker):
             f"into {path!r}"
         )
         try:
+            # Note: I do not think we should pass the `verify=Options.consider_ssl_errors` kwarg here
+            # because updates are critical and must be stored on a secured server.
             req = requests.get(url, stream=True)
             size = int(req.headers["content-length"])
             incr = self.chunk_size * 100 / size
@@ -182,6 +184,8 @@ class BaseUpdater(PollWorker):
 
         url = f"{self.update_site}/versions.yml"
         try:
+            # Note: I do not think we should pass the `verify=Options.consider_ssl_errors` kwarg here
+            # because updates are critical and must be stored on a secured server.
             with requests.get(url) as resp:
                 resp.raise_for_status()
                 content = resp.text

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -598,14 +598,16 @@ def guess_server_url(
         ("http", domain, "", "", ""),
     ]
 
+    kwargs = {"timeout": timeout, "verify": Options.consider_ssl_errors}
     for new_url_parts in urls:
         new_url = urlunsplit(new_url_parts).rstrip("/")
         try:
             rfc3987.parse(new_url, rule="URI")
             log.trace(f"Testing URL {new_url!r}")
-            full_url = new_url + "/" + login_page
-            kwargs = {"proxies": proxy.settings(url=full_url)} if proxy else {}
-            with requests.get(full_url, timeout=timeout, **kwargs) as resp:
+            full_url = f"{new_url}/{login_page}"
+            if proxy:
+                kwargs["proxies"] = proxy.settings(url=full_url)
+            with requests.get(full_url, **kwargs) as resp:
                 resp.raise_for_status()
                 if resp.status_code == 200:
                     return new_url


### PR DESCRIPTION
Requests made from the auto-updater are kept secure.