### PR TITLE
NXDRIVE-1537: Prompt the user for metrics sharing settings

### DIFF
--- a/docs/changes/4.1.0.md
+++ b/docs/changes/4.1.0.md
@@ -78,6 +78,9 @@ Release date: `2019-xx-xx`
 - Removed `LocalClient.get_children_ref()`
 - Renamed `Manager.nxdrive_home` to `home`
 - Removed `Manager.get()`
+- Removed `Manager.set_tracking()`
+- Removed `QMLDriveApi.get_tracking()`
+- Removed `QMLDriveApi.set_tracking()`
 - Added `WindowsIntegration.addons_installed()`
 - Added `WindowsIntegration.install_addons()`
 - Added `WindowsIntegration.open_local_file()`

--- a/docs/changes/4.1.0.md
+++ b/docs/changes/4.1.0.md
@@ -24,6 +24,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1531](https://jira.nuxeo.com/browse/NXDRIVE-1531): Fix QThread exception on exit
 - [NXDRIVE-1534](https://jira.nuxeo.com/browse/NXDRIVE-1534): Do not consider HTTP timeouts as errors in the Remote Watcher
 - [NXDRIVE-1535](https://jira.nuxeo.com/browse/NXDRIVE-1535): Handle `Unauthorized` errors from Processor
+- [NXDRIVE-1537](https://jira.nuxeo.com/browse/NXDRIVE-1537): Prompt the user for metrics sharing settings
 - [NXDRIVE-1543](https://jira.nuxeo.com/browse/NXDRIVE-1543): Make `LocalClient.exists()` return False on any `OSError`
 
 ## GUI
@@ -84,12 +85,15 @@ Release date: `2019-xx-xx`
 - Added `WindowsIntegration.unwatch_folder()`
 - Added `WindowsIntegration.watch_folder()`
 - Added `Remote.execute()`
+- Added constants.py::`COMPANY`
 - Added engine/dao/sqlite.py::`prepare_args()`
 - Added engine/dao/sqlite.py::`str_to_path()`
 - Added exceptions.py::`Forbidden`
 - Moved autolocker.py::`Item` to objects.py
 - Moved autolocker.py::`Items` to objects.py
 - Removed notifications.py::`FileDeletionError`. Use `LongPathError` instead.
+- Added options.py::`use_analytics`
+- Added options.py::`use_sentry`
 - Added osi/darwin/files.py
 - Added osi/linux
 - Added osi/windows/files.py

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,6 +57,8 @@ Parameter values are taken as is, except for booleans. In that case, you can spe
 | `timeout` | 30 | int | Define the socket timeout.
 | `update-check-delay` | 3600 | int | Define the auto-update check delay. 0 means disabled.
 | `update-site-url` | [URL](https://community.nuxeo.com/static/drive-updates) | str | Configure a custom update website. See Nuxeo Drive Update Site for more details.
+| `use-analytics` | False | bool | Share anonymous usage analytics to help the developers build the best experience for you.
+| `use-sentry` | True | bool | Allow sharing error reports when something unusual happen.
 
 ### Obsolete Parameters
 

--- a/nxdrive/__main__.py
+++ b/nxdrive/__main__.py
@@ -3,9 +3,108 @@
 In this file we cannot use a relative import here, else Drive will not start when packaged.
 See https://github.com/pyinstaller/pyinstaller/issues/2560
 """
+import os
 import sys
 from contextlib import suppress
 from typing import Any, Set
+
+from nxdrive.constants import APP_NAME, COMPANY
+from nxdrive.options import Options
+
+
+STATE_FILE = Options.nxdrive_home / "metrics.state"
+
+
+def show_metrics_acceptance() -> None:
+    """ Display a "friendly" dialog box to ask user for metrics approval. """
+
+    from PyQt5.QtCore import Qt
+    from PyQt5.QtGui import QIcon
+    from PyQt5.QtWidgets import (
+        QApplication,
+        QCheckBox,
+        QDialog,
+        QDialogButtonBox,
+        QLabel,
+        QVBoxLayout,
+    )
+
+    app = QApplication([])
+    app.setQuitOnLastWindowClosed(True)
+
+    dialog = QDialog()
+    dialog.setWindowTitle(f"{APP_NAME} - Improving Together")
+    dialog.setStyleSheet("background-color: #ffffff;")
+    layout = QVBoxLayout()
+
+    with suppress(Exception):
+        from nxdrive.utils import find_icon
+
+        dialog.setWindowIcon(QIcon(str(find_icon("app_icon.svg"))))
+
+    text = (
+        f"At {COMPANY}, we care about your privacy. However, to improve your experience,"
+        " it is crucial to share technical information with the developers, in case we ever need to help you."
+        " <span style='font-weight:bold;'>No sensitive data will ever be shared</span>."
+    )
+    info = QLabel(text)
+    info.setTextFormat(Qt.RichText)
+    info.setWordWrap(True)
+    layout.addWidget(info)
+
+    def analytics_choice(state) -> None:
+        Options.use_analytics = bool(state)
+
+    def errors_choice(state) -> None:
+        Options.use_sentry = bool(state)
+
+    # Checkboxes
+    em_analytics = QCheckBox(
+        "Allow sharing error reports when something unusual happens"
+    )
+    em_analytics.setChecked(True)
+    em_analytics.stateChanged.connect(errors_choice)
+    layout.addWidget(em_analytics)
+
+    cb_analytics = QCheckBox(
+        "Share anonymous usage analytics to help the developers build the best experience for you"
+    )
+    cb_analytics.stateChanged.connect(analytics_choice)
+    layout.addWidget(cb_analytics)
+
+    # Buttons
+    buttons = QDialogButtonBox()
+    buttons.setStandardButtons(QDialogButtonBox.Apply)
+    buttons.clicked.connect(dialog.close)
+    layout.addWidget(buttons)
+    dialog.setLayout(layout)
+    dialog.resize(400, 200)
+    dialog.show()
+    app.exec_()
+
+    states = []
+    if Options.use_analytics:
+        states.append("analytics")
+    if Options.use_sentry:
+        states.append("sentry")
+    STATE_FILE.write_text("\n".join(states))
+
+
+def ask_for_metrics_approval() -> None:
+    """Should we setup and use Sentry and/or Google Analytics?"""
+
+    # Check the user choice first
+    Options.nxdrive_home.mkdir(parents=True, exist_ok=True)
+
+    if STATE_FILE.is_file():
+        lines = STATE_FILE.read_text().splitlines()
+        Options.use_sentry = "sentry" in lines
+        Options.use_analytics = "analytics" in lines
+        # Abort now, the user already decided to use Sentry or not
+        return
+
+    # The user did not choose yet, display a message box
+    show_metrics_acceptance()
 
 
 def before_send(event: Any, hint: Any) -> Any:
@@ -13,6 +112,10 @@ def before_send(event: Any, hint: Any) -> Any:
     Alter an event before sending to the Sentry server.
     The event will not be sent if None is returned.
     """
+
+    # Sentry may have been disabled later, via a CLI argument or GUI parameter
+    if not Options.use_sentry:
+        return None
 
     # Local vars to hide from Sentry reports
     to_redact: Set[str] = {"password", "pwd", "token"}
@@ -37,10 +140,6 @@ def section(header: str, content: str) -> str:
 
 def setup_sentry() -> None:
     """ Setup Sentry. """
-    import os
-
-    if os.getenv("SKIP_SENTRY", "0") == "1":
-        return
 
     # TODO: Replace the testing DSN by "DSN_PLACEHOLDER" that will be replaced at when generating installers.
     sentry_dsn: str = os.getenv(
@@ -92,7 +191,7 @@ def show_critical_error() -> None:
     app.setQuitOnLastWindowClosed(True)
 
     dialog = QDialog()
-    dialog.setWindowTitle("Nuxeo Drive - Fatal error")
+    dialog.setWindowTitle(f"{APP_NAME} - Fatal error")
     dialog.resize(600, 400)
     layout = QVBoxLayout()
     css = "font-family: monospace; font-size: 12px;"
@@ -104,8 +203,8 @@ def show_critical_error() -> None:
         dialog.setWindowIcon(QIcon(find_icon("app_icon.svg")))
 
     # Display a little message to apologize
-    text = """Ooops! Unfortunately, a fatal error occurred and Nuxeo Drive has stopped.
-Please share the following informations with Nuxeo support: we’ll do our best to fix it!
+    text = f"""Ooops! Unfortunately, a fatal error occurred and {APP_NAME} has stopped.
+Please share the following informations with {COMPANY} support: we’ll do our best to fix it!
 """
     info = QLabel(text)
     info.setAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
@@ -188,9 +287,12 @@ def main() -> int:
     """ Entry point. """
 
     if sys.version_info < (3, 6):
-        raise RuntimeError("Nuxeo Drive requires Python 3.6+")
+        raise RuntimeError(f"{APP_NAME} requires Python 3.6+")
 
     try:
+        ask_for_metrics_approval()
+        # Setup Sentry even if the user did not allow it because it can be tweaked
+        # later via the "use-sentry" parameter. It will be useless if Sentry is not installed first.
         setup_sentry()
 
         from nxdrive.commandline import CliHandler

--- a/nxdrive/constants.py
+++ b/nxdrive/constants.py
@@ -8,6 +8,7 @@ WINDOWS = platform == "win32"
 
 BUNDLE_IDENTIFIER = "org.nuxeo.drive"
 APP_NAME = "Nuxeo Drive"
+COMPANY = "Nuxeo"
 
 TIMEOUT = 20
 STARTUP_PAGE_CONNECTION_TIMEOUT = 30

--- a/nxdrive/data/i18n/i18n.json
+++ b/nxdrive/data/i18n/i18n.json
@@ -230,7 +230,6 @@
     "SYNCHRONIZATION_ITEMS_LEFT": "Items to sync: %1",
     "SYSTEM": "System",
     "TECHNICAL_DETAILS": "Technical details:",
-    "TRACKER": "Report anonymous usage statistics",
     "TYPE": "Type",
     "UNAUTHORIZED": "Incorrect credentials",
     "UNAVAILABLE_UPDATE_SITE": "Update site unavailable",

--- a/nxdrive/data/qml/GeneralTab.qml
+++ b/nxdrive/data/qml/GeneralTab.qml
@@ -43,14 +43,6 @@ Rectangle {
         }
 
         NuxeoSwitch {
-            text: qsTr("TRACKER") + tl.tr
-            enabled: isFrozen
-            checked: manager.get_tracking()
-            onClicked: manager.set_tracking(checked)
-            Layout.leftMargin: -5
-        }
-
-        NuxeoSwitch {
             text: qsTr("USE_LIGHT_ICONS") + tl.tr
             checked: manager.use_light_icons()
             onClicked: manager.set_light_icons(checked)

--- a/nxdrive/gui/api.py
+++ b/nxdrive/gui/api.py
@@ -412,14 +412,6 @@ class QMLDriveApi(QObject):
             log.exception("Report error")
             return "[ERROR] " + str(e)
 
-    @pyqtSlot(bool)
-    def set_tracking(self, value: bool) -> None:
-        self._manager.set_tracking(value)
-
-    @pyqtSlot(result=bool)
-    def get_tracking(self) -> bool:
-        return self._manager.get_tracking()
-
     @pyqtSlot(str)
     def open_remote_server(self, uid: str) -> None:
         self.application.hide_systray()

--- a/nxdrive/manager.py
+++ b/nxdrive/manager.py
@@ -463,7 +463,11 @@ class Manager(QObject):
         """
         Avoid sending statistics when testing or if the user does not allow it.
         """
-        return Options.is_frozen and self._dao.get_bool("tracking", default=True)
+        return (
+            Options.is_frozen
+            and Options.use_analytics
+            and self._dao.get_bool("tracking", default=True)
+        )
 
     @pyqtSlot(bool)
     def set_tracking(self, value: bool) -> None:

--- a/nxdrive/manager.py
+++ b/nxdrive/manager.py
@@ -195,7 +195,8 @@ class Manager(QObject):
             "channel": self.get_update_channel(),
             "device_id": self.device_id,
             "tracker_id": self.get_tracker_id(),
-            "tracking": self.get_tracking(),
+            "tracking": Options.use_analytics,
+            "sentry": Options.use_sentry,
             "sip_version": SIP_VERSION_STR,
             "qt_version": QT_VERSION_STR,
             "python_version": platform.python_version(),
@@ -458,25 +459,11 @@ class Manager(QObject):
         if self.updater.enable:
             self.refresh_update_status()
 
-    @pyqtSlot(result=bool)
     def get_tracking(self) -> bool:
         """
         Avoid sending statistics when testing or if the user does not allow it.
         """
-        return (
-            Options.is_frozen
-            and Options.use_analytics
-            and self._dao.get_bool("tracking", default=True)
-        )
-
-    @pyqtSlot(bool)
-    def set_tracking(self, value: bool) -> None:
-        self._dao.store_bool("tracking", value)
-        if value:
-            self._create_tracker()
-        elif self._tracker:
-            self._tracker._thread.quit()
-            self._tracker = None
+        return Options.is_frozen and Options.use_analytics
 
     def get_tracker_id(self) -> str:
         return self._tracker.uid if self._tracker else ""

--- a/nxdrive/options.py
+++ b/nxdrive/options.py
@@ -192,6 +192,8 @@ class MetaOptions(type):
             "https://community.nuxeo.com/static/drive-updates",
             "default",
         ),
+        "use_sentry": (True, "default"),
+        "use_analytics": (False, "default"),
     }
 
     default_options = deepcopy(options)


### PR DESCRIPTION
* NXDRIVE-1537: Prompt the user for metrics sharing settings

Added `Options.use_analytics` and `Options.use_sentry` to control what data we will be able to collect.

The message box will be displayed one time, then preferences will be saved in a ".metrics.state" file next to the executable.

Also introduced a new constant, `COMPANY`, and removed all text mentioning "Nuxeo" or "Drive" in `__main__.py` to ease branding.

* NXDRIVE-1537: Removed the GUI option to control analytics

It is now useless as it is prompted the user to allow/disallow to send analytics at startup, then the preference is saved. The option can still be controlled by the `use-analytics` parameter.

Also added "sentry" to `Manager` metrics.