### PR TITLE
NXDRIVE-1433: Handle custom SSL certificates

### DIFF
--- a/docs/changes/4.0.1.md
+++ b/docs/changes/4.0.1.md
@@ -3,6 +3,7 @@
 Release date: `2018-11-21`
 
 Changes in command line arguments:
+
 - Changed `consider-ssl-errors` with default as `True` to `ssl-no-verify` with default as `False`.
 
 ## Core

--- a/docs/changes/4.0.2.md
+++ b/docs/changes/4.0.2.md
@@ -1,3 +1,11 @@
 # 4.0.2
 
 Release date: `2018-xx-xx`
+
+Changes in command line arguments:
+
+- Added `ca-bundle`.
+
+## Core
+
+- [NXDRIVE-1433](https://jira.nuxeo.com/browse/NXDRIVE-1433): Handle custom SSL certificates

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,18 +1,23 @@
 # Configuration
 
 Nuxeo Drive has different parameters that you can set up through:
-- the REST API endpoint `/drive/configuration` served by the server (since [NXP-22946](https://jira.nuxeo.com/browse/NXP-22946) and Drive 3.0.0),
-- a `$HOME/.nuxeo-drive/config.ini` file,
-- a registry key inside `HKEY_CURRENT_USER\Software\Nuxeo\Drive` (since Drive 3.1.0, Windows only),
-- the command line.
+
+- The REST API endpoint `/drive/configuration` served by the server (since [NXP-22946](https://jira.nuxeo.com/browse/NXP-22946) and Drive 3.0.0).
+- The command line.
+- A registry key inside `HKEY_CURRENT_USER\Software\Nuxeo\Drive` (since Drive 3.1.0, Windows only).
+- A `config.ini` file that can be located in different places:
+  - next to the Nuxeo Drive executable
+  - from the `$HOME/.nuxeo-drive` folder
+  - from the current working directory
+
 Each of these ways overrides the previous one.
 
 ## Parameters
 
 | Parameter | Default Value | Description
 |---|---|---
-| `beta-update-site-url` | https://community.nuxeo.com/static/drive-updates | Configure custom beta update website.
-| `ssl-no-verify` | False | Define if SSL errors should be ignored.
+| `beta-update-site-url` | `https://community.nuxeo.com/static/drive-updates` | Configure custom beta update website.
+| `ca-bundle` | None | File or directory with certificates of trusted CAs. If set, `ssl-no-verify` has no effect. See the `requests` [documentation](http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification) for more details.
 | `debug` | False | Activate the debug window, and debug mode.
 | `delay` | 30 | Define the delay before each remote check.
 | `force-locale` | None | Force the reset to the language.
@@ -25,24 +30,36 @@ Each of these ways overrides the previous one.
 | `ndrive-home` | `$HOME/.nuxeo-drive` | Define the personal folder.
 | `nofscheck` | False | Disable the standard check for binding, to allow installation on network filesystem.
 | `proxy-server` | None | Define the address of the proxy server (e.g. `http://proxy.example.com:3128`). This can also be set up by the user from the Settings window.
+| `ssl-no-verify` | False | Define if SSL errors should be ignored. Highly unadvised to enable this option.
 | `timeout` | 30 | Define the socket timeout.
 | `update-check-delay` | 3600 | Define the auto-update check delay. 0 means disabled.
-| `update-site-url` | https://community.nuxeo.com/static/drive-updates | Configure a custom update website. See Nuxeo Drive Update Site for more details.
+| `update-site-url` | `https://community.nuxeo.com/static/drive-updates` | Configure a custom update website. See Nuxeo Drive Update Site for more details.
 
 ## Command Line Arguments
 
-When used as a command line argument you need to prefix with the long argument modifier `--`, e.g.: `--log-level-file TRACE`.
+When used as a command line argument you need to prefix with the long argument modifier `--`, e.g.: `--log-level-file=TRACE`.
 
 ## Configuration File
 
-Instead of using command line arguments, you can create the `config.ini` file into the `$HOME/.nuxeo-drive` folder.
-The file syntax is:
+The format of the `config.ini` file is as following:
 
-    [DEFAULT]
-    env = custom
+```ini
+[DEFAULT]
+env = custom
 
-    [custom]
-    log-level-file = TRACE
-    debug = False
+[no-updates]
+; Unused section
+update-check-delay = 0
 
-You can add parameters inside the `[custom]` section.
+[custom]
+ca_bundle = C:\certificates\terena-ssl.crt
+debug = False
+log-level-file = TRACE
+ignored_suffixes =
+    .bak
+    .tmp
+    .XXX
+```
+
+The `env` option from the `[DEFAULT]` section defines in which section looking for options.
+Here, options defined in the `[custom]` section will be taken into account.

--- a/nxdrive/client/proxy.py
+++ b/nxdrive/client/proxy.py
@@ -179,11 +179,14 @@ def save_proxy(proxy: Proxy, dao: "EngineDAO", token: str = None) -> None:
 
 
 def validate_proxy(proxy: Proxy, url: str) -> bool:
+    verify = Options.ca_bundle or not Options.ssl_no_verify
     try:
-        with requests.get(
-            url, proxies=proxy.settings(url=url), verify=not Options.ssl_no_verify
-        ):
+        with requests.get(url, proxies=proxy.settings(url=url), verify=verify):
             return True
+    except OSError as exc:
+        # OSError: Could not find a suitable TLS CA certificate bundle, invalid path: ...
+        log.critical(f"{exc}. Ensure the 'ca_bundle' option is correct.")
+        return False
     except:
         log.exception("Invalid proxy.")
         return False

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -58,7 +58,7 @@ class Remote(Nuxeo):
         **kwargs: Any,
     ) -> None:
         auth = TokenAuth(token) if token else (user_id, password)
-        kwargs["verify"] = not Options.ssl_no_verify
+        kwargs["verify"] = Options.ca_bundle or not Options.ssl_no_verify
         self.kwargs = kwargs
 
         super().__init__(

--- a/nxdrive/commandline.py
+++ b/nxdrive/commandline.py
@@ -492,6 +492,7 @@ class CliHandler:
             has_ssl_support = QSslSocket.supportsSsl()
             log.info(f"SSL support: {has_ssl_support!r}")
             if not has_ssl_support:
+                options.ca_bundle = None
                 options.ssl_no_verify = True
 
         # Update default options

--- a/nxdrive/gui/api.py
+++ b/nxdrive/gui/api.py
@@ -723,9 +723,13 @@ class QMLDriveApi(QObject):
                 headers=headers,
                 proxies=self._manager.proxy.settings(url=url),
                 timeout=timeout,
-                verify=not Options.ssl_no_verify,
+                verify=Options.ca_bundle or not Options.ssl_no_verify,
             ) as resp:
                 status = resp.status_code
+        except OSError as exc:
+            # OSError: Could not find a suitable TLS CA certificate bundle, invalid path: ...
+            log.critical(f"{exc}. Ensure the 'ca_bundle' option is correct.")
+            raise StartupPageConnectionError()
         except:
             log.exception(
                 f"Error while trying to connect to {APP_NAME}"

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -775,8 +775,7 @@ class Application(QApplication):
             version += " beta"
 
         try:
-            # No need for the `verify=not Options.ssl_no_verify` here as GitHub will never use
-            # a bad certificate.
+            # No need for the `verify` kwarg here as GitHub will never use a bad certificate.
             with requests.get(url) as resp:
                 data = resp.json()
         except requests.HTTPError as exc:

--- a/nxdrive/options.py
+++ b/nxdrive/options.py
@@ -141,6 +141,7 @@ class MetaOptions(type):
             "default",
         ),
         "browser_startup_page": ("drive_browser_login.jsp", "default"),
+        "ca_bundle": (None, "default"),
         "debug": (False, "default"),
         "debug_pydev": (False, "default"),
         "delay": (30, "default"),

--- a/nxdrive/updater/base.py
+++ b/nxdrive/updater/base.py
@@ -158,7 +158,7 @@ class BaseUpdater(PollWorker):
             f"into {path!r}"
         )
         try:
-            # Note: I do not think we should pass the `verify=not Options.ssl_no_verify` kwarg here
+            # Note: I do not think we should pass the `verify` kwarg here
             # because updates are critical and must be stored on a secured server.
             req = requests.get(url, stream=True)
             size = int(req.headers["content-length"])
@@ -184,7 +184,7 @@ class BaseUpdater(PollWorker):
 
         url = f"{self.update_site}/versions.yml"
         try:
-            # Note: I do not think we should pass the `verify=not Options.ssl_no_verify` kwarg here
+            # Note: I do not think we should pass the `verify` kwarg here
             # because updates are critical and must be stored on a secured server.
             with requests.get(url) as resp:
                 resp.raise_for_status()


### PR DESCRIPTION
Introduce the `ca-bundle` option that must point to a file or directory with certificates of trusted CAs.
If set, the `ssl-no-verify` option has no effect.