### PR TITLE
NXDRIVE-1612: [macOS] Improve running applications detection

### DIFF
--- a/docs/changes/4.1.1.md
+++ b/docs/changes/4.1.1.md
@@ -10,6 +10,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1607](https://jira.nuxeo.com/browse/NXDRIVE-1607): Improve URLS computation
 - [NXDRIVE-1608](https://jira.nuxeo.com/browse/NXDRIVE-1608): Fix logging level setters
 - [NXDRIVE-1609](https://jira.nuxeo.com/browse/NXDRIVE-1609): Application cannot handle nxdrive:// url on first launch
+- [NXDRIVE-1612](https://jira.nuxeo.com/browse/NXDRIVE-1612): [macOS] Improve running applications detection
 
 ## GUI
 

--- a/nxdrive/osi/darwin/files.py
+++ b/nxdrive/osi/darwin/files.py
@@ -17,9 +17,17 @@ def _is_running(identifier: str) -> bool:
     the list of opened applications, meaning it is running.
     """
     shared_workspace = NSWorkspace.sharedWorkspace()
-    for running_app in shared_workspace.launchedApplications():
-        if identifier == str(running_app.allValues()[2]):
+    if not shared_workspace:
+        return False
+
+    running_apps = shared_workspace.runningApplications()
+    if not running_apps:
+        return False
+
+    for app in running_apps:
+        if str(app.bundleIdentifier()) == identifier:
             return True
+
     return False
 
 


### PR DESCRIPTION
* Add checks for `NSWorkspace` and running applications.
* Replace use of deprecated [launchedApplications()](https://developer.apple.com/documentation/appkit/nsworkspace/1579272-launchedapplications) with [runningApplications()](https://developer.apple.com/documentation/appkit/nsworkspace/1534059-runningapplications?language=objc).