### PR TITLE
NXDRIVE-1493: Add DirectEdit support for the Adobe Creative Suite

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,6 @@
 # Documentation
 
+- [behaviors](behaviors/): Application behavior analysis.
 - [changes](changes/): All changes (including technical ones) introduced in every release since Drive 2.4.6 (2017-06-29). Useful for the **support**.
 - [configuration.md](configuration.md): How to permanently configure Drive and the list of command line arguments.
 - [contextual_menu.md](contextual_menu.md): How to install contextual menu items.

--- a/docs/behaviors/Adobe Creative Suite.md
+++ b/docs/behaviors/Adobe Creative Suite.md
@@ -232,4 +232,15 @@ for doc in app.Application.Documents:
     print(doc.FullName)
 ```
 
-It will output the list of opened files.
+And for macOS, using AppleScript:
+
+```python
+from ScriptingBridge import SBApplication
+
+
+app = SBApplication.applicationWithBundleIdentifier_("com.adobe.Photoshop")
+for doc in app.documents():
+    print(doc.filePath().path())
+```
+
+Both codes will output the list of opened files.

--- a/docs/behaviors/Adobe Creative Suite.md
+++ b/docs/behaviors/Adobe Creative Suite.md
@@ -1,0 +1,235 @@
+# Adobe Creative Suite: Photoshop
+
+The following is a recipe based on a real world example on how we tried to understand how Photoshop is working with a opened files.
+For this scenario, we are on Windows 10 with the username Alice.
+
+1. First, install `watchmedo`.
+2. Create the folder `C:\Users\Alice\tests`.
+3. Open Photoshop and save a test file, let's say `test.psd`, inside that folder.
+4. Go to that folder and execute this code in a console:
+    ```batch
+    C:\Users\Alice\tests> watchmedo log --recursive .
+    ```
+5. Then, open `test.psd` with Photoshop.
+6. Observe the console output when doing different actions.
+
+## Opening
+
+When opening the file, nothing is logged. This is problematic as for now we have no way to know that `test.psd` is being edited in Photoshop.
+
+## Saving
+
+When saving changes, we can see (I removed useless data):
+
+```batch
+on_created(event=<FileCreatedEvent: src_path='.\\ps9985.tmp'>)
+on_modified(event=<FileModifiedEvent: src_path='.\\ps9985.tmp'>)
+on_modified(event=<FileModifiedEvent: src_path='.\\ps9985.tmp'>)
+on_deleted(event=<FileDeletedEvent: src_path='.\\test.psd'>)
+on_moved(event=<FileMovedEvent: src_path='.\\ps9985.tmp', dest_path='.\\test.psd'>)
+on_modified(event=<FileModifiedEvent: src_path='.\\test.psd'>)
+```
+
+What we can understand is that Photoshop is:
+
+1. Creating a temporary file `ps9985.tmp` with the updated content of `test.psd`.
+2. Deleting `test.psd`.
+3. Moving `ps9985.tmp` to `test.psd`.
+
+### Opened Files
+
+We have another way to detect opened files. We use this Python code (inspired from [autolocker.py](https://github.com/nuxeo/nuxeo-drive/blob/349d195f2337dd730f43a2d99bb0d2239dbeef87/nxdrive/autolocker.py#L115)):
+
+```python
+from contextlib import suppress
+from typing import Iterator, Tuple
+import psutil
+
+
+def get_open_files() -> Iterator[Tuple[int, str]]:
+    """
+    Get all opened files on the OS.
+    :return: Generator of (PID, file path).
+    """
+    for proc in psutil.process_iter():
+        with suppress(psutil.Error, OSError):
+            for handler in proc.open_files():
+                with suppress(PermissionError):
+                    yield proc.pid, handler.path.lower()
+
+
+for pid, path in get_open_files():
+    # XXX: This is here you can change what you are looking for
+    if (
+        "photoshop" in path
+        and not "required" in path
+        and not "web-cache-temp" in path
+    ):
+        print(pid, file)
+```
+
+Calling this script will output:
+
+```batch
+6872 C:\Program Files\Adobe\Adobe Photoshop CC 2018\TypeLibrary.tlb
+6872 C:\Users\Alice\AppData\Roaming\Adobe\Adobe Photoshop CC 2018\logs\debug.log
+6872 C:\Users\Alice\AppData\Local\Temp\Photoshop Temp1893966872
+```
+
+The interesting thing is `C:\Users\Alice\AppData\Local\Temp\Photoshop Temp1893966872`, which is a 163 Mo file!
+For information, `test.psd` is only 456Ko ...
+
+That file is protected and cannot be accessed outside Photoshop. Making a copy will result in an empty file.
+
+Now, can we do try something else with that? Let's try!
+
+#### Parsing the Debug File
+
+In the opened files, there was a `debug.log`:
+
+```batch
+C:\Users\Alice\AppData\Roaming\Adobe\Adobe Photoshop CC 2018\logs\debug.log
+```
+
+But this file is empty.
+
+#### Marking the File
+
+We can use xattr (extended attributes) to mark the original file and see if we find the marker in the temporary file too.
+
+We will use this Python code (inspired from [local_client.py](https://github.com/nuxeo/nuxeo-drive/blob/master/nxdrive/client/local_client.py#L331)):
+
+```python
+def set_xattr(path : str, marker: str, value: bytes) -> None:
+    """
+    Add a marker into extended attributes.
+    """
+    path_alt = f"{path}:{marker}"
+    with open(path_alt, "wb") as f:
+        f.write(value)
+
+def read_xattr(path : str, marker: str) -> bytes:
+    """
+    Read a marker from extended attributes.
+    """
+    path_alt = f"{path}:{marker}"
+    try:
+        with open(path_alt, "rb") as f:
+            return f.read()
+    except FileNotFoundError:
+        return b""
+```
+
+Then we mark the original file:
+
+```python
+set_xattr(r"C:\Users\Alice\test\test.psd", "marker", b"found me!")
+```
+
+And change the `XXX` part of the previous script to include the check:
+
+```python
+for pid, path in get_open_files():
+    # XXX: This is here you can change what you are looking for
+    if (
+        "photoshop" in path
+        and not "web-cache-temp" in path
+        and "temp" in path
+    ):
+        print(pid, path)
+        print("xattr marker:", read_xattr(path, "marker"))
+```
+
+The output will be, sadly:
+
+```batch
+7620 c:\users\window~1\appdata\local\temp\photoshop temp2608567620
+xattr marker: b''
+```
+
+The marker is empty, meaning this does not work.
+
+## Ideas
+
+### Idea 1
+
+In the Photoshop settings, we can set a log file where actions are writen.
+
+The file content look like:
+
+```log
+2019-02-01 17:50:17    D�but de la session Photoshop
+2019-02-01 17:50:21    Fichier test.psd ouvert
+2019-02-01 17:50:51    Fichier test.psd ferm�
+2019-02-01 17:50:51    Fin de la session Photoshop
+```
+
+But I only see many cons:
+
+1) We are asking the user to do something.
+2) If we do that, we need the user to save the file in a folder we define (into `$HOME/.nuxeo-drive/apps/` for example). For that, the user must show hidden files, which may be a painful task.
+3) The log file is localised (and it seems there are encoding issues on Windows, which will harden the task).
+4) If we decide to write a custom log parser for Photoshop, we will have to do that for others apps, which is a non desirable amount of work (not speaking about the log format changes in several apps versions).
+
+### Idea 2
+
+A naive approach would be to check that `get_open_files()` returns a path ending with `r"Photoshop Temp\d+"`.
+But this implies a lot of trouble:
+
+1) If another picture is already open in Photoshop when doing the DirectEdit on another document, we will have 2 temporary files. Which one is the good one?
+2) If Photoshtop failed to open the DirectEdit'ing document, but there already is another file opened, we will ses a temporary file but it will not be the good one.
+3) If there is several DirectEdit on mutiple files, how to know which temporary file belongs to whic document?
+
+And most probably a lot of issues I cannot imagine right now.
+So, this does not work either.
+
+### Idea 3
+
+We could use the Photoshop Scripting API. I uses COM objects on Windows and AppleScript on macOS.
+
+I read that we can setup a `Notifer` that will call a function on specifed a event.
+
+This is a non working POC for Windows (requires the `pywin32` module):
+
+```python
+from win32com.client import Dispatch, GetActiveObject
+
+
+app = GetActiveObject("Photoshop.Application")
+
+# Ensure the Notifier is enabled
+app.notifiersEnabled = True
+
+# Call the function 'on_open_event()' when any document is opened.
+# This is not work for documents opened via another script.
+def on_open_event(*args, **kwargs):
+    print(args, kwargs)
+
+def on_close_event(*args, **kwargs):
+    print(args, kwargs)
+
+app.notifiers.add("Opn ", on_open_event)
+app.notifiers.add("Cls ", on_close_event)
+
+while True:
+    pass
+```
+
+Reference manuals are [here](https://www.adobe.com/devnet/photoshop/scripting.html).
+
+## Solution
+
+The final idea was the good one: use the Photoshop Scripting API (COM objects on Windows and AppleScript on macOS).
+
+After a long search in the sparse documentation and a lot of bad snippets found on Internet, this is the so *simple* working script:
+
+```python
+from win32com.client import GetActiveObject
+
+
+app = GetActiveObject("Photoshop.Application")
+for doc in app.Application.Documents:
+    print(doc.FullName)
+```
+
+It will output the list of opened files.

--- a/docs/behaviors/README.md
+++ b/docs/behaviors/README.md
@@ -1,0 +1,18 @@
+# Application Behavior Analysis
+
+We are using [watchmedo](https://github.com/gorakhargosh/watchdog/#shell-utilities) to check and try to understand how a given software is managing files.
+This is crucial to be able to find a pattern to identify documents to lock/unlock on the server when using DirectEdit.
+
+The following is some guidelines (we are on Windows 10 with the username Alice and trying to analyse Photoshop):
+
+1. First, install `watchmedo`.
+2. Create the folder `C:\Users\Alice\tests`.
+3. Open Photoshop and save a test file, let's say `test.psd`, inside that folder.
+4. Go to that folder and execute this code in a console:
+    ```batch
+    C:\Users\Alice\tests> watchmedo log --recursive .
+    ```
+5. Then, open `test.psd` with Photoshop.
+6. Observe the console output when doing different actions.
+
+You can find valuable information in the different anaylsed behaviors in that folder.

--- a/docs/changes/4.1.0.md
+++ b/docs/changes/4.1.0.md
@@ -72,6 +72,7 @@ Release date: `2019-xx-xx`
 - Moved autolocker.py::`Item` to objects.py
 - Moved autolocker.py::`Items` to objects.py
 - Removed notifications.py::`FileDeletionError`. Use `LongPathError` instead.
+- Added osi/windows/files.py
 - Added updater/constants.py::`Login`
 - Changed updater/utils.py::`get_update_status()` argument `has_browser_login` (`bool`) to `login_type` (`Login`)
 - Removed utils.py::`path_join()`

--- a/docs/changes/4.1.0.md
+++ b/docs/changes/4.1.0.md
@@ -80,4 +80,5 @@ Release date: `2019-xx-xx`
 - Added osi/windows/files.py
 - Added updater/constants.py::`Login`
 - Changed updater/utils.py::`get_update_status()` argument `has_browser_login` (`bool`) to `login_type` (`Login`)
+- Added utils.py::`compute_fake_pid_from_path()`
 - Removed utils.py::`path_join()`

--- a/docs/changes/4.1.0.md
+++ b/docs/changes/4.1.0.md
@@ -46,6 +46,7 @@ Release date: `2019-xx-xx`
 
 ## Minor Changes
 
+- Packaging: Added `pyobjc-framework-ScriptingBridge` 4.2.2
 - Packaging: Updated `distro` from 1.3.0 to 1.4.0
 - Packaging: Updated `flake8` from 3.6.0 to 3.7.5
 - Packaging: Updated `mypy` from 0.650 to 0.660
@@ -74,6 +75,7 @@ Release date: `2019-xx-xx`
 - Moved autolocker.py::`Item` to objects.py
 - Moved autolocker.py::`Items` to objects.py
 - Removed notifications.py::`FileDeletionError`. Use `LongPathError` instead.
+- Added osi/darwin/files.py
 - Added osi/linux
 - Added osi/windows/files.py
 - Added updater/constants.py::`Login`

--- a/docs/changes/4.1.0.md
+++ b/docs/changes/4.1.0.md
@@ -62,9 +62,11 @@ Release date: `2019-xx-xx`
 - Added `ConfigurationDAO.store_bool()`
 - Added `ConfigurationDAO.store_int()`
 - Removed `name` keyword argument from `AbstractOSIntegration.register_folder_link()`
+- Added `DarwinIntegration.open_local_file()`
 - Removed `Engine.fileDeletionErrorTooLong`. Use `longPathError` instead.
 - Removed `Engine.local_folder_bs`
 - Removed `LocalClient.get_children_ref()`
+- Added `WindowsIntegration.open_local_file()`
 - Added `Remote.execute()`
 - Added engine/dao/sqlite.py::`prepare_args()`
 - Added engine/dao/sqlite.py::`str_to_path()`
@@ -72,6 +74,7 @@ Release date: `2019-xx-xx`
 - Moved autolocker.py::`Item` to objects.py
 - Moved autolocker.py::`Items` to objects.py
 - Removed notifications.py::`FileDeletionError`. Use `LongPathError` instead.
+- Added osi/linux
 - Added osi/windows/files.py
 - Added updater/constants.py::`Login`
 - Changed updater/utils.py::`get_update_status()` argument `has_browser_login` (`bool`) to `login_type` (`Login`)

--- a/docs/changes/4.1.0.md
+++ b/docs/changes/4.1.0.md
@@ -8,6 +8,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1469](https://jira.nuxeo.com/browse/NXDRIVE-1469): Display a message on forbidden DriveEdit action
 - [NXDRIVE-1475](https://jira.nuxeo.com/browse/NXDRIVE-1475): Use Sentry to share logs
 - [NXDRIVE-1492](https://jira.nuxeo.com/browse/NXDRIVE-1492): Access to the local socket is denied
+- [NXDRIVE-1493](https://jira.nuxeo.com/browse/NXDRIVE-1493): Add support for the Adobe Creative Suite with DirectEdit
 - [NXDRIVE-1494](https://jira.nuxeo.com/browse/NXDRIVE-1494): Introduce specific getters and setters for database
 - [NXDRIVE-1497](https://jira.nuxeo.com/browse/NXDRIVE-1497): Fix alert when a server is not responding
 - [NXDRIVE-1510](https://jira.nuxeo.com/browse/NXDRIVE-1510): Handle PermissionError in `get_open_files()`

--- a/docs/changes/4.1.0.md
+++ b/docs/changes/4.1.0.md
@@ -8,7 +8,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1469](https://jira.nuxeo.com/browse/NXDRIVE-1469): Display a message on forbidden DriveEdit action
 - [NXDRIVE-1475](https://jira.nuxeo.com/browse/NXDRIVE-1475): Use Sentry to share logs
 - [NXDRIVE-1492](https://jira.nuxeo.com/browse/NXDRIVE-1492): Access to the local socket is denied
-- [NXDRIVE-1493](https://jira.nuxeo.com/browse/NXDRIVE-1493): Add support for the Adobe Creative Suite with DirectEdit
+- [NXDRIVE-1493](https://jira.nuxeo.com/browse/NXDRIVE-1493): Add DirectEdit support for the Adobe Creative Suite
 - [NXDRIVE-1494](https://jira.nuxeo.com/browse/NXDRIVE-1494): Introduce specific getters and setters for database
 - [NXDRIVE-1497](https://jira.nuxeo.com/browse/NXDRIVE-1497): Fix alert when a server is not responding
 - [NXDRIVE-1510](https://jira.nuxeo.com/browse/NXDRIVE-1510): Handle PermissionError in `get_open_files()`

--- a/docs/changes/4.1.0.md
+++ b/docs/changes/4.1.0.md
@@ -69,6 +69,8 @@ Release date: `2019-xx-xx`
 - Added engine/dao/sqlite.py::`prepare_args()`
 - Added engine/dao/sqlite.py::`str_to_path()`
 - Added exceptions.py::`Forbidden`
+- Moved autolocker.py::`Item` to objects.py
+- Moved autolocker.py::`Items` to objects.py
 - Removed notifications.py::`FileDeletionError`. Use `LongPathError` instead.
 - Added updater/constants.py::`Login`
 - Changed updater/utils.py::`get_update_status()` argument `has_browser_login` (`bool`) to `login_type` (`Login`)

--- a/nxdrive/autolocker.py
+++ b/nxdrive/autolocker.py
@@ -3,13 +3,14 @@ from contextlib import suppress
 from copy import deepcopy
 from logging import getLogger
 from pathlib import Path
-from typing import Dict, Iterable, Iterator, List, Tuple, TYPE_CHECKING
+from typing import Dict, Iterable, Iterator, TYPE_CHECKING
 
 import psutil
 from PyQt5.QtCore import QTimer, pyqtSignal
 
 from .engine.workers import PollWorker
 from .exceptions import ThreadInterrupt
+from .objects import Item, Items
 
 if TYPE_CHECKING:
     from .direct_edit import DirectEdit  # noqa
@@ -18,8 +19,6 @@ if TYPE_CHECKING:
 __all__ = ("ProcessAutoLockerWorker",)
 
 log = getLogger(__name__)
-Item = Tuple[int, Path]
-Items = List[Item]
 
 
 class ProcessAutoLockerWorker(PollWorker):

--- a/nxdrive/autolocker.py
+++ b/nxdrive/autolocker.py
@@ -38,6 +38,8 @@ class ProcessAutoLockerWorker(PollWorker):
         self._first = True
 
     def set_autolock(self, filepath: Path, locker: "DirectEdit") -> None:
+        """Schedule the document lock."""
+
         if self._autolocked.get(filepath):
             # Already locked
             return
@@ -62,37 +64,52 @@ class ProcessAutoLockerWorker(PollWorker):
         return False
 
     def orphan_unlocked(self, path: Path) -> None:
+        """Unlock old documents, or documents from an old DirectEdit session."""
         self._dao.unlock_path(path)
 
     def _process(self) -> None:
-        to_unlock = deepcopy(self._autolocked)
+        current_locks = deepcopy(self._autolocked)
+
         for pid, path in get_open_files():
             if self._folder in path.parents:
                 log.debug(f"Found in watched folder: {path!r} (PID={pid})")
             elif path in self._autolocked:
                 log.debug(f"Found in auto-locked: {path!r} (PID={pid})")
             else:
+                # All documents are not interesting!
                 continue
 
             item: Item = (pid, path)
-            if path in to_unlock:
-                if not self._autolocked[path]:
-                    self._to_lock.append(item)
-                self._autolocked[path] = pid
-                del to_unlock[path]
+            if path in current_locks:
+                # If the doc has been detected but not yet locked ...
+                if self._autolocked[path] == 0:
+                    self._to_lock.append(item)  # ... schedule the lock
 
+                # Prevent re-locking the next time, set the PID as a flag (always != 0)
+                self._autolocked[path] = pid
+
+                # Remove the doc, else it will be unlocked just after
+                del current_locks[path]
+
+        # Lock new documents
         self._lock_files(self._to_lock)
-        self._unlock_files(to_unlock)
+
+        # If there are remaining documents, it means they are no more opened
+        # and therefore we need to unlock them.
+        self._unlock_files(current_locks)
 
     def _lock_files(self, items: Items) -> None:
+        """Schedule locks for the given documents."""
         for item in items:
             self._lock_file(item)
 
     def _unlock_files(self, files: Iterable[Path]) -> None:
+        """Schedule unlocks for the given documents."""
         for path in files:
             self._unlock_file(path)
 
     def _lock_file(self, item: Item) -> None:
+        """Lock a given document."""
         pid, path = item
         log.debug(f"Locking file {path!r} (PID={pid!r})")
         if path in self._lockers:
@@ -102,6 +119,7 @@ class ProcessAutoLockerWorker(PollWorker):
         self._to_lock.remove(item)
 
     def _unlock_file(self, path: Path) -> None:
+        """Unlock a given document."""
         log.debug(f"Unlocking file {path!r}")
         if path in self._lockers:
             locker = self._lockers[path]

--- a/nxdrive/autolocker.py
+++ b/nxdrive/autolocker.py
@@ -8,6 +8,7 @@ from typing import Dict, Iterable, Iterator, TYPE_CHECKING
 import psutil
 from PyQt5.QtCore import QTimer, pyqtSignal
 
+from .constants import LINUX, MAC, WINDOWS
 from .engine.workers import PollWorker
 from .exceptions import ThreadInterrupt
 from .objects import Item, Items
@@ -15,6 +16,13 @@ from .objects import Item, Items
 if TYPE_CHECKING:
     from .direct_edit import DirectEdit  # noqa
     from .engine.dao.sqlite import ManagerDAO  # noqa
+
+if LINUX:
+    from .osi.linux.files import get_other_opened_files
+elif MAC:
+    from .osi.darwin.files import get_other_opened_files
+elif WINDOWS:
+    from .osi.windows.files import get_other_opened_files
 
 __all__ = ("ProcessAutoLockerWorker",)
 
@@ -141,3 +149,5 @@ def get_open_files() -> Iterator[Item]:
             for handler in proc.open_files():
                 with suppress(PermissionError):
                     yield proc.pid, Path(handler.path)
+
+    yield from get_other_opened_files()

--- a/nxdrive/manager.py
+++ b/nxdrive/manager.py
@@ -261,6 +261,7 @@ class Manager(QObject):
 
         self.direct_edit = DirectEdit(self, self.direct_edit_folder, url)
         self.started.connect(self.direct_edit._thread.start)
+        self.autolock_service.direct_edit = self.direct_edit
         return self.direct_edit
 
     def is_paused(self) -> bool:  # TODO: Remove

--- a/nxdrive/objects.py
+++ b/nxdrive/objects.py
@@ -6,7 +6,7 @@ from contextlib import suppress
 from datetime import datetime
 from pathlib import Path
 from sqlite3 import Row
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from dataclasses import dataclass
 from dateutil import parser
@@ -23,6 +23,10 @@ Filters = List[str]
 
 # Metrics
 Metrics = Dict[str, Any]
+
+# Autolocker items
+Item = Tuple[int, Path]
+Items = List[Item]
 
 
 # Data Transfer Object for remote file info

--- a/nxdrive/osi/__init__.py
+++ b/nxdrive/osi/__init__.py
@@ -3,7 +3,7 @@ from logging import getLogger
 from pathlib import Path
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
-from ..constants import APP_NAME, MAC, WINDOWS
+from ..constants import APP_NAME, LINUX, MAC, WINDOWS
 from ..objects import DocPair
 
 if TYPE_CHECKING:
@@ -22,6 +22,16 @@ class AbstractOSIntegration:
     @property
     def zoom_factor(self) -> float:
         return self.__zoom_factor
+
+    def open_local_file(self, file_path: str, select: bool = False) -> None:
+        """
+        Launch the local OS program on the given file / folder.
+
+        :param file_path: The file URL to open.
+        :param select: Hightlight the given file_path. Useful when
+                       opening a folder and to select a file.
+        """
+        pass
 
     def register_startup(self) -> bool:
         return False
@@ -82,9 +92,11 @@ class AbstractOSIntegration:
     @staticmethod
     def get(manager: Optional["Manager"]) -> "AbstractOSIntegration":
 
-        integration, nature = AbstractOSIntegration, "None"
+        if LINUX:
+            from .linux.linux import LinuxIntegration
 
-        if MAC:
+            integration, nature = LinuxIntegration, "GNU/Linux"
+        elif MAC:
             from .darwin.darwin import DarwinIntegration
 
             integration, nature = DarwinIntegration, "macOS"
@@ -92,6 +104,8 @@ class AbstractOSIntegration:
             from .windows.windows import WindowsIntegration
 
             integration, nature = WindowsIntegration, "Windows"
+        else:
+            integration, nature = AbstractOSIntegration, "None"
 
         log.debug(f"OS integration type: {nature}")
         return integration(manager)

--- a/nxdrive/osi/darwin/darwin.py
+++ b/nxdrive/osi/darwin/darwin.py
@@ -93,6 +93,13 @@ class DarwinIntegration(AbstractOSIntegration):
     def _get_agent_file(self) -> Path:
         return Path(f"~/Library/LaunchAgents/{BUNDLE_IDENTIFIER}.plist").expanduser()
 
+    def open_local_file(self, file_path: str, select: bool = False) -> None:
+        args = ["open"]
+        if select:
+            args += ["-R"]
+        args += [file_path]
+        subprocess.check_call(args)
+
     @if_frozen
     def register_startup(self) -> bool:
         """

--- a/nxdrive/osi/darwin/files.py
+++ b/nxdrive/osi/darwin/files.py
@@ -1,26 +1,14 @@
 # coding: utf-8
-from binascii import crc32
 from contextlib import suppress
 from pathlib import Path
-from sys import getdefaultencoding
 from typing import Iterator
 
 from ScriptingBridge import SBApplication
 
 from ...objects import Items
+from ...utils import compute_fake_pid_from_path
 
 __all__ = ("get_other_opened_files",)
-
-
-def _compute_pid(path: str) -> int:
-    """
-    We have no way to find the PID of the apps using the opened file.
-    This is a limitation (or a feature) of COM objects.
-    To bypass this, we compute a unique ID for a given path.
-    """
-    if not isinstance(path, bytes):
-        path = path.encode(getdefaultencoding(), errors="ignore")  # type: ignore
-    return crc32(path)
 
 
 def _get_opened_files_adobe_cc(identifier: str) -> Iterator[Items]:
@@ -39,7 +27,8 @@ def _get_opened_files_adobe_cc(identifier: str) -> Iterator[Items]:
         app = SBApplication.applicationWithBundleIdentifier_(identifier)
         for doc in app.documents():
             path = doc.filePath().path()
-            yield _compute_pid(path), Path(path)
+            pid = compute_fake_pid_from_path(path)
+            yield pid, Path(path)
 
 
 def get_other_opened_files() -> Iterator[Items]:

--- a/nxdrive/osi/darwin/files.py
+++ b/nxdrive/osi/darwin/files.py
@@ -1,0 +1,52 @@
+# coding: utf-8
+from binascii import crc32
+from contextlib import suppress
+from pathlib import Path
+from sys import getdefaultencoding
+from typing import Iterator
+
+from ScriptingBridge import SBApplication
+
+from ...objects import Items
+
+__all__ = ("get_other_opened_files",)
+
+
+def _compute_pid(path: str) -> int:
+    """
+    We have no way to find the PID of the apps using the opened file.
+    This is a limitation (or a feature) of COM objects.
+    To bypass this, we compute a unique ID for a given path.
+    """
+    if not isinstance(path, bytes):
+        path = path.encode(getdefaultencoding(), errors="ignore")  # type: ignore
+    return crc32(path)
+
+
+def _get_opened_files_adobe_cc(identifier: str) -> Iterator[Items]:
+    """
+    Retrieve documents path of opened files of the given bundle *identifier* (application).
+    Where application is one of the Adobe Creative Suite:
+
+        >>> get_opened_files_via_com("com.adobe.Photoshop")
+        >>> get_opened_files_via_com("com.adobe.Illustrator")
+
+    Complete specs of supported applications:
+        - Illustrator: https://www.adobe.com/devnet/illustrator/scripting.html
+        - Photoshop: https://www.adobe.com/devnet/photoshop/scripting.html
+    """
+    with suppress(Exception):
+        app = SBApplication.applicationWithBundleIdentifier_(identifier)
+        for doc in app.documents():
+            path = doc.filePath().path()
+            yield _compute_pid(path), Path(path)
+
+
+def get_other_opened_files() -> Iterator[Items]:
+    """
+    This is the function that calls other functions specialized in the
+    retrieval of opened files that are not listed in the process list.
+    See autolocker.py::get_opened_files() for those ones.
+    """
+    yield from _get_opened_files_adobe_cc("com.adobe.Photoshop")
+    yield from _get_opened_files_adobe_cc("com.adobe.Illustrator")

--- a/nxdrive/osi/linux/files.py
+++ b/nxdrive/osi/linux/files.py
@@ -1,0 +1,15 @@
+# coding: utf-8
+from typing import Iterator
+
+from ...objects import Items
+
+__all__ = ("get_other_opened_files",)
+
+
+def get_other_opened_files() -> Iterator[Items]:
+    """
+    This is the function that calls other functions specialized in the
+    retrieval of opened files that are not listed in the process list.
+    See autolocker.py::get_opened_files() for those ones.
+    """
+    yield from []

--- a/nxdrive/osi/linux/linux.py
+++ b/nxdrive/osi/linux/linux.py
@@ -1,0 +1,21 @@
+# coding: utf-8
+import subprocess
+from logging import getLogger
+
+from .. import AbstractOSIntegration
+
+__all__ = ("LinuxIntegration",)
+
+log = getLogger(__name__)
+
+
+class LinuxIntegration(AbstractOSIntegration):
+    def open_local_file(self, file_path: str, select: bool = False) -> None:
+        if select:
+            log.info(
+                "The Select/Highlight feature is not yet implemented, please vote "
+                "https://jira.nuxeo.com/browse/NXDRIVE-848 to show your interest"
+            )
+
+        # xdg-open should be supported by recent Gnome, KDE, Xfce
+        subprocess.Popen(["xdg-open", file_path])

--- a/nxdrive/osi/windows/files.py
+++ b/nxdrive/osi/windows/files.py
@@ -1,0 +1,51 @@
+# coding: utf-8
+from binascii import crc32
+from contextlib import suppress
+from pathlib import Path
+from sys import getdefaultencoding
+from typing import Iterator
+
+from win32com.client import GetActiveObject
+
+from ...objects import Items
+
+__all__ = ("get_other_opened_files",)
+
+
+def _compute_pid(path: str) -> int:
+    """
+    We have no way to find the PID of the apps using the opened file.
+    This is a limitation (or a feature) of COM objects.
+    To bypass this, we compute a unique ID for a given path.
+    """
+    if not isinstance(path, bytes):
+        path = path.encode(getdefaultencoding(), errors="ignore")  # type: ignore
+    return crc32(path)
+
+
+def _get_opened_files_adobe_cc(obj: str) -> Iterator[Items]:
+    """
+    Retrieve documents path of opened files of the given *obj* (application).
+    Where application is one of the Adobe Creative Suite:
+
+        >>> get_opened_files_via_com("Illustrator.Application")
+        >>> get_opened_files_via_com("Photoshop.Application")
+
+    Complete specs of supported applications:
+        - Illustrator: https://www.adobe.com/devnet/illustrator/scripting.html
+        - Photoshop: https://www.adobe.com/devnet/photoshop/scripting.html
+    """
+    with suppress(Exception):
+        app = GetActiveObject(obj)
+        for doc in app.Application.Documents:
+            yield _compute_pid(doc.fullName), Path(doc.FullName)
+
+
+def get_other_opened_files() -> Iterator[Items]:
+    """
+    This is the function that calls other functions specialized in the
+    retrieval of opened files that are not listed in the process list.
+    See autolocker.py::get_opened_files() for those ones.
+    """
+    yield from _get_opened_files_adobe_cc("Photoshop.Application")
+    yield from _get_opened_files_adobe_cc("Illustrator.Application")

--- a/nxdrive/osi/windows/windows.py
+++ b/nxdrive/osi/windows/windows.py
@@ -62,6 +62,14 @@ class WindowsIntegration(AbstractOSIntegration):
             for key, value in config.items()
         }
 
+    def open_local_file(self, file_path: str, select: bool = False) -> None:
+        if select:
+            win32api.ShellExecute(
+                None, "open", "explorer.exe", f"/select,{file_path}", None, 1
+            )
+        else:
+            os.startfile(file_path)  # type: ignore
+
     @if_frozen
     def register_contextual_menu(self) -> None:
         log.debug("Registering contextual menu")

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -20,8 +20,9 @@ if TYPE_CHECKING:
 
 __all__ = (
     "PidLockFile",
-    "current_milli_time",
+    "compute_fake_pid_from_path",
     "copy_to_clipboard",
+    "current_milli_time",
     "decrypt",
     "encrypt",
     "find_icon",
@@ -80,6 +81,20 @@ def cmp(a: Any, b: Any) -> int:
     if b is None:
         return 1
     return (a > b) - (a < b)
+
+
+def compute_fake_pid_from_path(path: str) -> int:
+    """
+    We have no way to find the PID of the apps using the opened file.
+    This is a limitation (or a feature) of COM objects and AppleScript.
+    To bypass this, we compute a "unique" ID for a given path.
+    """
+    from binascii import crc32
+    from sys import getdefaultencoding
+
+    if not isinstance(path, bytes):
+        path = path.encode(getdefaultencoding() or "utf-8", errors="ignore")
+    return crc32(path)
 
 
 def copy_to_clipboard(text: str) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ pycryptodomex==3.7.3
 # Ignore pyobjc updates until NXDRIVE-1396 is done
 pyobjc-framework-Cocoa==4.2.2; sys_platform == 'darwin'  # pyup: ignore
 pyobjc-framework-LaunchServices==4.2.2; sys_platform == 'darwin'  # pyup: ignore
+pyobjc-framework-ScriptingBridge==4.2.2; sys_platform == 'darwin'  # pyup: ignore
 pypac==0.12.0
 pypiwin32==223; sys_platform == 'win32'
 # Ignore PyQt5 updates until NXDRIVE-1391 is done

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,23 @@ import pytest
 import nxdrive.utils
 
 
+@pytest.mark.parametrize(
+    "path, pid",
+    [
+        ("/Users/Bob/Documents/Sans%20titre-1.psd", 1868982964),
+        (b"/Users/Bob/Documents/Sans%20titre-1.psd", 1868982964),
+        ("C:\\Users\\Alice\\tests\\test.psd", 3523690320),
+        (r"C:\Users\Alice\tests\test.psd", 3523690320),
+        (br"C:\Users\Alice\tests\test.psd", 3523690320),
+        ("", 0),
+        (b"", 0),
+    ],
+)
+def test_compute_fake_pid_from_path(path, pid):
+    func = nxdrive.utils.compute_fake_pid_from_path
+    assert func(path) == pid
+
+
 def test_encrypt_decrypt():
     enc = nxdrive.utils.encrypt
     dec = nxdrive.utils.decrypt


### PR DESCRIPTION
I splitted changes in several commits. Will do a single commit when merging.

For now, only support for Photoshop and Illustrator as other apps do not expose any API (via COM or AppleScript). And it works pretty well :muscle:

On Windows, we are using COM objects to communicate with an eventual running instance of Photoshop.
And on macOS, we are doing the same but with AppleScript.