### PR TITLE
Revert "NXDRIVE-1564: Drop support for Nuxeo Platform 7.10"

### DIFF
--- a/docs/changes/4.1.0.md
+++ b/docs/changes/4.1.0.md
@@ -2,8 +2,6 @@
 
 Release date: `2019-xx-xx`
 
-**Important**: Dropped support for Nuxeo Platform 7.10.
-
 ## Core
 
 - [NXDRIVE-1109](https://jira.nuxeo.com/browse/NXDRIVE-1109): Use the pathlib module to handle paths

--- a/docs/support.md
+++ b/docs/support.md
@@ -9,14 +9,13 @@ The **only requirement** is to always have the Nuxeo Drive addon up-to-date.
 
 The current Nuxeo Drive version supports:
 
+- Nuxeo Platform 7.10
 - Nuxeo Platform 8.10
 - Nuxeo Platform 9.10
-- Nuxeo Platform 10.10
 - Nuxeo Platform SNAPSHOT
 
 History:
 
-- `2019-xx-xx` (v4.1.0): dropped support for Nuxeo Platform 7.10
 - `2018-01-29` (v3.0.4): dropped support for Nuxeo Platform 6.10
 
 ## OS

--- a/tools/scripts/check_update_process.py
+++ b/tools/scripts/check_update_process.py
@@ -52,6 +52,7 @@ def create_versions(dst, version):
     Note that we removed the following section with NXDRIVE-1419:
 
     min_all:
+        "7.10": "7.10-HF47"
         "8.10": "8.10-HF38"
         "9.10": "9.10-HF20"
         "10.3": "10.3-SNAPSHOT"
@@ -59,7 +60,7 @@ def create_versions(dst, version):
     """
     yml = f"""
 "{version}":
-    min: "8.10"
+    min: "7.10"
     type: alpha
     checksum:
         algo: sha256

--- a/tools/versions.py
+++ b/tools/versions.py
@@ -89,13 +89,14 @@ def create(version, category):
     Note that we removed the following section with NXDRIVE-1419:
 
     min_all:
+        "7.10": "7.10-HF47"
         "8.10": "8.10-HF38"
         "9.10": "9.10-HF20"
         "10.3": "10.3-SNAPSHOT"
         "10.10": "10.10-SNAPSHOT"
     """
     yml = """{}:
-    min: "8.10"
+    min: "7.10"
     type: {}
     checksum:
         algo: sha256


### PR DESCRIPTION
This reverts commit 28928d39dc5d8b2e4bc4f2dd0b9e5abf58f1c400.

It has been decided to not drop the 7.10 support until we use a missing feature from 7.10 that would effectively break its support.