### PR TITLE
NXDRIVE-1542: Unlock tests parallelization!

### DIFF
--- a/docs/changes/4.1.0.md
+++ b/docs/changes/4.1.0.md
@@ -67,11 +67,13 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1503](https://jira.nuxeo.com/browse/NXDRIVE-1503): Fix `test_collection.py` when it fails early
 - [NXDRIVE-1510](https://jira.nuxeo.com/browse/NXDRIVE-1510): Unskip `test_move_untrash_file_on_parent_with_no_rights()` since [NXP-25066](https://jira.nuxeo.com/browse/NXP-25066) has been resolved sometime ago
 - [NXDRIVE-1536](https://jira.nuxeo.com/browse/NXDRIVE-1536): Use mock'ed objects instead of manual swap
+- [NXDRIVE-1542](https://jira.nuxeo.com/browse/NXDRIVE-1542): Unlock tests parallelization!
 
 ## Minor Changes
 
 - Packaging: Added `pyobjc-framework-ScriptingBridge` 4.2.2
 - Packaging: Added `PyQt5-sip` 4.19.13
+- Packaging: Added `pytest-xdist` 1.26.1
 - Packaging: Added `sentry-sdk` 0.7.3
 - Packaging: Updated `distro` from 1.3.0 to 1.4.0
 - Packaging: Updated `flake8` from 3.6.0 to 3.7.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ appdirs==1.4.3
 dataclasses==0.6
 distro==1.4.0; sys_platform == 'linux'
 https://github.com/GoodRx/universal-analytics-python/archive/77ce628c56de1ba51a9bf0774794fd687f785803.zip
-https://github.com/gorakhargosh/watchdog/archive/11cb8d5ac57f162beb5c0eea13dcabc4dfdb9d63.zip
+https://github.com/gorakhargosh/watchdog/archive/9852970c0535335d2a5ca58062fb02dffc4f9b73.zip
 # nuxeo==2.0.5
 https://github.com/nuxeo/nuxeo-python-client/archive/c8a7a274cb40c6447d929bb4b8460e76b212ff7c.zip
 markdown==3.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,3 +20,8 @@ addopts =
     --failed-first
     --no-print-logs
     -r fE
+    --numprocesses=auto
+    # Print the N slowest tests
+    --durations=20
+    # Print a full stacktrace of all threads after 20 seconds
+    # --faulthandler-timeout=195

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,35 +1,20 @@
-# coding: utf-8
+import logging
 import os
+import os.path
 import shutil
 
-from nxdrive.engine.queue_manager import QueueManager
-from nxdrive.manager import Manager
+import nuxeo.constants
+
+from nxdrive.logging_config import configure
 
 
-# Add Manager and QueueManager features for tests
-def dispose_all(self) -> None:
-    for engine in self.get_engines().values():
-        engine.dispose_db()
-    self.dispose_db()
+# Automatically check all operations done with the Python client
+nuxeo.constants.CHECK_PARAMS = True
 
 
-def unbind_all(self) -> None:
-    if not self._engines:
-        self.load()
-    for engine in self._engine_definitions:
-        self.unbind_engine(engine.uid)
-
-
-def requeue_errors(self) -> None:
-    with self._error_lock:
-        for doc_pair in self._on_error_queue.values():
-            doc_pair.error_next_try = 0
-
-
-def _basename(path):
+def _basename(path: str) -> str:
     """
     Patch shutil._basename for pathlib compatibility.
-
     TODO: remove when https://bugs.python.org/issue32689 is fixed (Python 3.7.3 or newer)
     """
     if isinstance(path, os.PathLike):
@@ -39,10 +24,21 @@ def _basename(path):
     return os.path.basename(path.rstrip(sep))
 
 
-Manager.dispose_all = dispose_all
-Manager.unbind_all = unbind_all
-QueueManager.requeue_errors = requeue_errors
 shutil._basename = _basename
 
-# Remove feature for tests
-Manager._create_server_config_updater = lambda *args: None
+
+def configure_logs():
+    """Configure the logging module."""
+
+    formatter = logging.Formatter(
+        "%(thread)-4d %(module)-14s %(levelname).1s %(message)s"
+    )
+    configure(
+        console_level="TRACE",
+        command_name="test",
+        force_configure=True,
+        formatter=formatter,
+    )
+
+
+configure_logs()

--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -2,12 +2,6 @@
 import os
 from typing import Any
 
-import nuxeo.constants
-
-
-# Automatically check all operations done with the Python client
-nuxeo.constants.CHECK_PARAMS = True
-
 
 def before_send(event: Any, hint: Any) -> Any:
     """
@@ -39,16 +33,14 @@ def setup_sentry() -> None:
     sentry_dsn = os.getenv(
         "SENTRY_DSN", "https://c4daa72433b443b08bd25e0c523ecef5@sentry.io/1372714"
     )
-    if not sentry_dsn:
-        return
 
     import sentry_sdk
-    from nxdrive import __version__ as version
+    from nxdrive import __version__
 
     sentry_sdk.init(
         dsn=sentry_dsn,
-        environment="testing",
-        release=version,
+        environment=os.getenv("SENTRY_ENV", "testing"),
+        release=__version__,
         attach_stacktrace=True,
         before_send=before_send,
     )

--- a/tests/old_functional/local_client_windows.py
+++ b/tests/old_functional/local_client_windows.py
@@ -11,15 +11,17 @@ situation. It cannot be used for a multithreaded apartment (MTA) situation.
 For MTA, you still must use SHFileOperation.
 """
 
+import logging
 import time
 from pathlib import Path
 from typing import Union
 
 from win32com.shell import shell, shellcon
 
-from . import LocalTest, log
+from . import LocalTest
 
 RawPath = Union[Path, str]
+log = logging.getLogger(__name__)
 
 
 class WindowsLocalClient(LocalTest):

--- a/tests/old_functional/test_bulk_remote_changes.py
+++ b/tests/old_functional/test_bulk_remote_changes.py
@@ -31,12 +31,12 @@ from requests import ConnectionError
 
 from nxdrive.client.remote_client import Remote
 from nxdrive.objects import RemoteFileInfo
-from .common import TEST_DEFAULT_DELAY, UnitTestCase
+from .common import TEST_DEFAULT_DELAY, TwoUsersTest
 
 log = getLogger(__name__)
 
 
-class TestBulkRemoteChanges(UnitTestCase):
+class TestBulkRemoteChanges(TwoUsersTest):
     """
     Test Bulk Remote Changes when network error happen in get_children_info()
     will simulate network error when required.  test_many_changes method will

--- a/tests/old_functional/test_collection.py
+++ b/tests/old_functional/test_collection.py
@@ -1,23 +1,27 @@
 # coding: utf-8
 from contextlib import suppress
 
-from .common import UnitTestCase
+import pytest
+
+from .common import OneUserTest
 
 
-class TestCollection(UnitTestCase):
-    def tearDown(self):
-        with suppress(AttributeError):
-            # Happened when the test fails at setUp()
+class TestCollection(OneUserTest):
+    @pytest.fixture(autouse=True)
+    def teardown(self):
+        yield
+
+        with suppress(Exception):
+            # Happened when the test fails at setup_method()
             self.remote_document_client_1.delete(
                 self.collection["uid"], use_trash=False
             )
-        super().tearDown()
 
     def test_collection_synchronization(self):
         remote = self.remote_1
 
         # Remove synchronization root
-        remote.unregister_as_root(self.workspace_1)
+        remote.unregister_as_root(self.workspace)
 
         # Create a document "Fiiile" in a folder "Test"
         folder = self.remote_document_client_1.make_folder("/", "Test")

--- a/tests/old_functional/test_concurrent_synchronization.py
+++ b/tests/old_functional/test_concurrent_synchronization.py
@@ -7,11 +7,11 @@ from .common import (
     OS_STAT_MTIME_RESOLUTION,
     REMOTE_MODIFICATION_TIME_RESOLUTION,
     TEST_DEFAULT_DELAY,
-    UnitTestCase,
+    TwoUsersTest,
 )
 
 
-class TestConcurrentSynchronization(UnitTestCase):
+class TestConcurrentSynchronization(TwoUsersTest):
     def create_docs(self, parent, number, name_pattern=None, delay=1.0):
         return self.root_remote.execute(
             command="NuxeoDrive.CreateTestDocuments",

--- a/tests/old_functional/test_conflicts.py
+++ b/tests/old_functional/test_conflicts.py
@@ -4,15 +4,12 @@ import time
 
 import pytest
 
-from .common import OS_STAT_MTIME_RESOLUTION, UnitTestCase
+from .common import OS_STAT_MTIME_RESOLUTION, SYNC_ROOT_FAC_ID, TwoUsersTest
 
 
-class TestConflicts(UnitTestCase):
+class TestConflicts(TwoUsersTest):
     def setUp(self):
-        super().setUp()
-        self.workspace_id = "defaultSyncRootFolderItemFactory#" "default#{}".format(
-            self.workspace
-        )
+        self.workspace_id = f"{SYNC_ROOT_FAC_ID}{self.workspace}"
         self.file_id = self.remote_1.make_file(
             self.workspace_id, "test.txt", content=b"Some content"
         ).uid
@@ -96,8 +93,7 @@ class TestConflicts(UnitTestCase):
         remote = self.remote_1
 
         self.engine_1.suspend()
-        workspace = "defaultSyncRootFolderItemFactory#default#{}".format(self.workspace)
-        folder = remote.make_folder(workspace, "ABC").uid
+        folder = remote.make_folder(self.workspace_id, "ABC").uid
         self.engine_1.resume()
         self.wait_sync(wait_for_async=True)
 

--- a/tests/old_functional/test_copy.py
+++ b/tests/old_functional/test_copy.py
@@ -1,8 +1,8 @@
 # coding: utf-8
-from .common import UnitTestCase
+from .common import OneUserTest
 
 
-class TestCopy(UnitTestCase):
+class TestCopy(OneUserTest):
     def test_synchronize_remote_copy(self):
         local = self.local_1
         remote = self.remote_document_client_1

--- a/tests/old_functional/test_encoding.py
+++ b/tests/old_functional/test_encoding.py
@@ -3,11 +3,11 @@ import os
 from pathlib import Path
 
 from nxdrive.client.local_client import FileInfo
-from .common import UnitTestCase
+from .common import OneUserTest
 from ..markers import not_mac
 
 
-class TestEncoding(UnitTestCase):
+class TestEncoding(OneUserTest):
     def test_filename_with_accents_from_server(self):
         local = self.local_1
         remote = self.remote_document_client_1

--- a/tests/old_functional/test_ignored.py
+++ b/tests/old_functional/test_ignored.py
@@ -1,8 +1,8 @@
 # coding: utf-8
-from .common import UnitTestCase
+from .common import OneUserTest
 
 
-class TestIgnored(UnitTestCase):
+class TestIgnored(OneUserTest):
     def test_ignore_file(self):
         local = self.local_1
         remote = self.remote_document_client_1

--- a/tests/old_functional/test_local_changes_when_offline.py
+++ b/tests/old_functional/test_local_changes_when_offline.py
@@ -7,7 +7,8 @@ later when Drive becomes online.
 import shutil
 
 from nxdrive.constants import MAC, WINDOWS
-from .common import FILE_CONTENT, UnitTestCase
+
+from .common import FILE_CONTENT, OneUserTest
 
 if WINDOWS:
     from win32com.shell import shell, shellcon
@@ -18,7 +19,7 @@ else:
         import Cocoa
 
 
-class TestOfflineChangesSync(UnitTestCase):
+class TestOfflineChangesSync(OneUserTest):
     """
     All changes made in local PC while drive is offline should sync later when
     drive comes back online.
@@ -39,9 +40,6 @@ class TestOfflineChangesSync(UnitTestCase):
             self.folder1_remote, "File1.txt", FILE_CONTENT
         )
         self.wait_sync(wait_for_async=True)
-
-        # Verify that the folder and file are sync'd (download) successfully
-        assert self.local.exists("/Folder1/File1.txt")
 
     @staticmethod
     def copy_with_xattr(src, dst):

--- a/tests/old_functional/test_local_client.py
+++ b/tests/old_functional/test_local_client.py
@@ -15,8 +15,9 @@ import pytest
 from nxdrive.constants import ROOT, WINDOWS
 from nxdrive.exceptions import DuplicationDisabledError, NotFound
 from . import LocalTest
-from .common import UnitTestCase
+from .common import OneUserTest
 from ..markers import not_linux, windows_only
+from ..utils import random_png
 
 if WINDOWS:
     import win32api
@@ -303,7 +304,7 @@ The final tree must be:
         local = self.local_1
         remote = self.remote_document_client_1
         folder = "l" * 90
-        folders = [self.workspace_1]
+        folders = [self.workspace]
 
         self.engine_1.start()
         self.wait_sync(wait_for_async=True)
@@ -313,7 +314,7 @@ The final tree must be:
             folders.append(remote.make_folder(folders[-1], folder))
 
         # Create a file in it
-        remote.make_file(folders[-1], "stone.png", self.generate_random_png())
+        remote.make_file(folders[-1], "stone.png", random_png())
         picture = "/" + "/".join([folder] * 3) + "/stone.png"
         assert remote.exists(picture)
 
@@ -332,7 +333,7 @@ The final tree must be:
         path = "/" + "/".join([folder] * 3)
         local.make_folder(path, "Par îçi")
         path += "/Par îçi"
-        local.make_file(path, "alive.png", self.generate_random_png())
+        local.make_file(path, "alive.png", random_png())
         picture = path + "/alive.png"
         assert local.exists(picture)
 
@@ -356,7 +357,7 @@ The final tree must be:
         assert child[0].name == "alive.png"
 
 
-class TestLocalClientNative(StubLocalClient, UnitTestCase):
+class TestLocalClientNative(StubLocalClient, OneUserTest):
     """
     Test LocalClient using native Python commands to make FS operations.
     This will simulate Drive actions.
@@ -387,7 +388,7 @@ class TestLocalClientNative(StubLocalClient, UnitTestCase):
         remote = self.remote_document_client_1
 
         # Step 1: remotely create an accentued folder
-        root = remote.make_folder(self.workspace_1, "Projet Hémodialyse")
+        root = remote.make_folder(self.workspace, "Projet Hémodialyse")
         folder = remote.make_folder(root, "Pièces graphiques")
 
         self.wait_sync(wait_for_async=True)
@@ -404,7 +405,7 @@ class TestLocalClientNative(StubLocalClient, UnitTestCase):
 
 
 @not_linux(reason="GNU/Linux uses native LocalClient.")
-class TestLocalClientSimulation(StubLocalClient, UnitTestCase):
+class TestLocalClientSimulation(StubLocalClient, OneUserTest):
     """
     Test LocalClient using OS-specific commands to make FS operations.
     This will simulate user actions on:

--- a/tests/old_functional/test_local_copy_paste.py
+++ b/tests/old_functional/test_local_copy_paste.py
@@ -1,10 +1,10 @@
 # coding: utf-8
 import shutil
 
-from .common import FILE_CONTENT, UnitTestCase
+from .common import FILE_CONTENT, OneUserTest
 
 
-class TestLocalCopyPaste(UnitTestCase):
+class TestLocalCopyPaste(OneUserTest):
 
     NUMBER_OF_LOCAL_TEXT_FILES = 10
     NUMBER_OF_LOCAL_IMAGE_FILES = 10
@@ -19,8 +19,6 @@ class TestLocalCopyPaste(UnitTestCase):
     """
 
     def setUp(self):
-        super().setUp()
-
         remote = self.remote_1
         local = self.local_1
         self.engine_1.start()
@@ -36,7 +34,7 @@ class TestLocalCopyPaste(UnitTestCase):
         # NXDRIVE-477 If created after files are created inside A,
         # creation of B isn't detected wy Watchdog!
         # Reproducible with watchdemo, need to investigate.
-        # That's why we are now using local scan for setUp.
+        # That's why we are now using local scan for setup_method().
         local.make_folder("/", "B")
         self.folder_path_2 = "/B"
 

--- a/tests/old_functional/test_local_creations.py
+++ b/tests/old_functional/test_local_creations.py
@@ -7,10 +7,10 @@ import pytest
 
 from nxdrive.constants import MAC, WINDOWS
 from nuxeo.exceptions import Unauthorized
-from .common import FILE_CONTENT, UnitTestCase
+from .common import FILE_CONTENT, SYNC_ROOT_FAC_ID, OneUserTest
 
 
-class TestLocalCreations(UnitTestCase):
+class TestLocalCreations(OneUserTest):
     def test_invalid_credentials_on_file_upload(self):
         local = self.local_1
         engine = self.engine_1
@@ -35,7 +35,7 @@ class TestLocalCreations(UnitTestCase):
             errors = dao.get_errors()
             assert len(errors) == 1
             assert errors[0].last_error == "INVALID_CREDENTIALS"
-            assert not self.remote_1.get_children_info(self.workspace_1)
+            assert not self.remote_1.get_children_info(self.workspace)
 
         # When the credentials are restored, retrying the sync should work
         errors = dao.get_errors()
@@ -43,7 +43,7 @@ class TestLocalCreations(UnitTestCase):
         self.wait_sync()
 
         assert not dao.get_errors()
-        children = self.remote_1.get_children_info(self.workspace_1)
+        children = self.remote_1.get_children_info(self.workspace)
         assert len(children) == 1
         assert children[0].name == file
         children = local.get_children_info("/")
@@ -144,7 +144,7 @@ class TestLocalCreations(UnitTestCase):
         self.wait_sync()
 
         # Checks
-        children = remote.get_children_info(self.workspace_1)
+        children = remote.get_children_info(self.workspace)
         assert len(children) == 1
         assert children[0].name == folder_upper
         children = local.get_children_info("/")
@@ -181,7 +181,7 @@ class TestLocalCreations(UnitTestCase):
         self.wait_sync()
 
         # Checks
-        children = remote.get_children_info(self.workspace_1)
+        children = remote.get_children_info(self.workspace)
         assert len(children) == 1
         assert children[0].name == filename_upper
         children = local.get_children_info("/")
@@ -255,7 +255,7 @@ class TestLocalCreations(UnitTestCase):
         local = self.local_1
         engine = self.engine_1
 
-        workspace_id = f"defaultSyncRootFolderItemFactory#default#{self.workspace}"
+        workspace_id = f"{SYNC_ROOT_FAC_ID}{self.workspace}"
         name = "東京スカイツリー.jpg"
         filepath = self.location / "resources" / name
         remote.stream_file(workspace_id, filepath)
@@ -276,7 +276,7 @@ class TestLocalCreations(UnitTestCase):
         local = self.local_1
         engine = self.engine_1
 
-        workspace_id = f"defaultSyncRootFolderItemFactory#default#{self.workspace}"
+        workspace_id = f"{SYNC_ROOT_FAC_ID}{self.workspace}"
         name = "こんにちは.jpg"
         filepath = self.location / "resources" / name
         remote.stream_file(workspace_id, filepath)
@@ -298,7 +298,7 @@ class TestLocalCreations(UnitTestCase):
         engine = self.engine_1
         sleep_time = 3
 
-        workspace_id = f"defaultSyncRootFolderItemFactory#default#{self.workspace}"
+        workspace_id = f"{SYNC_ROOT_FAC_ID}{self.workspace}"
         filename = "abc.txt"
         file_id = remote.make_file(workspace_id, filename, content=b"1234").uid
         after_ctime = time.time()
@@ -334,7 +334,7 @@ class TestLocalCreations(UnitTestCase):
         engine = self.engine_1
         sleep_time = 3
 
-        workspace_id = f"defaultSyncRootFolderItemFactory#default#{self.workspace}"
+        workspace_id = f"{SYNC_ROOT_FAC_ID}{self.workspace}"
         name = "東京スカイツリー.jpg"
         filename = self.location / "resources" / name
         file_id = remote.stream_file(workspace_id, filename).uid
@@ -372,7 +372,7 @@ class TestLocalCreations(UnitTestCase):
         engine = self.engine_1
         sleep_time = 3
 
-        workspace_id = f"defaultSyncRootFolderItemFactory#default#{self.workspace}"
+        workspace_id = f"{SYNC_ROOT_FAC_ID}{self.workspace}"
         name = "こんにちは.jpg"
         filename = self.location / "resources" / name
         file_id = remote.stream_file(workspace_id, filename).uid

--- a/tests/old_functional/test_local_deletion.py
+++ b/tests/old_functional/test_local_deletion.py
@@ -5,12 +5,11 @@ import pytest
 
 from nxdrive.constants import WINDOWS
 from nxdrive.options import Options
-from .common import UnitTestCase
+from .common import OneUserTest
 
 
-class TestLocalDeletion(UnitTestCase):
+class TestLocalDeletion(OneUserTest):
     def setUp(self):
-        super().setUp()
         self.engine_1.start()
         self.wait_sync(wait_for_async=True)
 
@@ -114,9 +113,7 @@ class TestLocalDeletion(UnitTestCase):
         self.wait_sync()
 
         # Remove rights
-        folder_path = (
-            "/default-domain/workspaces" "/nuxeo-drive-test-workspace/ToDelete"
-        )
+        folder_path = f"{self.ws.path}/ToDelete"
         input_obj = "doc:" + folder_path
         self.root_remote.execute(
             command="Document.SetACE",
@@ -164,7 +161,7 @@ class TestLocalDeletion(UnitTestCase):
         self.wait_sync()
 
         # Remove rights
-        folder_path = "/default-domain/workspaces" "/nuxeo-drive-test-workspace/ToCopy"
+        folder_path = f"{self.ws.path}/ToCopy"
         input_obj = "doc:" + folder_path
         self.root_remote.execute(
             command="Document.SetACE",

--- a/tests/old_functional/test_local_filter.py
+++ b/tests/old_functional/test_local_filter.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
-from .common import UnitTestCase
+from .common import FS_ITEM_ID_PREFIX, SYNC_ROOT_FAC_ID, OneUserTest
 
 
-class TestLocalFilter(UnitTestCase):
+class TestLocalFilter(OneUserTest):
     def test_synchronize_local_filter(self):
         """Test that filtering remote documents is impacted client side
 
@@ -43,10 +43,9 @@ class TestLocalFilter(UnitTestCase):
         root_path = (
             "/org.nuxeo.drive.service.impl."
             "DefaultTopLevelFolderItemFactory#/"
-            "defaultSyncRootFolderItemFactory#default#"
+            f"{SYNC_ROOT_FAC_ID}{doc.root}"
         )
-        root_path = root_path + doc.root
-        doc_path = root_path + "/defaultFileSystemItemFactory#default#" + doc.uid
+        doc_path = f"{root_path}/{FS_ITEM_ID_PREFIX}{doc.uid}"
 
         self.engine_1.add_filter(doc_path)
         self.wait_sync()
@@ -131,16 +130,9 @@ class TestLocalFilter(UnitTestCase):
         root_path = (
             "/org.nuxeo.drive.service.impl."
             "DefaultTopLevelFolderItemFactory#/"
-            "defaultSyncRootFolderItemFactory#default#"
+            f"{SYNC_ROOT_FAC_ID}{doc.root}"
         )
-        root_path = root_path + doc.root
-        doc_path_filtered = (
-            root_path
-            + "/defaultFileSystemItemFactory#default#"
-            + doc.uid
-            + "/defaultFileSystemItemFactory#default#"
-            + filtered_doc.uid
-        )
+        doc_path_filtered = f"{root_path}/{FS_ITEM_ID_PREFIX}{doc.uid}/{FS_ITEM_ID_PREFIX}{filtered_doc.uid}"
 
         self.engine_1.add_filter(doc_path_filtered)
         self.wait_sync()
@@ -192,10 +184,9 @@ class TestLocalFilter(UnitTestCase):
         root_path = (
             "/org.nuxeo.drive.service.impl."
             "DefaultTopLevelFolderItemFactory#/"
-            "defaultSyncRootFolderItemFactory#default#"
+            f"{SYNC_ROOT_FAC_ID}{doc.root}"
         )
-        root_path = root_path + doc.root
-        doc_path = root_path + "/defaultFileSystemItemFactory#default#" + doc.uid
+        doc_path = f"{root_path}/{FS_ITEM_ID_PREFIX}{doc.uid}"
 
         self.engine_1.add_filter(doc_path)
         self.wait_sync()

--- a/tests/old_functional/test_local_move_and_rename.py
+++ b/tests/old_functional/test_local_move_and_rename.py
@@ -11,24 +11,27 @@ from nuxeo.exceptions import HTTPError
 
 from nxdrive.engine.dao.sqlite import EngineDAO
 from . import DocRemote, LocalTest
-from .common import OS_STAT_MTIME_RESOLUTION, UnitTestCase
+from .common import OS_STAT_MTIME_RESOLUTION, OneUserTest, TwoUsersTest
 
 
 # TODO NXDRIVE-170: refactor
 
 
-class TestLocalMoveAndRename(UnitTestCase):
-    # Sets up the following local hierarchy:
-    # Nuxeo Drive Test Workspace
-    #    |-- Original File 1.txt
-    #    |-- Original File 2.txt
-    #    |-- Original Folder 1
-    #    |       |-- Sub-Folder 1.1
-    #    |       |-- Sub-Folder 1.2
-    #    |       |-- Original File 1.1.txt
-    #    |-- Original Folder 2
-    #    |       |-- Original File 3.txt
+class TestLocalMoveAndRename(OneUserTest):
     def setUp(self):
+        """
+        Sets up the following local hierarchy:
+        Nuxeo Drive Test Workspace
+           |-- Original File 1.txt
+           |-- Original File 2.txt
+           |-- Original Folder 1
+           |       |-- Sub-Folder 1.1
+           |       |-- Sub-Folder 1.2
+           |       |-- Original File 1.1.txt
+           |-- Original Folder 2
+           |       |-- Original File 3.txt
+        """
+
         self.engine_1.start()
         self.wait_sync(wait_for_async=True)
         local = self.local_1
@@ -76,7 +79,7 @@ class TestLocalMoveAndRename(UnitTestCase):
             info = remote.get_info("/New Folder")
             assert info.name == "Renamed Folder"
             assert len(local.get_children_info("/")) == 5
-            assert len(remote.get_children_info(self.workspace_1)) == 5
+            assert len(remote.get_children_info(self.workspace)) == 5
 
     def test_local_rename_file_while_creating(self):
         local = self.engine_1.local
@@ -102,7 +105,7 @@ class TestLocalMoveAndRename(UnitTestCase):
             info = remote.get_info("/File.txt")
             assert info.name == "Renamed File.txt"
             assert len(local.get_children_info("/")) == 5
-            assert len(remote.get_children_info(self.workspace_1)) == 5
+            assert len(remote.get_children_info(self.workspace)) == 5
 
     @pytest.mark.randombug("NXDRIVE-811", condition=True, mode="REPEAT")
     def test_local_rename_file_while_creating_before_marker(self):
@@ -128,7 +131,7 @@ class TestLocalMoveAndRename(UnitTestCase):
             info = remote.get_info("/File.txt")
             assert info.name == "Renamed File.txt"
             assert len(local.get_children_info("/")) == 5
-            assert len(remote.get_children_info(self.workspace_1)) == 5
+            assert len(remote.get_children_info(self.workspace)) == 5
 
     def test_local_rename_file_while_creating_after_marker(self):
         marker = False
@@ -155,7 +158,7 @@ class TestLocalMoveAndRename(UnitTestCase):
             info = remote.get_info("/File.txt")
             assert info.name == "Renamed File.txt"
             assert len(local.get_children_info("/")) == 5
-            assert len(remote.get_children_info(self.workspace_1)) == 5
+            assert len(remote.get_children_info(self.workspace)) == 5
 
     def test_replace_file(self):
         local = self.local_1
@@ -218,7 +221,7 @@ class TestLocalMoveAndRename(UnitTestCase):
         assert len(local.get_children_info("/Original Folder 1")) == 3
         assert len(remote.get_children_info(info_1_1.parent_uid)) == 3
         assert len(local.get_children_info("/")) == 4
-        assert len(remote.get_children_info(self.workspace_1)) == 4
+        assert len(remote.get_children_info(self.workspace)) == 4
 
     def test_local_rename_file_uppercase_stopped(self):
         local = self.local_1
@@ -293,7 +296,7 @@ class TestLocalMoveAndRename(UnitTestCase):
         assert len(local.get_children_info("/Original Folder 1")) == 4
         assert len(remote.get_children_info(info.parent_uid)) == 4
         assert len(local.get_children_info("/")) == 3
-        assert len(remote.get_children_info(self.workspace_1)) == 3
+        assert len(remote.get_children_info(self.workspace)) == 3
 
     def test_local_move_and_rename_file(self):
         local = self.local_1
@@ -319,7 +322,7 @@ class TestLocalMoveAndRename(UnitTestCase):
         assert len(local.get_children_info("/Original Folder 1")) == 4
         assert len(remote.get_children_info(info.parent_uid)) == 4
         assert len(local.get_children_info("/")) == 3
-        assert len(remote.get_children_info(self.workspace_1)) == 3
+        assert len(remote.get_children_info(self.workspace)) == 3
 
     def test_local_rename_folder(self):
         local = self.local_1
@@ -354,7 +357,7 @@ class TestLocalMoveAndRename(UnitTestCase):
         assert len(local.get_children_info("/Renamed Folder 1 \xe9")) == 3
         assert len(remote.get_children_info(file_info.parent_uid)) == 3
         assert len(local.get_children_info("/")) == 4
-        assert len(remote.get_children_info(self.workspace_1)) == 4
+        assert len(remote.get_children_info(self.workspace)) == 4
 
     def test_local_rename_folder_while_suspended(self):
         local = self.local_1
@@ -397,7 +400,7 @@ class TestLocalMoveAndRename(UnitTestCase):
         assert len(local.get_children_info("/Renamed Folder 1 \xe9")) == count
         assert len(remote.get_children_info(folder_1)) == count
         assert len(local.get_children_info("/")) == 4
-        assert len(remote.get_children_info(self.workspace_1)) == 4
+        assert len(remote.get_children_info(self.workspace)) == 4
 
     def test_local_rename_file_after_create(self):
         # Office 2010 and >, create a tmp file with 8 chars
@@ -415,7 +418,7 @@ class TestLocalMoveAndRename(UnitTestCase):
         # Path don't change on Nuxeo
         assert local.get_remote_id("/Renamed File.txt")
         assert len(local.get_children_info("/")) == 5
-        assert len(remote.get_children_info(self.workspace_1)) == 5
+        assert len(remote.get_children_info(self.workspace)) == 5
 
     def test_local_rename_file_after_create_detected(self):
         # MS Office 2010+ creates a tmp file with 8 chars
@@ -447,7 +450,7 @@ class TestLocalMoveAndRename(UnitTestCase):
             # Path doesn't change on Nuxeo
             assert local.get_remote_id("/Renamed File.txt")
             assert len(local.get_children_info("/")) == 5
-            assert len(remote.get_children_info(self.workspace_1)) == 5
+            assert len(remote.get_children_info(self.workspace)) == 5
 
     def test_local_move_folder(self):
         local = self.local_1
@@ -484,7 +487,7 @@ class TestLocalMoveAndRename(UnitTestCase):
         assert len(local.get_children_info("/Original Folder 2/Original Folder 1")) == 3
         assert len(remote.get_children_info(folder_1)) == 3
         assert len(local.get_children_info("/")) == 3
-        assert len(remote.get_children_info(self.workspace_1)) == 3
+        assert len(remote.get_children_info(self.workspace)) == 3
 
     def test_concurrent_local_rename_folder(self):
         local = self.local_1
@@ -529,7 +532,7 @@ class TestLocalMoveAndRename(UnitTestCase):
         assert len(local.get_children_info("/Renamed Folder 2")) == 1
         assert len(remote.get_children_info(folder_2)) == 1
         assert len(local.get_children_info("/")) == 4
-        assert len(remote.get_children_info(self.workspace_1)) == 4
+        assert len(remote.get_children_info(self.workspace)) == 4
 
     def test_local_replace(self):
         local = LocalTest(self.local_test_folder_1)
@@ -590,7 +593,7 @@ class TestLocalMoveAndRename(UnitTestCase):
         folder_1_info = remote.get_info(folder_1_uid)
         assert folder_1_info.name == "Original Folder 1"
         assert folder_1_info.parent_uid == self.workspace
-        assert len(remote.get_children_info(self.workspace_1)) == 4
+        assert len(remote.get_children_info(self.workspace)) == 4
 
     def test_local_move_with_remote_error(self):
         local = self.local_1
@@ -621,14 +624,14 @@ class TestLocalMoveAndRename(UnitTestCase):
         assert len(local.get_children_info("/OSErrorTest")) == 3
         assert len(remote.get_children_info(folder_1.uid)) == 3
         assert len(local.get_children_info("/")) == 4
-        assert len(remote.get_children_info(self.workspace_1)) == 4
+        assert len(remote.get_children_info(self.workspace)) == 4
 
     # TODO: implement me once canDelete is checked in the synchronizer
     # def test_local_move_sync_root_folder(self):
     #    pass
 
 
-class TestLocalMove(UnitTestCase):
+class TestLocalMove(TwoUsersTest):
     def test_nxdrive_1033(self):
         """
 1. Connect Drive in 2 PC's with same account (Drive-01, Drive-02)
@@ -682,22 +685,22 @@ are well taken into account.
         self.wait_sync(wait_for_async=True)
 
         # Create documents
-        files = ["test_file_%d.odt" % i for i in range(1, 21)]
+        files = [f"test_file_{i + 1}.odt" for i in range(20)]
         srcname = "Folder 01"
         folder = local1.make_folder("/", srcname)
-        srcname = "/" + srcname
+        srcname = f"/{srcname}"
         for filename in files:
             local1.make_file(srcname, filename, content=filename.encode("utf-8"))
 
         # Checks
         self.wait_sync(wait_for_async=True, wait_for_engine_2=True)
         for local, filename in product((local1, local2), files):
-            assert local.exists(srcname + "/" + filename)
+            assert local.exists(f"{srcname}/{filename}")
 
         # Step 4
         dstname = "8 78"
         dst = local1.make_folder(srcname, dstname)
-        dstname = "/" + dstname
+        dstname = f"/{dstname}"
         for child in local1.get_children_info(folder):
             if not child.folderish:
                 local1.move(child.path, dst)
@@ -715,12 +718,14 @@ are well taken into account.
             assert not dao.get_filters()
             assert not dao.get_unsynchronizeds()
 
-        for remote, ws in zip(
-            (self.remote_document_client_1, self.remote_document_client_2),
-            (self.workspace_1, self.workspace_2),
-        ):
+        for dao in {self.engine_1.get_dao(), self.engine_2.get_dao()}:
+            assert not dao.get_errors(limit=0)
+            assert not dao.get_filters()
+            assert not dao.get_unsynchronizeds()
+
+        for remote in (self.remote_document_client_1, self.remote_document_client_2):
             # '/'
-            children = remote.get_children_info(ws)
+            children = remote.get_children_info(self.workspace)
             assert len(children) == 1
 
             # srcname

--- a/tests/old_functional/test_local_move_folders.py
+++ b/tests/old_functional/test_local_move_folders.py
@@ -2,10 +2,11 @@
 import shutil
 from pathlib import Path
 
-from .common import UnitTestCase
+from .common import OneUserTest
+from ..utils import random_png
 
 
-class TestLocalMoveFolders(UnitTestCase):
+class TestLocalMoveFolders(OneUserTest):
 
     NUMBER_OF_LOCAL_IMAGE_FILES = 10
 
@@ -31,7 +32,7 @@ class TestLocalMoveFolders(UnitTestCase):
         for path in {self.folder_path_1, self.folder_path_2}:
             for name in names:
                 file_path = local.abspath(path) / name
-                self.generate_random_png(file_path)
+                random_png(file_path)
 
         self.engine_1.start()
         self.wait_sync(timeout=30, wait_win=True)

--- a/tests/old_functional/test_local_paste.py
+++ b/tests/old_functional/test_local_paste.py
@@ -1,17 +1,16 @@
 # coding: utf-8
 import shutil
 import tempfile
-from logging import getLogger
 from pathlib import Path
 
 from nxdrive.utils import normalized_path
-from .common import FILE_CONTENT, UnitTestCase
 
-log = getLogger(__name__)
+from .common import FILE_CONTENT, OneUserTest
+
 TEST_TIMEOUT = 60
 
 
-class TestLocalPaste(UnitTestCase):
+class TestLocalPaste(OneUserTest):
 
     NUMBER_OF_LOCAL_FILES = 25
     TEMP_FOLDER = "temp_folder"
@@ -19,54 +18,43 @@ class TestLocalPaste(UnitTestCase):
     FOLDER_A2 = Path("a2")
     FILENAME_PATTERN = "file%03d.txt"
 
-    """
+    def setUp(self):
+        """
         1. create folder 'temp/a1' with more than 20 files in it
         2. create folder 'temp/a2', empty
         3. copy 'a1' and 'a2', in this order to the test sync root
         4. repeat step 3, but copy 'a2' and 'a1', in this order
-           (to the test sync root)
+        (to the test sync root)
         5. Verify that both folders and their content is sync to DM,
-           in both steps 3 and 4
-    """
+        in both steps 3 and 4
+        """
 
-    def setUp(self):
-        super().setUp()
-
-        log.debug("*** enter TestLocalPaste.setUp()")
-        log.debug("*** engine1 starting")
         self.engine_1.start()
         self.wait_sync(wait_for_async=True)
-        log.debug("*** engine 1 synced")
         local = self.local_1
         assert local.exists("/")
         self.workspace_abspath = local.abspath("/")
 
-        # create  folder a1 and a2 under a temp folder
+        # Create  folder a1 and a2 under a temp folder
         self.local_temp = normalized_path(tempfile.mkdtemp(self.TEMP_FOLDER))
         self.folder1 = self.local_temp / self.FOLDER_A1
         self.folder1.mkdir(parents=True)
         self.folder2 = self.local_temp / self.FOLDER_A2
         self.folder2.mkdir(parents=True)
-        # add files in folder 'temp/a1'
+
+        # Add files in folder 'temp/a1'
         for file_num in range(1, self.NUMBER_OF_LOCAL_FILES + 1):
             filename = self.FILENAME_PATTERN % file_num
             (self.folder1 / filename).write_bytes(FILE_CONTENT)
 
-        log.debug("*** exit TestLocalPaste.setUp()")
-
     def tearDown(self):
-        log.debug("*** enter TestLocalPaste.tearDown()")
-        # delete temp folder
         shutil.rmtree(self.local_temp)
-        super().tearDown()
-        log.debug("*** exit TestLocalPaste.tearDown()")
 
     def test_copy_paste_empty_folder_first(self):
         """
         copy 'a2' to 'Nuxeo Drive Test Workspace',
         then 'a1' to 'Nuxeo Drive Test Workspace'
         """
-        log.debug("*** enter TestLocalPaste" ".test_copy_paste_empty_folder_first()")
         # copy 'temp/a2' under 'Nuxeo Drive Test Workspace'
         shutil.copytree(self.folder2, self.workspace_abspath / self.FOLDER_A2)
         # copy 'temp/a1' under 'Nuxeo Drive Test Workspace'
@@ -74,15 +62,12 @@ class TestLocalPaste(UnitTestCase):
         self.wait_sync(timeout=TEST_TIMEOUT)
 
         self._check_integrity()
-
-        log.debug("*** exit TestLocalPaste" ".test_copy_paste_empty_folder_first()")
 
     def test_copy_paste_empty_folder_last(self):
         """
         copy 'a1' to 'Nuxeo Drive Test Workspace',
         then 'a2' to 'Nuxeo Drive Test Workspace'
         """
-        log.debug("*** enter TestLocalPaste" ".test_copy_paste_empty_folder_last()")
         # copy 'temp/a1' under 'Nuxeo Drive Test Workspace'
         shutil.copytree(self.folder1, self.workspace_abspath / self.FOLDER_A1)
         # copy 'temp/a2' under 'Nuxeo Drive Test Workspace'
@@ -90,8 +75,6 @@ class TestLocalPaste(UnitTestCase):
         self.wait_sync(timeout=TEST_TIMEOUT)
 
         self._check_integrity()
-
-        log.debug("*** exit TestLocalPaste" ".test_copy_paste_empty_folder_last()")
 
     def _check_integrity(self):
         local = self.local_1
@@ -118,7 +101,6 @@ class TestLocalPaste(UnitTestCase):
         assert len(children) == num
 
     def test_copy_paste_same_file(self):
-        log.debug("*** enter TestLocalPaste.test_copy_paste_same_file()")
         local = self.local_1
         remote = self.remote_1
         name = self.FILENAME_PATTERN % 1
@@ -145,10 +127,8 @@ class TestLocalPaste(UnitTestCase):
         assert len(remote_children) == 1
         remote_id = local.get_remote_id(path)
 
-        log.debug("*** copy file TestLocalPaste.test_copy_paste_same_file()")
         shutil.copy2(local.abspath(path), local.abspath(copypath))
         local.set_remote_id(copypath, remote_id)
-        log.debug("*** wait sync TestLocalPaste.test_copy_paste_same_file()")
         self.wait_sync(timeout=TEST_TIMEOUT)
         remote_children = [
             remote_info.name for remote_info in remote.get_fs_children(remote_ref)
@@ -156,4 +136,3 @@ class TestLocalPaste(UnitTestCase):
         assert len(remote_children) == 2
         children = list((self.workspace_abspath / self.FOLDER_A1).iterdir())
         assert len(children) == 2
-        log.debug("*** exit TestLocalPaste.test_copy_paste_same_file()")

--- a/tests/old_functional/test_local_share_move_folders.py
+++ b/tests/old_functional/test_local_share_move_folders.py
@@ -1,13 +1,14 @@
 # coding: utf-8
 import shutil
-
 from unittest.mock import patch
 
 from nxdrive.engine.watcher.remote_watcher import RemoteWatcher
-from .common import UnitTestCase
+
+from .common import TwoUsersTest
+from ..utils import random_png
 
 
-class TestLocalShareMoveFolders(UnitTestCase):
+class TestLocalShareMoveFolders(TwoUsersTest):
 
     NUMBER_OF_LOCAL_IMAGE_FILES = 10
 
@@ -17,6 +18,7 @@ class TestLocalShareMoveFolders(UnitTestCase):
         2. Create folder a2 in Nuxeo Drive Test Workspace sycn root
         3. Add 10 image files in a1
         """
+
         self.engine_1.start()
         self.wait_sync(wait_for_async=True)
         self.engine_1.stop()
@@ -34,7 +36,7 @@ class TestLocalShareMoveFolders(UnitTestCase):
         for file_num in range(1, num + 1):
             file_name = "file%03d.png" % file_num
             file_path = abs_folder_path_1 / file_name
-            self.generate_random_png(file_path)
+            random_png(file_path)
 
         self.engine_1.start()
         self.wait_sync(timeout=60, wait_win=True)

--- a/tests/old_functional/test_local_storage_issue.py
+++ b/tests/old_functional/test_local_storage_issue.py
@@ -3,10 +3,10 @@ import errno
 import os
 from unittest.mock import patch
 
-from .common import UnitTestCase
+from .common import OneUserTest
 
 
-class TestLocalStorageSpaceIssue(UnitTestCase):
+class TestLocalStorageSpaceIssue(OneUserTest):
     def test_local_invalid_timestamp(self):
         # Synchronize root workspace
         self.engine_1.start()
@@ -17,7 +17,7 @@ class TestLocalStorageSpaceIssue(UnitTestCase):
         os.utime(self.local_1.abspath("/Test.txt"), (0, 999999999999999))
         self.engine_1.start()
         self.wait_sync()
-        children = self.remote_document_client_1.get_children_info(self.workspace_1)
+        children = self.remote_document_client_1.get_children_info(self.workspace)
         assert len(children) == 1
         assert children[0].name == "Test.txt"
 

--- a/tests/old_functional/test_long_path.py
+++ b/tests/old_functional/test_long_path.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from nxdrive.constants import WINDOWS
 
-from .common import UnitTestCase
+from .common import OneUserTest
 
 
 # Number of chars in path "C:\...\Nuxeo..." is approx 96 chars
@@ -15,10 +15,8 @@ FOLDER_D = "D" * 50
 FILE = "F" * 255 + ".txt"
 
 
-class TestLongPath(UnitTestCase):
+class TestLongPath(OneUserTest):
     def setUp(self):
-        super().setUp()
-
         self.remote_1 = self.remote_document_client_1
         self.folder_a = self.remote_1.make_folder("/", FOLDER_A)
         self.folder_b = self.remote_1.make_folder(self.folder_a, FOLDER_B)
@@ -27,7 +25,6 @@ class TestLongPath(UnitTestCase):
 
     def tearDown(self):
         self.remote_1.delete(self.folder_a, use_trash=False)
-        super().tearDown()
 
     def test_long_path(self):
         self.engine_1.start()
@@ -75,8 +72,8 @@ class TestLongPath(UnitTestCase):
         self.engine_1 = self.manager_1.bind_server(
             self.local_nxdrive_folder_1,
             self.nuxeo_url,
-            self.user_2,
-            self.password_2,
+            self.user_1,
+            self.password_1,
             start_engine=False,
         )
 
@@ -84,7 +81,7 @@ class TestLongPath(UnitTestCase):
         self.engine_1.stop()
 
 
-class TestLongFileName(UnitTestCase):
+class TestLongFileName(OneUserTest):
     def test_long_file_name(self):
         def error(*_):
             nonlocal received

--- a/tests/old_functional/test_mac_local_client.py
+++ b/tests/old_functional/test_mac_local_client.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from .common import UnitTestCase
+from .common import OneUserTest
 from ..markers import mac_only
 
 try:
@@ -9,7 +9,7 @@ except ImportError:
 
 
 @mac_only
-class TestMacSpecific(UnitTestCase):
+class TestMacSpecific(OneUserTest):
     def test_finder_in_use(self):
         """ Test that if Finder is using the file we postpone the sync. """
 

--- a/tests/old_functional/test_multiple_files.py
+++ b/tests/old_functional/test_multiple_files.py
@@ -5,11 +5,11 @@ from pathlib import Path
 import pytest
 
 from nxdrive.constants import LINUX, MAC
-from .common import UnitTestCase
+from .common import OneUserTest
 from ..markers import not_linux
 
 
-class TestMultipleFiles(UnitTestCase):
+class TestMultipleFiles(OneUserTest):
 
     NUMBER_OF_LOCAL_FILES = 10
     SYNC_TIMEOUT = 20  # in seconds
@@ -20,19 +20,21 @@ class TestMultipleFiles(UnitTestCase):
         2. create folder 'Nuxeo Drive Test Workspace/a2'
         2. create folder 'Nuxeo Drive Test Workspace/a3'
         """
-        super().setUp()
 
         self.engine_1.start()
         self.wait_sync()
         local = self.local_1
-        # create  folder a1
+
+        # Create  folder a1
         self.folder_path_1 = local.make_folder("/", "a1")
-        # add 100 files in folder 'Nuxeo Drive Test Workspace/a1'
+
+        # Add 100 files in folder 'Nuxeo Drive Test Workspace/a1'
         for file_num in range(1, self.NUMBER_OF_LOCAL_FILES + 1):
             local.make_file(
                 self.folder_path_1, "local%04d.txt" % file_num, content=b"content"
             )
-        # create  folder a2
+
+        # Create  folder a2
         self.folder_path_2 = local.make_folder("/", "a2")
         self.folder_path_3 = Path("a3")
         self.wait_sync(wait_for_async=True, timeout=self.SYNC_TIMEOUT)

--- a/tests/old_functional/test_nxdrive_903.py
+++ b/tests/old_functional/test_nxdrive_903.py
@@ -29,10 +29,10 @@ instead of disabling the network card.
 
 import os.path
 
-from .common import UnitTestCase
+from .common import TwoUsersTest
 
 
-class Test(UnitTestCase):
+class Test(TwoUsersTest):
     def test_nxdrive_903(self):
         remote = self.remote_document_client_1
         local_1, local_2 = self.local_1, self.local_2

--- a/tests/old_functional/test_reinit_database.py
+++ b/tests/old_functional/test_reinit_database.py
@@ -3,10 +3,10 @@ import time
 from pathlib import Path
 
 from .common import OS_STAT_MTIME_RESOLUTION
-from .common import UnitTestCase
+from .common import OneUserTest
 
 
-class TestReinitDatabase(UnitTestCase):
+class TestReinitDatabase(OneUserTest):
     def setUp(self):
         self.local = self.local_1
         self.remote = self.remote_document_client_1
@@ -21,7 +21,6 @@ class TestReinitDatabase(UnitTestCase):
         self.engine_1.start()
         self.wait_sync(wait_for_async=True)
 
-        # Verify that everything is synchronized
         assert self.local.exists("/Test folder")
         assert self.local.exists("/Test folder/Test.txt")
 

--- a/tests/old_functional/test_shared_folders.py
+++ b/tests/old_functional/test_shared_folders.py
@@ -2,10 +2,11 @@
 from pathlib import Path
 
 from . import LocalTest
-from .common import TEST_WORKSPACE_PATH, UnitTestCase
+from .common import TwoUsersTest
+from ..utils import random_png
 
 
-class TestSharedFolders(UnitTestCase):
+class TestSharedFolders(TwoUsersTest):
     def test_move_sync_root_child_to_user_workspace(self):
         """See https://jira.nuxeo.com/browse/NXP-14870"""
         uid = None
@@ -89,7 +90,7 @@ class TestSharedFolders(UnitTestCase):
         remote_1.unregister_as_root(self.workspace)
 
         # Remove ReadWrite permission for user_1 on the test workspace
-        test_workspace = "doc:" + TEST_WORKSPACE_PATH
+        test_workspace = f"doc:{self.ws.path}"
         self.root_remote.execute(
             command="Document.SetACE",
             input_obj=test_workspace,
@@ -101,7 +102,7 @@ class TestSharedFolders(UnitTestCase):
         # Create initial folders and files as user_2
         folder = remote_2.make_folder("/", "Folder01")
         subfolder_1 = remote_2.make_folder(folder, "SubFolder01")
-        remote_2.make_file(subfolder_1, "Image01.png", self.generate_random_png())
+        remote_2.make_file(subfolder_1, "Image01.png", random_png())
         file_id = remote_2.make_file(folder, "File01.txt", content=b"plaintext")
 
         # Grant Read permission for user_1 on the test folder and register
@@ -201,7 +202,7 @@ class TestSharedFolders(UnitTestCase):
 
         # Create initial folder and file
         folder = remote.make_folder("/", "Final")
-        remote.make_file("/Final", "Aerial04.png", self.generate_random_png())
+        remote.make_file("/Final", "Aerial04.png", random_png())
 
         # First checks, everything should be online for every one
         self.wait_sync(wait_for_async=True)
@@ -219,7 +220,7 @@ class TestSharedFolders(UnitTestCase):
 
         # Make changes
         folder_conflicted = local.make_folder("/", "Finished")
-        local.make_file(folder_conflicted, "Aerial04.png", self.generate_random_png())
+        local.make_file(folder_conflicted, "Aerial04.png", random_png())
         remote.update(folder, properties={"dc:title": "Finished"})
 
         # Restart clients and wait

--- a/tests/old_functional/test_special_characters.py
+++ b/tests/old_functional/test_special_characters.py
@@ -1,11 +1,11 @@
 # coding: utf-8
 from nxdrive.constants import WINDOWS
 
-from .common import UnitTestCase
+from .common import OneUserTest
 from ..markers import not_windows
 
 
-class TestSpecialCharacters(UnitTestCase):
+class TestSpecialCharacters(OneUserTest):
     @not_windows(reason="Explorer prevents using those characters")
     def test_create_local(self):
         local = self.local_1

--- a/tests/old_functional/test_sync_roots.py
+++ b/tests/old_functional/test_sync_roots.py
@@ -1,8 +1,8 @@
 # coding: utf-8
-from .common import UnitTestCase
+from .common import OneUserTest
 
 
-class TestSyncRoots(UnitTestCase):
+class TestSyncRoots(OneUserTest):
     def test_register_sync_root_parent(self):
         remote = self.remote_document_client_1
         local = self.local_root_client_1
@@ -12,13 +12,13 @@ class TestSyncRoots(UnitTestCase):
 
         # Create a child folder and register it as a synchronization root
         child = remote.make_folder(self.workspace, "child")
-        remote.make_file(child, "aFile.txt", "My content")
+        remote.make_file(child, "aFile.txt", content=b"My content")
         remote.register_as_root(child)
 
         # Start engine and wait for synchronization
         self.engine_1.start()
         self.wait_sync(wait_for_async=True)
-        assert not local.exists("/Nuxeo Drive Test Workspace")
+        assert not local.exists(f"/{self.workspace_title}")
         assert local.exists("/child")
         assert local.exists("/child/aFile.txt")
 
@@ -28,6 +28,6 @@ class TestSyncRoots(UnitTestCase):
         # Start engine and wait for synchronization
         self.wait_sync(wait_for_async=True)
         assert not local.exists("/child")
-        assert local.exists("/Nuxeo Drive Test Workspace")
-        assert local.exists("/Nuxeo Drive Test Workspace/child")
-        assert local.exists("/Nuxeo Drive Test Workspace/child/aFile.txt")
+        assert local.exists(f"/{self.workspace_title}")
+        assert local.exists(f"/{self.workspace_title}/child")
+        assert local.exists(f"/{self.workspace_title}/child/aFile.txt")

--- a/tests/old_functional/test_synchronization_dedup.py
+++ b/tests/old_functional/test_synchronization_dedup.py
@@ -4,10 +4,10 @@ Test behaviors when the server allows duplicates and not the client.
 """
 from pathlib import Path
 
-from .common import UnitTestCase
+from .common import OneUserTest
 
 
-class TestSynchronizationDedup(UnitTestCase):
+class TestSynchronizationDedup(OneUserTest):
     def test_children_of_folder_in_dedup_error(self):
         """
         NXDRIVE-1037: Children of a folder that is in DEDUP error should be
@@ -20,12 +20,12 @@ class TestSynchronizationDedup(UnitTestCase):
         engine.start()
 
         # Step 1: create Unisys folder (1st)
-        remote.make_folder(self.workspace_1, "Unisys")
+        remote.make_folder(self.workspace, "Unisys")
         self.wait_sync(wait_for_async=True)
         assert local.exists("/Unisys")
 
         # Step 2: create Unisys folder (2nd)
-        unisys2 = remote.make_folder(self.workspace_1, "Unisys")
+        unisys2 = remote.make_folder(self.workspace, "Unisys")
         self.wait_sync(wait_for_async=True)
 
         # Check DEDUP error
@@ -48,7 +48,7 @@ class TestSynchronizationDedup(UnitTestCase):
         assert not engine.get_dao().get_syncing_count()
 
 
-class TestSynchronizationDedupCaseSensitive(UnitTestCase):
+class TestSynchronizationDedupCaseSensitive(OneUserTest):
     def test_file_sync_under_dedup_shared_folders_rename_dupe_remotely(self):
         """ NXDRIVE-842: do not sync duplicate conflicted folder content. """
 

--- a/tests/old_functional/test_synchronization_suspend.py
+++ b/tests/old_functional/test_synchronization_suspend.py
@@ -1,10 +1,10 @@
 # coding: utf-8
 
 from nxdrive.constants import WINDOWS
-from .common import UnitTestCase
+from .common import OneUserTest
 
 
-class TestSynchronizationSuspend(UnitTestCase):
+class TestSynchronizationSuspend(OneUserTest):
     def test_basic_synchronization_suspend(self):
         local = self.local_1
         remote = self.remote_document_client_1
@@ -25,7 +25,7 @@ class TestSynchronizationSuspend(UnitTestCase):
         local.make_folder("/", "Folder 4")
         local.make_file("/Folder 4", "Test.txt", content=b"Plop")
         self.wait_sync(wait_for_async=True, fail_if_timeout=False)
-        assert len(remote.get_children_info(self.workspace_1)) == 4
+        assert len(remote.get_children_info(self.workspace)) == 4
         assert self.engine_1.get_queue_manager().is_paused()
 
     def test_synchronization_local_watcher_paused_when_offline(self):
@@ -59,7 +59,7 @@ class TestSynchronizationSuspend(UnitTestCase):
         self.wait_sync(fail_if_timeout=False)
 
         # Checks
-        assert len(remote.get_children_info(self.workspace_1)) == 1
+        assert len(remote.get_children_info(self.workspace)) == 1
         assert engine.get_queue_manager().is_paused()
 
         # Restore network connection
@@ -67,7 +67,7 @@ class TestSynchronizationSuspend(UnitTestCase):
 
         # Wait for sync and check synced files
         self.wait_sync(wait_for_async=True)
-        assert len(remote.get_children_info(self.workspace_1)) == 2
+        assert len(remote.get_children_info(self.workspace)) == 2
         assert not engine.get_queue_manager().is_paused()
 
     def test_synchronization_end_with_children_ignore_parent(self):
@@ -94,4 +94,4 @@ class TestSynchronizationSuspend(UnitTestCase):
         local.make_file("/.hidden/normal", "Test.txt", content=b"Plop")
         # Should not try to sync therefor it should not timeout
         self.wait_sync(wait_for_async=True)
-        assert len(remote.get_children_info(self.workspace_1)) == 4
+        assert len(remote.get_children_info(self.workspace)) == 4

--- a/tests/old_functional/test_versioning.py
+++ b/tests/old_functional/test_versioning.py
@@ -1,40 +1,10 @@
 # coding: utf-8
 import time
 
-from .common import OS_STAT_MTIME_RESOLUTION, TEST_WORKSPACE_PATH, UnitTestCase
+from .common import OS_STAT_MTIME_RESOLUTION, OneUserTest, TwoUsersTest
 
 
-class TestVersioning(UnitTestCase):
-    def test_versioning(self):
-        local = self.local_1
-        self.engine_1.start()
-        remote = self.remote_document_client_2
-
-        # Create a file as user 2
-        remote.make_file("/", "Test versioning.txt", content=b"This is version 0")
-        assert remote.exists("/Test versioning.txt")
-        doc = self.root_remote.fetch(TEST_WORKSPACE_PATH + "/Test versioning.txt")
-        self._assert_version(doc, 0, 0)
-
-        # Synchronize it for user 1
-        self.wait_sync(wait_for_async=True)
-        assert local.exists("/Test versioning.txt")
-
-        # Update it as user 1 => should be versioned
-        time.sleep(OS_STAT_MTIME_RESOLUTION)
-        local.update_content("/Test versioning.txt", b"Modified content")
-        self.wait_sync()
-        doc = self.root_remote.fetch(TEST_WORKSPACE_PATH + "/Test versioning.txt")
-        self._assert_version(doc, 0, 1)
-
-        # Update it as user 1 => should NOT be versioned
-        # since the versioning delay is not passed by
-        time.sleep(OS_STAT_MTIME_RESOLUTION)
-        local.update_content("/Test versioning.txt", b"Content twice modified")
-        self.wait_sync()
-        doc = self.root_remote.fetch(TEST_WORKSPACE_PATH + "/Test versioning.txt")
-        self._assert_version(doc, 0, 1)
-
+class TestVersioning(OneUserTest):
     def test_version_restore(self):
         remote = self.remote_document_client_1
         local = self.local_1
@@ -58,6 +28,38 @@ class TestVersioning(UnitTestCase):
         remote.restore_version(version_uid)
         self.wait_sync(wait_for_async=True)
         assert local.get_content("/Document to restore.txt") == b"Initial content."
+
+
+class TestVersioning2(TwoUsersTest):
+    def test_versioning(self):
+        local = self.local_1
+        self.engine_1.start()
+        remote = self.remote_document_client_2
+
+        # Create a file as user 2
+        remote.make_file("/", "Test versioning.txt", content=b"This is version 0")
+        assert remote.exists("/Test versioning.txt")
+        doc = self.root_remote.fetch(f"{self.ws.path}/Test versioning.txt")
+        self._assert_version(doc, 0, 0)
+
+        # Synchronize it for user 1
+        self.wait_sync(wait_for_async=True)
+        assert local.exists("/Test versioning.txt")
+
+        # Update it as user 1 => should be versioned
+        time.sleep(OS_STAT_MTIME_RESOLUTION)
+        local.update_content("/Test versioning.txt", b"Modified content")
+        self.wait_sync()
+        doc = self.root_remote.fetch(f"{self.ws.path}/Test versioning.txt")
+        self._assert_version(doc, 0, 1)
+
+        # Update it as user 1 => should NOT be versioned
+        # since the versioning delay is not passed by
+        time.sleep(OS_STAT_MTIME_RESOLUTION)
+        local.update_content("/Test versioning.txt", b"Content twice modified")
+        self.wait_sync()
+        doc = self.root_remote.fetch(f"{self.ws.path}/Test versioning.txt")
+        self._assert_version(doc, 0, 1)
 
     def _assert_version(self, doc, major, minor):
         assert doc["properties"]["uid:major_version"] == major

--- a/tests/old_functional/test_volume.py
+++ b/tests/old_functional/test_volume.py
@@ -10,7 +10,8 @@ import pytest
 
 from nxdrive.constants import ROOT
 
-from .common import TEST_WORKSPACE_PATH, UnitTestCase
+from .common import OneUserTest
+from ..utils import random_png
 
 log = getLogger(__name__)
 
@@ -19,7 +20,7 @@ log = getLogger(__name__)
     "TEST_VOLUME" not in os.environ,
     reason="Deactivate if not launched on purpose with TEST_VOLUME set",
 )
-class VolumeTestCase(UnitTestCase):
+class VolumeTestCase(OneUserTest):
 
     NUMBER_OF_LOCAL_FILES = 10
     SYNC_TIMEOUT = 100  # in seconds
@@ -48,7 +49,7 @@ class VolumeTestCase(UnitTestCase):
                 folderobj["childs"][filename]["name"] = filename
                 if not self.fake:
                     file_path = os.path.join(abspath, filename)
-                    self.generate_random_png(file_path)
+                    random_png(file_path)
                 self.items += 1
 
     def create(self, stopped=True, wait_for_sync=True):
@@ -275,7 +276,7 @@ class VolumeTestCase(UnitTestCase):
     def test_remote_scan(self):
         nb_nodes = int(os.environ.get("TEST_REMOTE_SCAN_VOLUME", 20))
         # Random mass import
-        self.root_remote.mass_import(TEST_WORKSPACE_PATH, nb_nodes)
+        self.root_remote.mass_import(self.ws.path, nb_nodes)
         # Wait for ES indexing
         self.root_remote.wait_for_async_and_es_indexing()
         # Synchronize

--- a/tests/unit/test_proxy.py
+++ b/tests/unit/test_proxy.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-from contextlib import suppress
 from unittest.mock import patch
 from pathlib import Path
 
@@ -43,8 +42,8 @@ def config_dao():
 
 
 @pytest.fixture
-def pac_file(js):
-    pac = Path("proxy.pac")
+def pac_file(tmp_path, js):
+    pac = tmp_path / "proxy.pac"
     pac.write_text(js)
 
     uri = pac.resolve().as_uri()
@@ -53,8 +52,7 @@ def pac_file(js):
 
     yield uri
 
-    with suppress(Exception):
-        pac.unlink()
+    pac.unlink()
 
 
 def test_manual_proxy():
@@ -93,7 +91,7 @@ def test_mock_autoconfigurl_windows(pac_file):
     with _patch_winreg_qve(return_value=(pac_file, "foo")):
         proxy = get_proxy(category="Automatic")
         assert isinstance(proxy, AutomaticProxy)
-        assert proxy._pac_file
+        assert proxy._pac_file is not None
         settings = proxy.settings("http://nuxeo.com")
         assert settings["http"] == settings["https"] == "http://localhost:8899"
         settings = proxy.settings("http://example.com")

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -31,4 +31,3 @@ def test_logs(tmp):
         path_managed = manager.generate_report()
         assert path_managed.is_file()
         assert path_managed.suffix == ".zip"
-        assert path == path_managed

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,84 @@
+import os
+import random
+import shutil
+import struct
+import zlib
+from pathlib import Path
+from time import sleep
+from typing import Union
+
+from nxdrive.utils import normalized_path, safe_long_path, unset_path_readonly
+
+
+def clean_dir(_dir: Path, retry: int = 1, max_retries: int = 5) -> None:
+    _dir = safe_long_path(_dir)
+    if not _dir.exists():
+        return
+
+    test_data = os.environ.get("TEST_SAVE_DATA")
+    if test_data:
+        shutil.move(_dir, test_data)
+        return
+
+    try:
+        for path, folders, filenames in os.walk(_dir):
+            dirpath = normalized_path(path)
+            for folder in folders:
+                unset_path_readonly(dirpath / folder)
+            for filename in filenames:
+                unset_path_readonly(dirpath / filename)
+        shutil.rmtree(_dir)
+    except Exception:
+        if retry < max_retries:
+            sleep(2)
+            clean_dir(_dir, retry=retry + 1)
+
+
+def random_png(filename: Path = None, size: int = 0) -> Union[None, bytes]:
+    """ Generate a random PNG file.
+
+    :param filename: The output file name. If None, returns
+            the picture content.
+    :param size: The number of black pixels of the picture.
+    :return: None if given filename else bytes
+    """
+
+    if not size:
+        size = random.randint(1, 42)
+    else:
+        size = max(1, size)
+
+    pack = struct.pack
+
+    def chunk(header, data):
+        return (
+            pack(">I", len(data))
+            + header
+            + data
+            + pack(">I", zlib.crc32(header + data) & 0xFFFFFFFF)
+        )
+
+    magic = pack(">8B", 137, 80, 78, 71, 13, 10, 26, 10)
+    png_filter = pack(">B", 0)
+    scanline = pack(">{}B".format(size * 3), *[0] * (size * 3))
+    content = [png_filter + scanline for _ in range(size)]
+    png = (
+        magic
+        + chunk(b"IHDR", pack(">2I5B", size, size, 8, 2, 0, 0, 0))
+        + chunk(b"IDAT", zlib.compress(b"".join(content)))
+        + chunk(b"IEND", b"")
+    )
+
+    if not filename:
+        return png
+
+    filename.write_bytes(png)
+
+
+def salt(text: str, prefix: str = "ndt-", with_suffix: bool = True) -> str:
+    """
+    Add some salt to the given text to ensure no collisions.
+    To use for workspace titles, usernames, groups names ...
+    """
+    suffix = random.randint(1, 99999) if with_suffix else ""
+    return f"{prefix}{text}{suffix}"

--- a/tools/posix/deploy_jenkins_slave.sh
+++ b/tools/posix/deploy_jenkins_slave.sh
@@ -176,13 +176,13 @@ launch_tests() {
     # ${PYTHON} -b -Wall -m pytest "${SPECIFIC_TEST}"
 
     echo ">>> Launching unit tests"
-    ${PYTHON} -b -Wall -m pytest -n 4 tests/unit
+    ${PYTHON} -b -Wall -m pytest tests/unit
 
     echo ">>> Launching functional tests"
-    ${PYTHON} -b -Wall -m pytest -n 4 tests/functional
+    ${PYTHON} -b -Wall -m pytest tests/functional
 
     echo ">>> Launching old functional tests"
-    ${PYTHON} -b -Wall -m pytest -v tests/old_functional
+    ${PYTHON} -b -Wall -m pytest tests/old_functional
 
     # echo ">>> Launching integration tests"
     # ${PYTHON} -b -Wall -m pytest tests/integration

--- a/tools/windows/deploy_jenkins_slave.ps1
+++ b/tools/windows/deploy_jenkins_slave.ps1
@@ -239,19 +239,19 @@ function launch_tests {
 	# }
 
 	Write-Output ">>> Launching unit tests"
-	& $Env:STORAGE_DIR\Scripts\python.exe $global:PYTHON_OPT -b -Wall -m pytest -n 4 "tests\\unit"
+	& $Env:STORAGE_DIR\Scripts\python.exe $global:PYTHON_OPT -b -Wall -m pytest "tests\\unit"
 	if ($lastExitCode -ne 0) {
 		ExitWithCode $lastExitCode
 	}
 
 	Write-Output ">>> Launching functional tests"
-	& $Env:STORAGE_DIR\Scripts\python.exe $global:PYTHON_OPT -b -Wall -m pytest -n 4 "tests\\functional"
+	& $Env:STORAGE_DIR\Scripts\python.exe $global:PYTHON_OPT -b -Wall -m pytest "tests\\functional"
 	if ($lastExitCode -ne 0) {
 		ExitWithCode $lastExitCode
 	}
 
 	Write-Output ">>> Launching old functional tests"
-	& $Env:STORAGE_DIR\Scripts\python.exe $global:PYTHON_OPT -b -Wall -m pytest -v "tests\\old_functional"
+	& $Env:STORAGE_DIR\Scripts\python.exe $global:PYTHON_OPT -b -Wall -m pytest "tests\\old_functional"
 	if ($lastExitCode -ne 0) {
 		ExitWithCode $lastExitCode
 	}


### PR DESCRIPTION
Also minor clean-up:

* Refactoring of `UnitTestCase.wait*()`.
* Use the `wait_win` argument of `UnitTestCase.wait_sync()` instead of sleeping manually.
* Renamed `UnitTestCase` to `TwoUsersTest`.
* Added `OneUserTest` class.
* Move some functions into `test/utils.py`.
* Removed useless `self.worspace_title_*` and `self.workspace_*` attributes.

To add a custom setup or teardown to a class, you _must_ use unittest style. In other words, use `setUp()` and `tearDown()`.

In rare cases, like in `test_direct_edit.py`, you have to use a pytest fixture. I do not know exactly why but it works for now.

---

Running the whole test suite will output something like:
```shell
    PYTHON_DRIVE_VERSION = 3.6.7
    WORKSPACE            = /home/tiger-222/projects
    WORKSPACE_DRIVE      = /home/tiger-222/projects/nuxeo-drive
    STORAGE_DIR          = /home/tiger-222/projects/deploy-dir
>>> [pyenv] Initializing
>>> [pyenv] Using Python 3.6.7
>>> Verifying Python version in use
>>> Checking Python code: import sqlite3 ... OK.
>>> Checking the style
>>> Checking type annotations

>>> Launching unit tests
============================= test session starts ==============================
platform linux -- Python 3.6.7, pytest-4.3.0, py-1.7.0, pluggy-0.8.0
rootdir: /home/tiger-222/projects/nuxeo-drive, inifile: setup.cfg
plugins: xdist-1.26.1, timeout-1.3.3, forked-1.0.1, cov-2.6.1
gw0 I / gw1 I / gw2 I / gw3 I / gw4 I / gw5 I / gw6 I / gw7 I
gw0 [278] / gw1 [278] / gw2 [278] / gw3 [278] / gw4 [278] / gw5 [278] / gw6 [278] / gw7 [278]

ss.s.........................s....s..s.................................. [ 25%]
.......................................s.s....s......................... [ 51%]
..............................................................s..ss..... [ 77%]
...............................sss.sss........................           [100%]
=================== 260 passed, 18 skipped in 16.50 seconds ====================

>>> Launching functional tests
============================= test session starts ==============================
platform linux -- Python 3.6.7, pytest-4.3.0, py-1.7.0, pluggy-0.8.0
rootdir: /home/tiger-222/projects/nuxeo-drive, inifile: setup.cfg
plugins: xdist-1.26.1, timeout-1.3.3, forked-1.0.1, cov-2.6.1
gw0 I / gw1 I / gw2 I / gw3 I / gw4 I / gw5 I / gw6 I / gw7 I
gw0 [5] / gw1 [5] / gw2 [5] / gw3 [5] / gw4 [5] / gw5 [5] / gw6 [5] / gw7 [5]

s....                                                                    [100%]
===================== 4 passed, 1 skipped in 2.45 seconds ======================

>>> Launching old functional tests
============================= test session starts ==============================
platform linux -- Python 3.6.7, pytest-4.3.0, py-1.7.0, pluggy-0.8.0
rootdir: /home/tiger-222/projects/nuxeo-drive, inifile: setup.cfg
plugins: xdist-1.26.1, timeout-1.3.3, forked-1.0.1, cov-2.6.1
gw0 I / gw1 I / gw2 I / gw3 I / gw4 I / gw5 I / gw6 I / gw7 I
gw0 [290] / gw1 [290] / gw2 [290] / gw3 [290] / gw4 [290] / gw5 [290] / gw6 [290] / gw7 [290]

..s.....s........................................sssssssssssss.......... [ 23%]
sxs...........................F........sFF.F.FF.FFFFFF..sF.FsFF.FFFFFFFF [ 47%]
FRR.FFFF..R.F....FF..F.R.FRRF..sR.RFFR.R.s.sRR.RR.R.R....RF.R.E...R.R... [ 63%]
......s....s..................s...F..............................ss...ss [ 88%]
.....ssss..s...........
=========================== short test summary info ============================
 39 failed, 215 passed, 35 skipped, 1 xfailed, 1 error, 20 repeated in 976.89 seconds 
```

But those 39 errors are random and caused by the server that cannot handle soo many connections.
I then ran every failures manually and the whole class containing test methods and everything work well, eg:
- `tests/old_functional/test_synchronization.py::TestSynchronization::test_synchronize_special_filenames`
- `tests/old_functional/test_synchronization.py`

So I think it is safe to merge and I will handle sever customization after.

To summarize: using 8 cores, tests are running in **00:17:00** (for between 01:20:20 and 3:00:00 before).