### PR TITLE
NXDRIVE-1358: Reduce the complexity of LocalWatcher.handle_watchdog_event()

### DIFF
--- a/docs/changes/4.0.2.md
+++ b/docs/changes/4.0.2.md
@@ -12,6 +12,7 @@ Changes in command line arguments:
 
 - [NXDRIVE-404](https://jira.nuxeo.com/browse/NXDRIVE-404): Handle custom SSL certificates
 - [NXDRIVE-1347](https://jira.nuxeo.com/browse/NXDRIVE-1347): Ignore unknown versions in versions.yml
+- [NXDRIVE-1358](https://jira.nuxeo.com/browse/NXDRIVE-1358): Reduce the complexity of `LocalWatcher.handle_watchdog_event()`
 - [NXDRIVE-1385](https://jira.nuxeo.com/browse/NXDRIVE-1385): Missing translations
 - [NXDRIVE-1432](https://jira.nuxeo.com/browse/NXDRIVE-1432): Remove automatic logout before login
 - [NXDRIVE-1433](https://jira.nuxeo.com/browse/NXDRIVE-1433): Add the ca-bundle option to allow setting a custom SSL certificate


### PR DESCRIPTION
Before:
```shell
$ python -m radon cc nxdrive/engine/watcher/local_watcher.py | grep "\.handle_watchdog_event"
    M 901:4 LocalWatcher.handle_watchdog_event - F
```
After:
```shell
$ python -m radon cc nxdrive/engine/watcher/local_watcher.py | grep "\.handle_watchdog_event"
    M 907:4 LocalWatcher.handle_watchdog_event - C
```
New methods:
```shell
$ python -m radon cc nxdrive/engine/watcher/local_watcher.py | grep __handler
    M 1052:4 LocalWatcher.__handle_event_with_local_info - C
    M 1017:4 LocalWatcher.__handle_watchdog_event_on_known_pair - B
    M 990:4 LocalWatcher.__handle_event_moved - B
    M 985:4 LocalWatcher.__handle_event_deleted - A
```