### PR TITLE
NXDRIVE-1501: Fix contentHeight of the popup

### DIFF
--- a/nxdrive/data/qml/DeletionPopup.qml
+++ b/nxdrive/data/qml/DeletionPopup.qml
@@ -7,7 +7,7 @@ NuxeoPopup {
 
     title: qsTr("DELETION_BEHAVIOR_CHANGE_SETTINGS") + tl.tr
     width: 400
-    height: 200
+    contentHeight: 150
     topPadding: 60
     bottomPadding: 50
     leftPadding: 50


### PR DESCRIPTION
To fix such warning when Drive is packaged:
```
GeneralTab.qml:149:5: QML NuxeoPopup: Binding loop detected for property "contentHeight"
```