### PR TITLE
NXDRIVE-1598: Ensure the QLocalSocket is connected before disconnection

### DIFF
--- a/docs/changes/4.1.0.md
+++ b/docs/changes/4.1.0.md
@@ -48,6 +48,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1587](https://jira.nuxeo.com/browse/NXDRIVE-1587): Do not call `Manager.stop()` when the server is not compatible
 - [NXDRIVE-1588](https://jira.nuxeo.com/browse/NXDRIVE-1588): Fix folders watch on Windows
 - [NXDRIVE-1595](https://jira.nuxeo.com/browse/NXDRIVE-1595): Fix malformed SSL certificate retrieving
+- [NXDRIVE-1598](https://jira.nuxeo.com/browse/NXDRIVE-1598): Ensure the `QLocalSocket` is connected before disconnection
 
 ## GUI
 

--- a/nxdrive/commandline.py
+++ b/nxdrive/commandline.py
@@ -553,7 +553,7 @@ class CliHandler:
         from PyQt5.QtNetwork import QLocalSocket
 
         named_pipe = f"{BUNDLE_IDENTIFIER}.protocol.{pid}"
-        log.info(
+        log.debug(
             f"Opening a local socket to the running instance on {named_pipe} "
             f"(payload={self.redact_payload(payload)})"
         )
@@ -568,10 +568,11 @@ class CliHandler:
             client.write(QByteArray(payload))
             client.waitForBytesWritten()
             client.disconnectFromServer()
-            client.waitForDisconnected()
+            if client.state() == QLocalSocket.ConnectedState:
+                client.waitForDisconnected()
         finally:
             del client
-        log.info("Successfully closed client socket")
+        log.debug("Successfully closed client socket")
 
     def clean_folder(self, options: Namespace) -> int:
         from .client.local_client import LocalClient

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -1197,7 +1197,8 @@ class Application(QApplication):
                 self._handle_nxdrive_url(url)
 
             con.disconnectFromServer()
-            con.waitForDisconnected()
+            if con.state() == QLocalSocket.ConnectedState:
+                con.waitForDisconnected()
         finally:
             del con
         log.info("Successfully closed server socket")

--- a/nxdrive/osi/extension.py
+++ b/nxdrive/osi/extension.py
@@ -89,7 +89,8 @@ class ExtensionListener(QTcpServer):
                     con.write(self._format_response(response))
 
         con.disconnectFromHost()
-        con.waitForDisconnected()
+        if con.state() == QTcpSocket.ConnectedState:
+            con.waitForDisconnected()
         del con
 
     def _parse_payload(self, payload: bytes) -> str:


### PR DESCRIPTION
There is a case where `QLocalSocket.disconnectFromHost()` will disconnect immediately.
So the next call to `QLocalSocket.waitForDisconnected()` will print out a warning:
```
QLocalSocket::waitForDisconnected() is not allowed in UnconnectedState
```