### PR TITLE
NXDRIVE-1411: Use consistent icons to edit document / open local folder

### DIFF
--- a/docs/changes/4.0.1.md
+++ b/docs/changes/4.0.1.md
@@ -9,6 +9,7 @@
 ## GUI
 
 - [NXDRIVE-1407](https://jira.nuxeo.com/browse/NXDRIVE-1407): Display CLI arguments in the fatal error screen
+- [NXDRIVE-1410](https://jira.nuxeo.com/browse/NXDRIVE-1410): Add a frame to systray layer
 - [NXDRIVE-1418](https://jira.nuxeo.com/browse/NXDRIVE-1418): Fix the error and conflict notifications' action
 
 ## Packaging / Build

--- a/docs/changes/4.0.1.md
+++ b/docs/changes/4.0.1.md
@@ -10,6 +10,7 @@
 
 - [NXDRIVE-1407](https://jira.nuxeo.com/browse/NXDRIVE-1407): Display CLI arguments in the fatal error screen
 - [NXDRIVE-1410](https://jira.nuxeo.com/browse/NXDRIVE-1410): Add a frame to systray layer
+- [NXDRIVE-1411](https://jira.nuxeo.com/browse/NXDRIVE-1411): Use consistent icons to edit document / open local folder
 - [NXDRIVE-1418](https://jira.nuxeo.com/browse/NXDRIVE-1418): Fix the error and conflict notifications' action
 
 ## Packaging / Build

--- a/docs/changes/4.0.1.md
+++ b/docs/changes/4.0.1.md
@@ -14,6 +14,7 @@
 - [NXDRIVE-1412](https://jira.nuxeo.com/browse/NXDRIVE-1412): Replace "Synchronization completed" label by "Synchronization complete"
 - [NXDRIVE-1413](https://jira.nuxeo.com/browse/NXDRIVE-1413): Prevent long server URL from moving folder and settings icons to the right
 - [NXDRIVE-1418](https://jira.nuxeo.com/browse/NXDRIVE-1418): Fix the error and conflict notifications' action
+- [NXDRIVE-1421](https://jira.nuxeo.com/browse/NXDRIVE-1421): Enable text selection on server URL and destination folder
 
 ## Packaging / Build
 

--- a/docs/changes/4.0.1.md
+++ b/docs/changes/4.0.1.md
@@ -12,6 +12,7 @@
 - [NXDRIVE-1410](https://jira.nuxeo.com/browse/NXDRIVE-1410): Add a frame to systray layer
 - [NXDRIVE-1411](https://jira.nuxeo.com/browse/NXDRIVE-1411): Use consistent icons to edit document / open local folder
 - [NXDRIVE-1412](https://jira.nuxeo.com/browse/NXDRIVE-1412): Replace "Synchronization completed" label by "Synchronization complete"
+- [NXDRIVE-1413](https://jira.nuxeo.com/browse/NXDRIVE-1413): Prevent long server URL from moving folder and settings icons to the right
 - [NXDRIVE-1418](https://jira.nuxeo.com/browse/NXDRIVE-1418): Fix the error and conflict notifications' action
 
 ## Packaging / Build

--- a/docs/changes/4.0.1.md
+++ b/docs/changes/4.0.1.md
@@ -11,6 +11,7 @@
 - [NXDRIVE-1407](https://jira.nuxeo.com/browse/NXDRIVE-1407): Display CLI arguments in the fatal error screen
 - [NXDRIVE-1410](https://jira.nuxeo.com/browse/NXDRIVE-1410): Add a frame to systray layer
 - [NXDRIVE-1411](https://jira.nuxeo.com/browse/NXDRIVE-1411): Use consistent icons to edit document / open local folder
+- [NXDRIVE-1412](https://jira.nuxeo.com/browse/NXDRIVE-1412): Replace "Synchronization completed" label by "Synchronization complete"
 - [NXDRIVE-1418](https://jira.nuxeo.com/browse/NXDRIVE-1418): Fix the error and conflict notifications' action
 
 ## Packaging / Build

--- a/nxdrive/data/i18n/i18n.json
+++ b/nxdrive/data/i18n/i18n.json
@@ -206,7 +206,7 @@
     "SHOW_FILE_STATUS": "Show file status",
     "SOURCE_LINK": "See the source",
     "SUSPEND": "Suspend",
-    "SYNCHRONIZATION_COMPLETED": "Synchronization completed",
+    "SYNCHRONIZATION_COMPLETED": "Synchronization complete",
     "SYNCHRONIZATION_IN_PROGRESS": "Synchronization in progress",
     "SYNCHRONIZATION_ITEMS_LEFT": "Items to sync: %1",
     "SYSTEM": "System",

--- a/nxdrive/data/qml/NuxeoInput.qml
+++ b/nxdrive/data/qml/NuxeoInput.qml
@@ -10,6 +10,7 @@ TextInput {
     selectionColor: teal
     horizontalAlignment: TextInput.AlignLeft
     verticalAlignment: TextInput.AlignVCenter
+    selectByMouse: true
 
     Rectangle {
         color: control.focus ? control.lineColor : lightGray

--- a/nxdrive/data/qml/Systray.qml
+++ b/nxdrive/data/qml/Systray.qml
@@ -85,6 +85,7 @@ Rectangle {
 
                 ColumnLayout {
                     Layout.alignment: Qt.AlignLeft
+                    Layout.maximumWidth: parent.width / 2
 
                     AccountsComboBox {
                         id: accountSelect
@@ -94,9 +95,24 @@ Rectangle {
                     }
 
                     ScaledText {
+                        id: accountUrl
+                        Layout.maximumWidth: parent.width
                         text: accountSelect.getRole("url")
+                        elide: Text.ElideRight
                         pointSize: 10
                         color: mediumGray
+
+                        MouseArea {
+                            id: urlHover
+                            z: parent.z + 10
+                            anchors.fill: parent
+                            anchors.margins: -3
+                            hoverEnabled: true
+                        }
+                        NuxeoToolTip {
+                            text: accountUrl.text
+                            visible: urlHover.containsMouse
+                        }
                     }
                 }
 

--- a/nxdrive/data/qml/Systray.qml
+++ b/nxdrive/data/qml/Systray.qml
@@ -4,9 +4,13 @@ import QtQuick.Layouts 1.3
 import QtQuick.Window 2.2
 import "icon-font/Icon.js" as MdiFont
 
-Item {
+Rectangle {
     id: systray
     width: 300; height: 370
+    border {
+        width: 1
+        color: "#33000000"
+    }
 
     property bool hasAccounts: EngineModel.count > 0
 
@@ -46,11 +50,12 @@ Item {
     ColumnLayout {
         id: systrayContainer
         visible: hasAccounts
-
+        width: parent.width - 2
+        height: parent.height - 2
         property int syncingCount: 0
         property int extraCount: 0
 
-        anchors.fill: parent
+        anchors.centerIn: parent
         z: 5; spacing: 0
 
         Rectangle {
@@ -281,7 +286,9 @@ Item {
 
     Rectangle {
         visible: !hasAccounts
-        anchors.fill: parent
+        width: parent.width - 2
+        height: parent.height - 2
+        anchors.centerIn: parent
         z: 5
         color: "white"
 

--- a/nxdrive/data/qml/SystrayFile.qml
+++ b/nxdrive/data/qml/SystrayFile.qml
@@ -45,7 +45,7 @@ Rectangle {
         IconLabel {
             z: 20; size: 24
             Layout.alignment: Qt.AlignLeft; Layout.rightMargin: 10
-            icon: MdiFont.Icon.folder
+            icon: MdiFont.Icon.pencil
             onClicked: api.open_local(accountSelect.getRole("uid"), local_path)
         }
     }

--- a/tests/resources/i18n/i18n.json
+++ b/tests/resources/i18n/i18n.json
@@ -53,7 +53,7 @@
     "QUIT": "Quit",
     "CONFLICTS_SYSTRAY": "%1 conflicts",
     "ERRORS_SYSTRAY": "%1 errors",
-    "SYNCHRONIZATION_COMPLETED": "Synchronization completed",
+    "SYNCHRONIZATION_COMPLETED": "Synchronization complete",
     "SYNCHRONIZATION_IN_PROGRESS": "Synchronization in progress",
     "OPEN_ROOT_FOLDER": "Open Nuxeo Drive Folder",
     "OPEN_SERVER": "Open Nuxeo Server",


### PR DESCRIPTION
NXDRIVE-1412: Replace 'Synchronization completed' label by 'Synchronization complete'
NXDRIVE-1413: Prevent long server URL from moving folder and settings icons to the right
NXDRIVE-1421: Enable text selection on server URL and destination folder
NXDRIVE-1410: Add a frame to systray layer