### PR TITLE
NXDRIVE-1552: Pre-release 4.1.0 fixes

### DIFF
--- a/nxdrive/commandline.py
+++ b/nxdrive/commandline.py
@@ -113,7 +113,7 @@ class CliHandler:
 
         common_parser.add_argument(
             "--channel",
-            default=None,
+            default="release",
             choices=("alpha", "beta", "release"),
             help="Update channel",
         )

--- a/nxdrive/manager.py
+++ b/nxdrive/manager.py
@@ -125,10 +125,14 @@ class Manager(QObject):
             beta = self.get_config("beta_channel")
             if beta is not None:
                 if beta:
-                    Options.set("channel", "beta", setter="manual")
+                    Options.set("channel", "beta", setter="local")
+                else:
+                    Options.set("channel", "release", setter="local")
                 self._dao.delete_config("beta_channel")
-            else:
-                Options.set("channel", self.get_update_channel(), setter="manual")
+
+            Options.set("channel", self.get_update_channel(), setter="local")
+            if self.get_config("channel") != Options.channel:
+                self.set_config("channel", Options.channel)
 
             # Keep a trace of installed versions
             if not self.get_config("original_version"):

--- a/nxdrive/options.py
+++ b/nxdrive/options.py
@@ -153,7 +153,7 @@ class MetaOptions(type):
     options: Dict[str, Tuple[Any, str]] = {
         "browser_startup_page": ("drive_browser_login.jsp", "default"),
         "ca_bundle": (None, "default"),
-        "channel": (None, "default"),
+        "channel": ("release", "default"),
         "debug": (False, "default"),
         "debug_pydev": (False, "default"),
         "delay": (30, "default"),

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -157,6 +157,31 @@ def test_error():
 
 
 @Options.mock()
+def test_list_conversion_and_original_values_updated():
+    assert isinstance(Options.ignored_suffixes, tuple)
+    assert "azerty" not in Options.ignored_suffixes
+    current_len = len(Options.ignored_suffixes)
+
+    Options.set("ignored_suffixes", ["azerty"], setter="manual")
+    assert isinstance(Options.ignored_suffixes, tuple)
+    assert "azerty" in Options.ignored_suffixes
+    assert len(Options.ignored_suffixes) == current_len + 1
+
+    new_values = {
+        "ignored_files": ["bim", "bam", "boom", "zzzzzzzzzz"],
+        "force_locale": "zh",
+    }
+    Options.update(new_values, setter="manual")
+    assert isinstance(Options.ignored_files, tuple)
+    assert "bim" in Options.ignored_files
+    assert "bam" in Options.ignored_files
+    assert "boom" in Options.ignored_files
+    assert len(Options.ignored_files) > 4
+    # Check it is sorted
+    assert Options.ignored_files[-1] == "zzzzzzzzzz"
+
+
+@Options.mock()
 def test_repr():
     assert repr(Options)
 

--- a/tools/posix/deploy_jenkins_slave.sh
+++ b/tools/posix/deploy_jenkins_slave.sh
@@ -69,10 +69,12 @@ check_vars() {
     # Check required variables
     if [ "${PYTHON_DRIVE_VERSION:=unset}" = "unset" ]; then
         export PYTHON_DRIVE_VERSION="3.6.7"  # XXX_PYTHON
-    elif [ "${WORKSPACE:=unset}" = "unset" ]; then
+    fi
+    if [ "${WORKSPACE:=unset}" = "unset" ]; then
         echo "WORKSPACE not defined. Aborting."
         exit 1
-    elif [ "${OSI:=unset}" = "unset" ]; then
+    fi
+    if [ "${OSI:=unset}" = "unset" ]; then
         echo "OSI not defined. Aborting."
         echo "Please do not call this script directly. Use the good one from 'tools/OS/deploy_jenkins_slave.sh'."
         exit 1

--- a/tools/scripts/check_update_process.py
+++ b/tools/scripts/check_update_process.py
@@ -67,7 +67,7 @@ def create_versions(dst, version):
         dmg: {checksum}
         exe: {checksum}
     """
-    with open(os.path.join(dst, "versions.yml"), "w") as versions:
+    with open(os.path.join(dst, "versions.yml"), "a") as versions:
         versions.write(yml)
 
 
@@ -292,6 +292,9 @@ def main():
         dst_file = os.path.join(path, installer)
         print(">>> Moving", src_file, "->", path)
         shutil.move(src_file, dst_file)
+
+        # Append the versions.yml file
+        create_versions(root, previous)
 
         # Install Drive on the computer
         install_drive(dst_file)


### PR DESCRIPTION
* NXDRIVE-1596: Set the `channel` option to release by default. Also fix the `channel` option persistence in the database.
* NXDRIVE-1597: Update options of type sequence instead of overwriting them.
* NXDRIVE-1552: Fix deploy script on macOS.
* NXDRIVE-1552: Fix the `check_update_process.py` script.