### PR TITLE
NXDRIVE-1542: Little improvements

### DIFF
--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -4,6 +4,7 @@ from contextlib import suppress
 
 import pytest
 import requests
+from sentry_sdk import configure_scope
 
 from nxdrive.options import Options
 
@@ -127,7 +128,9 @@ def test_error():
     with pytest.raises(RuntimeError):
         Options.set("no key", 42)
 
-    Options.set("no key", 42, fail_on_error=False)
+    with configure_scope() as scope:
+        scope._should_capture = False
+        Options.set("no key", 42, fail_on_error=False)
 
     with pytest.raises(TypeError) as err:
         Options.set("delay", "foo")


### PR DESCRIPTION
* Do not trigger a Sentry event in `test_options.py`::`test_error`.
* Ensure the tested method is sent to Sentry to ease debugging.