### PR TITLE
NXDRIVE-1090: Long path names generates duplicata on folder creation

### DIFF
--- a/tests/test_long_path.py
+++ b/tests/test_long_path.py
@@ -50,16 +50,15 @@ class TestLongPath(UnitTestCase):
 
         self.wait_sync(wait_for_async=True, fail_if_timeout=False)
         remote_children_of_c = self.remote_1.get_children_info(self.folder_c)
-        children_names = [item.name for item in remote_children_of_c]
         log.warning("Verify if FOLDER_D is uploaded to server")
-        assert FOLDER_D in children_names
-        folder_d = [item.uid for item in remote_children_of_c if item.name == FOLDER_D][
-            0
-        ]
-        remote_children_of_d = self.remote_1.get_children_info(folder_d)
-        children_names = [item.name for item in remote_children_of_d]
+        assert len(remote_children_of_c) == 2
+        folder = [item for item in remote_children_of_c if item.name == FOLDER_D][0]
+        assert folder.name == FOLDER_D
+
+        remote_children_of_d = self.remote_1.get_children_info(folder.uid)
+        assert len(remote_children_of_d) == 1
         log.warning("Verify if FOLDER_D\\File2.txt is uploaded to server")
-        assert "File2.txt" in children_names
+        assert remote_children_of_d[0].name == "File2.txt"
 
     def test_setup_on_long_path(self):
         """ NXDRIVE-689: Fix error when adding a new account when installation


### PR DESCRIPTION
Just restricting a test, this bug has been fixed by the use of pathlib with NXDRIVE-1109.