### PR TITLE
Revert "Update sentry-sdk from 0.7.3 to 0.7.4"

### DIFF
--- a/docs/changes/4.1.0.md
+++ b/docs/changes/4.1.0.md
@@ -73,7 +73,7 @@ Release date: `2019-xx-xx`
 
 - Packaging: Added `pyobjc-framework-ScriptingBridge` 4.2.2
 - Packaging: Added `PyQt5-sip` 4.19.13
-- Packaging: Added `sentry-sdk` 0.7.4
+- Packaging: Added `sentry-sdk` 0.7.3
 - Packaging: Updated `distro` from 1.3.0 to 1.4.0
 - Packaging: Updated `flake8` from 3.6.0 to 3.7.7
 - Packaging: Updated `mypy` from 0.650 to 0.670

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,5 @@ PyQt5-sip==4.19.13
 python-dateutil==2.8.0
 rfc3987==1.3.8
 Send2Trash==1.5.0
-sentry-sdk==0.7.4
+sentry-sdk==0.7.3  # pyup: ignore
 xattr==0.9.6; sys_platform != 'win32'


### PR DESCRIPTION
This reverts commit f379aed8373eed4654f6186e04dd7b3a7708d6b9.

It causes a fatal error on macOS:

    ModuleNotFoundError: No module named 'sentry_sdk.integrations.logging'

Will take time later to investigate, but this is not a priority.