### PR TITLE
NXDRIVE-1523: Handle paths with more than 143 chars on encrypted FS

### DIFF
--- a/docs/changes/4.1.0.md
+++ b/docs/changes/4.1.0.md
@@ -14,6 +14,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1517](https://jira.nuxeo.com/browse/NXDRIVE-1517): Ensure remote ref is always set
 - [NXDRIVE-1518](https://jira.nuxeo.com/browse/NXDRIVE-1518): Fix watchdog observer `stop()` call
 - [NXDRIVE-1520](https://jira.nuxeo.com/browse/NXDRIVE-1520): Always send statistics, even if there is no engine
+- [NXDRIVE-1523](https://jira.nuxeo.com/browse/NXDRIVE-1523): Handle paths with more than 143 chars on encrypted FS
 
 ## Packaging / Build
 
@@ -35,12 +36,14 @@ Release date: `2019-xx-xx`
 
 - Changed type of all local paths from `str` to pathlib `Path`
 - Removed `name` keyword argument from `AbstractOSIntegration.register_folder_link()`
+- Removed `Engine.fileDeletionErrorTooLong`. Use `longPathError` instead.
 - Removed `Engine.local_folder_bs`
 - Removed `LocalClient.get_children_ref()`
 - Added `Remote.execute()`
 - Added engine/dao/sqlite.py::`prepare_args()`
 - Added engine/dao/sqlite.py::`str_to_path()`
 - Added exceptions.py::`Forbidden`
+- Removed notifications.py::`FileDeletionError`. Use `LongPathError` instead.
 - Added updater/constants.py::`Login`
 - Changed updater/utils.py::`get_update_status()` argument `has_browser_login` (`bool`) to `login_type` (`Login`)
 - Removed utils.py::`path_join()`

--- a/nxdrive/client/local_client.py
+++ b/nxdrive/client/local_client.py
@@ -611,7 +611,14 @@ FolderType=Generic
                 self.lock_ref(parent_ref, locker)
 
     def exists(self, ref: Path) -> bool:
-        return self.abspath(ref).exists()
+        try:
+            return self.abspath(ref).exists()
+        except OSError as exc:
+            if exc.errno == 36:  # Filename too long
+                # On such error, no file can be accessed nor modified,
+                # so this is the same as if it does not exist.
+                return False
+            raise exc
 
     def rename(self, ref: Path, to_name: str) -> FileInfo:
         """ Rename a local file or folder. """

--- a/nxdrive/data/i18n/i18n.json
+++ b/nxdrive/data/i18n/i18n.json
@@ -124,6 +124,8 @@
     "LOCKED_FILE": "Cannot update „%1“ as it was locked by %2 on %3",
     "LOCK_NOTIFICATION_DESCRIPTION": "The document „%1“ has been locked",
     "LOCK_NOTIFICATION_TITLE": "Autolock",
+    "LONG_PATH_ERROR_TITLE": "Filename too long",
+    "LONG_PATH_ERROR_MSG": "The document „%1“ cannot be processed because its filename or full path is too long.",
     "MANUAL": "Manual",
     "METADATA_FILE_NOT_HANDLE": "This file is not handled by the Nuxeo server or is not synchronized yet.",
     "MINS_AGO": "%1 minutes ago",
@@ -242,7 +244,5 @@
     "WELCOME_MESSAGE": "Set your account and synchronize your files with the Nuxeo Platform.",
     "WINDOWS_ERROR_TITLE": "Document error",
     "WINDOWS_ERROR_OPENED_FILE": "The file „%1“ is open by another software. Please close it before Nuxeo Drive can process the deletion from your local storage.",
-    "WINDOWS_ERROR_OPENED_FOLDER": "The folder „%1“ or its children is locked by another software. Please close it before Nuxeo Drive can process the deletion from your local storage.",
-    "DELETION_ERROR_TITLE": "Document deletion error",
-    "DELETION_ERROR_MSG": "The document „%1“ cannot be unsynchronised because its full path is too long."
+    "WINDOWS_ERROR_OPENED_FOLDER": "The folder „%1“ or its children is locked by another software. Please close it before Nuxeo Drive can process the deletion from your local storage."
 }

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -58,7 +58,7 @@ class Engine(QObject):
     _stop = pyqtSignal()
     _scanPair = pyqtSignal(str)
     errorOpenedFile = pyqtSignal(object)
-    fileDeletionErrorTooLong = pyqtSignal(object)
+    longPathError = pyqtSignal(object)
     syncStarted = pyqtSignal(object)
     syncCompleted = pyqtSignal()
     # Sent when files are in blacklist but the rest is ok

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -337,8 +337,12 @@ class Processor(EngineWorker):
                         )
                         self.engine.errorOpenedFile.emit(doc_pair)
                         self._postpone_pair(doc_pair, "Used by another process")
-                    elif error in {111, 121, 124, 206, 1223}:
+                    elif error in {36, 111, 121, 124, 206, 1223}:
                         """
+                        OSError: [Errno 36] Filename too long
+                        Cause: on GNU/Linux, filename is restricted to 255 chars
+                        or even worse: 143 if using encryptFS
+
                         WindowsError: [Error 111] ??? (seems related to deep
                         tree)
                         Cause: short paths are disabled on Windows
@@ -362,7 +366,7 @@ class Processor(EngineWorker):
                         self._dao.remove_filter(
                             doc_pair.remote_parent_path + "/" + doc_pair.remote_ref
                         )
-                        self.engine.fileDeletionErrorTooLong.emit(doc_pair)
+                        self.engine.longPathError.emit(doc_pair)
                     elif hasattr(exc, "trash_issue"):
                         """
                         Special value to handle trash issues from filters on

--- a/nxdrive/notification.py
+++ b/nxdrive/notification.py
@@ -428,13 +428,13 @@ class ErrorOpenedFile(Notification):
         )
 
 
-class FileDeletionError(Notification):
+class LongPathError(Notification):
     def __init__(self, path: str) -> None:
         values = [short_name(path)]
         super().__init__(
-            "DELETION_ERROR",
-            title=Translator.get("DELETION_ERROR_TITLE"),
-            description=Translator.get("DELETION_ERROR_MSG", values),
+            "LONG_PATH_ERROR",
+            title=Translator.get("LONG_PATH_ERROR_TITLE"),
+            description=Translator.get("LONG_PATH_ERROR_MSG", values),
             level=Notification.LEVEL_ERROR,
             flags=(
                 Notification.FLAG_UNIQUE
@@ -489,13 +489,13 @@ class DefaultNotificationService(NotificationService):
         engine.invalidAuthentication.connect(self._invalidAuthentication)
         engine.online.connect(self._validAuthentication)
         engine.errorOpenedFile.connect(self._errorOpenedFile)
-        engine.fileDeletionErrorTooLong.connect(self._fileDeletionErrorTooLong)
+        engine.longPathError.connect(self._longPathError)
 
     def _errorOpenedFile(self, doc: DocPair) -> None:
         self.send_notification(ErrorOpenedFile(str(doc.local_path), doc.folderish))
 
-    def _fileDeletionErrorTooLong(self, doc: DocPair) -> None:
-        self.send_notification(FileDeletionError(str(doc.local_path)))
+    def _longPathError(self, doc: DocPair) -> None:
+        self.send_notification(LongPathError(str(doc.local_path)))
 
     def _lockDocument(self, filename: str) -> None:
         self.send_notification(LockNotification(filename))

--- a/tests/test_long_path.py
+++ b/tests/test_long_path.py
@@ -1,19 +1,20 @@
 # coding: utf-8
-from logging import getLogger
 import os
+from unittest.mock import patch
+
 import pytest
 
 from nxdrive.constants import WINDOWS
 
 from .common import UnitTestCase
 
-log = getLogger(__name__)
 
-# Number of chars in path c://.../Nuxeo.. is approx 96 chars
+# Number of chars in path "C:\...\Nuxeo..." is approx 96 chars
 FOLDER_A = "A" * 90
 FOLDER_B = "B" * 90
 FOLDER_C = "C" * 90
 FOLDER_D = "D" * 50
+FILE = "F" * 255 + ".txt"
 
 
 class TestLongPath(UnitTestCase):
@@ -21,7 +22,6 @@ class TestLongPath(UnitTestCase):
         super().setUp()
 
         self.remote_1 = self.remote_document_client_1
-        log.info("Create a folder AAAA... (90 chars) in server")
         self.folder_a = self.remote_1.make_folder("/", FOLDER_A)
         self.folder_b = self.remote_1.make_folder(self.folder_a, FOLDER_B)
         self.folder_c = self.remote_1.make_folder(self.folder_b, FOLDER_C)
@@ -40,24 +40,20 @@ class TestLongPath(UnitTestCase):
         )
         if WINDOWS:
             parent_path = f"\\\\?\\{parent_path}"
-        log.info(f"Creating folder with path: {parent_path}")
         os.makedirs(parent_path, exist_ok=True)
 
         new_file = os.path.join(parent_path, "File2.txt")
-        log.info(f"Creating file with path: {new_file}")
         with open(new_file, "wb") as f:
             f.write(b"Hello world")
 
         self.wait_sync(wait_for_async=True, fail_if_timeout=False)
         remote_children_of_c = self.remote_1.get_children_info(self.folder_c)
-        log.warning("Verify if FOLDER_D is uploaded to server")
         assert len(remote_children_of_c) == 2
         folder = [item for item in remote_children_of_c if item.name == FOLDER_D][0]
         assert folder.name == FOLDER_D
 
         remote_children_of_d = self.remote_1.get_children_info(folder.uid)
         assert len(remote_children_of_d) == 1
-        log.warning("Verify if FOLDER_D\\File2.txt is uploaded to server")
         assert remote_children_of_d[0].name == "File2.txt"
 
     def test_setup_on_long_path(self):
@@ -88,3 +84,25 @@ class TestLongPath(UnitTestCase):
 
         self.engine_1.start()
         self.engine_1.stop()
+
+
+class TestLongFileName(UnitTestCase):
+    def test_long_file_name(self):
+        def error(*_):
+            nonlocal received
+            received = True
+
+        received = False
+        remote = self.remote_document_client_1
+
+        self.engine_1.start()
+        self.wait_sync(wait_for_async=True)
+
+        with patch.object(
+            self.manager_1.notification_service, "_longPathError", new_callable=error
+        ):
+            remote.make_file(self.workspace, FILE, content=b"Sample Content")
+            self.wait_sync(wait_for_async=True, timeout=5, fail_if_timeout=False)
+
+            assert received
+            assert not self.local_1.exists(f"/{FILE}")


### PR DESCRIPTION
On most GNU/Linux FS, the maximum filename size is 255.
It is worst when using encryptFS which sets the limit to 143.

The patch makes `Processor()` to handle this case (`OSError` 36) and adapt `LocalClient.exists()` to return `False` when encountering that error.