### PR TITLE
NXDRIVE-986: Creating a new folder then renaming generates meaningless URLs

### DIFF
--- a/docs/changes/4.1.1.md
+++ b/docs/changes/4.1.1.md
@@ -44,6 +44,7 @@ Release date: `2019-xx-xx`
 - Added `FileAction.done` signal
 - Added `FileAction.progressing` signal
 - Added `FileAction.started` signal
+- Removed `use_trash` keyword argument from `Remote.get_info()`
 - Moved __main__.py::`ask_for_metrics_approval()` to `Application`
 - Moved __main__.py::`show_metrics_acceptance()` to `Application`
 - Added gui/view.py::`ActionModel`

--- a/docs/changes/4.1.1.md
+++ b/docs/changes/4.1.1.md
@@ -4,6 +4,7 @@ Release date: `2019-xx-xx`
 
 ## Core
 
+- [NXDRIVE-986](https://jira.nuxeo.com/browse/NXDRIVE-986): Creating a new folder then renaming generates meaningless URLs
 - [NXDRIVE-1600](https://jira.nuxeo.com/browse/NXDRIVE-1600): [Windows] OSError with datetime.fromtimestamp(t) when t < 0
 - [NXDRIVE-1601](https://jira.nuxeo.com/browse/NXDRIVE-1601): Ensure SSL support when packaged
 - [NXDRIVE-1603](https://jira.nuxeo.com/browse/NXDRIVE-1603): Improve URLs guesses upon connection
@@ -44,6 +45,7 @@ Release date: `2019-xx-xx`
 - Added `FileAction.done` signal
 - Added `FileAction.progressing` signal
 - Added `FileAction.started` signal
+- Added `Remote.move2()`
 - Removed `use_trash` keyword argument from `Remote.get_info()`
 - Moved __main__.py::`ask_for_metrics_approval()` to `Application`
 - Moved __main__.py::`show_metrics_acceptance()` to `Application`

--- a/nxdrive/client/local_client.py
+++ b/nxdrive/client/local_client.py
@@ -511,7 +511,7 @@ FolderType=Generic
 
         return result
 
-    def get_children_info(self, ref: Path) -> List[FileInfo]:
+    def _get_children_info(self, ref: Path) -> List[FileInfo]:
         os_path = self.abspath(ref)
         result = []
 
@@ -533,6 +533,13 @@ FolderType=Generic
                 result.append(info)
 
         return result
+
+    def get_children_info(self, ref: Path) -> List[FileInfo]:
+        try:
+            return self._get_children_info(ref)
+        except FileNotFoundError as exc:
+            log.warning(str(exc))
+            return []
 
     def unlock_ref(
         self, ref: Path, unlock_parent: bool = True, is_abs: bool = False

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -126,6 +126,10 @@ class Remote(Nuxeo):
                 raise NotFound(stack)
             raise e
 
+    def _escape(self, path) -> str:
+        """Escape any single quote with an antislash to further use in a NXQL query."""
+        return path.replace("'", r"\'")
+
     def exists(
         self, ref: str, use_trash: bool = True, include_versions: bool = False
     ) -> bool:
@@ -137,7 +141,7 @@ class Remote(Nuxeo):
         :param include_versions:
         :rtype: bool
         """
-        ref = self._check_ref(ref)
+        ref = self._escape(self._check_ref(ref))
         id_prop = "ecm:path" if ref.startswith("/") else "ecm:uuid"
 
         trash = self._get_trash_condition() if use_trash else ""
@@ -498,8 +502,7 @@ class Remote(Nuxeo):
         if not self.exists(ref, use_trash=use_trash, include_versions=include_versions):
             if raise_if_missing:
                 raise NotFound(
-                    "Could not find '%s' on '%s'"
-                    % (self._check_ref(ref), self.client.host)
+                    f"Could not find {self._check_ref(ref)} on {self.client.host}"
                 )
             return None
 

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -247,6 +247,7 @@ class Remote(Nuxeo):
 
                 # If there is an UploadError, we catch it from the processor
                 for _ in uploader.iter_upload():
+                    # Here 0 may happen when doing a single upload
                     action.progress += uploader.chunk_size or 0
 
                 upload_result = uploader.response
@@ -447,6 +448,14 @@ class Remote(Nuxeo):
                 command="NuxeoDrive.Move", srcId=fs_item_id, destId=new_parent_id
             )
         )
+
+    def move2(self, fs_item_id: str, parent_ref: str, name: str) -> Dict[str, Any]:
+        """Move a document using the Document.Move operation."""
+        if "#" in fs_item_id:
+            fs_item_id = fs_item_id.split("#")[-1]
+        if "#" in parent_ref:
+            parent_ref = parent_ref.split("#")[-1]
+        return self.documents.move(fs_item_id, parent_ref, name=name)
 
     def get_fs_item(
         self, fs_item_id: str, parent_fs_item_id: str = None

--- a/nxdrive/engine/dao/sqlite.py
+++ b/nxdrive/engine/dao/sqlite.py
@@ -1224,14 +1224,14 @@ class EngineDAO(ConfigurationDAO):
             con = self._get_write_connection()
             c = con.cursor()
             if doc_pair.folderish:
-                count = str(
-                    len(f"{doc_pair.remote_parent_path}/{doc_pair.remote_ref}") + 1
+                count = len(
+                    self._escape(f"{doc_pair.remote_parent_path}/{doc_pair.remote_ref}")
                 )
-                path = f"{new_path}/{doc_pair.remote_ref}"
+                path = self._escape(f"{new_path}/{doc_pair.remote_ref}")
                 query = (
                     "UPDATE States"
                     f"  SET remote_parent_path = '{path}'"
-                    f"      || substr(remote_parent_path, {count})"
+                    f"      || substr(remote_parent_path, {count + 1})"
                     + self._get_recursive_remote_condition(doc_pair)
                 )
 
@@ -1249,16 +1249,14 @@ class EngineDAO(ConfigurationDAO):
             con = self._get_write_connection()
             c = con.cursor()
             if doc_pair.folderish:
-                path = f"/{(new_path / new_name).as_posix()}"
-                count = str(len(doc_pair.local_path.as_posix()) + 2)
+                path = self._escape(f"/{(new_path / new_name).as_posix()}")
+                count = len(self._escape(doc_pair.local_path.as_posix()))
                 query = (
                     "UPDATE States"
                     f"  SET local_parent_path = '{path}'"
-                    f"      || substr(local_parent_path, {count}),"
+                    f"      || substr(local_parent_path, {count + 2}),"
                     f"         local_path = '{path}'"
-                    "       || substr(local_path, "
-                    + count
-                    + ") "
+                    f"      || substr(local_path, {count + 2}) "
                     + self._get_recursive_condition(doc_pair)
                 )
                 c.execute(query)

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -623,7 +623,7 @@ class Processor(EngineWorker):
             # If same hash don't do anything and reconcile
             uid = remote_ref.split("#")[-1]
             info = self.remote.get_info(
-                uid, raise_if_missing=False, fetch_parent_uid=False, use_trash=False
+                uid, raise_if_missing=False, fetch_parent_uid=False
             )
             log.warning(
                 f"This document {doc_pair!r} has remote_ref {remote_ref}, info={info!r}"

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -860,6 +860,14 @@ class Processor(EngineWorker):
 
         remote_info = None
         self._search_for_dedup(doc_pair, doc_pair.remote_name)
+
+        parent_ref = self.local.get_remote_id(doc_pair.local_parent_path)
+        if not parent_ref:
+            parent_pair = self._dao.get_state_from_local(doc_pair.local_parent_path)
+            parent_ref = parent_pair.remote_ref if parent_pair else ""
+        else:
+            parent_pair = self._get_normal_state_from_remote_ref(parent_ref)
+
         if doc_pair.local_name != doc_pair.remote_name:
             try:
                 if not doc_pair.remote_can_rename:
@@ -870,18 +878,24 @@ class Processor(EngineWorker):
                 remote_info = self.remote.rename(
                     doc_pair.remote_ref, doc_pair.local_name
                 )
+
+                if parent_ref and parent_ref == doc_pair.remote_parent_ref:
+                    # Handle cases when the user creates a new folder, it has the default name
+                    # set to the local system: "New folder", "Nouveau dossier (2)" ...
+                    # The folder is created directly and it generates useless URLs.
+                    # So we move the document to get back good URLs.
+                    # The trick here is that we move the document inside the same
+                    # parent folder but with a different name.
+                    log.info(f"Moving remote document according to local {doc_pair!r}")
+                    self.remote.move2(
+                        doc_pair.remote_ref, parent_ref, doc_pair.local_name
+                    )
+
                 self._refresh_remote(doc_pair, remote_info=remote_info)
             except Exception as e:
-                log.info(str(e))
+                log.error(str(e))
                 self._handle_failed_remote_rename(doc_pair, doc_pair)
                 return
-
-        parent_ref = self.local.get_remote_id(doc_pair.local_parent_path)
-        if not parent_ref:
-            parent_pair = self._dao.get_state_from_local(doc_pair.local_parent_path)
-            parent_ref = parent_pair.remote_ref if parent_pair else ""
-        else:
-            parent_pair = self._get_normal_state_from_remote_ref(parent_ref)
 
         if not parent_pair:
             raise ValueError("Should have a parent pair")

--- a/tests/old_functional/__init__.py
+++ b/tests/old_functional/__init__.py
@@ -196,7 +196,7 @@ class RemoteBase(Remote):
         return self.execute(command="Document.GetChildren", input_obj=f"doc:{ref}")
 
     def get_children_info(self, ref: str, limit: int = 1000) -> List[NuxeoDocumentInfo]:
-        ref = self._check_ref(ref)
+        ref = self._escape(self._check_ref(ref))
         types = {"File", "Note", "Workspace", "Folder", "Picture"}
 
         query = (

--- a/tests/old_functional/test_local_changes_when_offline.py
+++ b/tests/old_functional/test_local_changes_when_offline.py
@@ -95,15 +95,16 @@ class TestOfflineChangesSync(OneUserTest):
         # Verify that local changes are uploaded to server successfully
         if self.remote.exists("/Folder1/File1 - Copy.txt"):
             # '/Folder1/File1 - Copy.txt' is uploaded to server.
-            # So original file named should be changed as 'File_renamed.txt'
             remote_info = self.remote.get_info(self.file1_remote)
-            assert remote_info.name == "File1_renamed.txt"
+            assert remote_info.name == "File1 - Copy.txt"
         else:
             # Original file is renamed as 'File1 - Copy.txt'.
             # This is a bug only if Drive is online during copy + rename
             assert self.remote.exists("/Folder1/File1_renamed.txt")
             remote_info = self.remote.get_info(self.file1_remote)
-            assert remote_info.name == "File1 - Copy.txt"
+            assert remote_info.name == "File1_renamed.txt"
+
+        assert not self.remote.exists("/Folder1/File1.txt")
 
     def test_copy_paste_normal(self):
         """
@@ -134,10 +135,13 @@ class TestOfflineChangesSync(OneUserTest):
             # '/Folder1/File1 - Copy.txt' is uploaded to server.
             # So original file named should be changed as 'File_renamed.txt'
             remote_info = self.remote.get_info(self.file1_remote)
-            assert remote_info.name == "File1_renamed.txt"
+            assert remote_info.name == "File1 - Copy.txt"
+
         else:
             # Original file is renamed as 'File1 - Copy.txt'.
             # This is a bug only if Drive is online during copy + rename
             assert self.remote.exists("/Folder1/File1_renamed.txt")
             remote_info = self.remote.get_info(self.file1_remote)
-            assert remote_info.name == "File1 - Copy.txt"
+            assert remote_info.name == "File1_renamed.txt"
+
+        assert not self.remote.exists("/Folder1/File1.txt")

--- a/tests/old_functional/test_local_deletion.py
+++ b/tests/old_functional/test_local_deletion.py
@@ -22,8 +22,8 @@ class TestLocalDeletion(OneUserTest):
         self.wait_sync()
         assert remote.exists("/" + file1)
 
-        old_info = remote.get_info("/" + file1, use_trash=True)
-        abs_path = local.abspath("/" + file1)
+        old_info = remote.get_info(f"/{file1}")
+        abs_path = local.abspath(f"/{file1}")
 
         # Pretend we had trash the file
         shutil.move(abs_path, self.local_test_folder_1 / file1)
@@ -44,10 +44,10 @@ class TestLocalDeletion(OneUserTest):
 
         local.make_file("/", file1, content=b"This is a content")
         self.wait_sync()
-        assert remote.exists("/" + file1)
-        uid = local.get_remote_id("/" + file1)
-        old_info = remote.get_info("/" + file1, use_trash=True)
-        abs_path = local.abspath("/" + file1)
+        assert remote.exists(f"/{file1}")
+        uid = local.get_remote_id(f"/{file1}")
+        old_info = remote.get_info(f"/{file1}")
+        abs_path = local.abspath(f"/{file1}")
         # Pretend we had trash the file
         shutil.move(abs_path, self.local_test_folder_1 / file2)
         self.wait_sync(wait_for_async=True)
@@ -75,7 +75,7 @@ class TestLocalDeletion(OneUserTest):
         local.make_file("/ToDelete", file1, content=b"This is a content")
         self.wait_sync()
         assert remote.exists(file_path)
-        old_info = remote.get_info(file_path, use_trash=True)
+        old_info = remote.get_info(file_path)
         abs_path = local.abspath(file_path)
         # Pretend we had trash the file
         shutil.move(abs_path, self.local_test_folder_1 / file1)
@@ -88,9 +88,9 @@ class TestLocalDeletion(OneUserTest):
         # See if it untrash or recreate
         shutil.move(self.local_test_folder_1 / file1, local.abspath("/"))
         self.wait_sync()
-        new_info = remote.get_info(old_info.uid, use_trash=True)
+        new_info = remote.get_info(old_info.uid)
         assert new_info.state == "project"
-        assert local.exists("/" + file1)
+        assert local.exists(f"/{file1}")
         # Because remote_document_client_1 was used
         assert local.get_remote_id("/").endswith(new_info.parent_uid)
 
@@ -106,7 +106,7 @@ class TestLocalDeletion(OneUserTest):
         local.make_file("/ToDelete", file1, content=b"This is a content")
         self.wait_sync()
         assert remote.exists(file_path)
-        old_info = remote.get_info(file_path, use_trash=True)
+        old_info = remote.get_info(file_path)
         abs_path = local.abspath(file_path)
         # Pretend we had trash the file
         shutil.move(abs_path, self.local_test_folder_1 / file1)
@@ -153,7 +153,7 @@ class TestLocalDeletion(OneUserTest):
         local.make_file("/ToDelete", file1, content=b"This is a content")
         self.wait_sync()
         assert remote.exists(file_path)
-        remote.get_info(file_path, use_trash=True)
+        remote.get_info(file_path)
         abs_path = local.abspath(file_path)
 
         # Pretend we had trash the file
@@ -192,7 +192,7 @@ class TestLocalDeletion(OneUserTest):
         local.make_file("/ToDelete", file1, content=b"This is a content")
         self.wait_sync()
         assert remote.exists(file_path)
-        old_info = remote.get_info(file_path, use_trash=True)
+        old_info = remote.get_info(file_path)
         abs_path = local.abspath(file_path)
 
         # Pretend we had trash the file
@@ -208,7 +208,7 @@ class TestLocalDeletion(OneUserTest):
         shutil.move(self.local_test_folder_1 / file1, local.abspath("/ToDelete"))
         self.wait_sync()
         assert remote.exists(old_info.uid)
-        new_info = remote.get_info(old_info.uid, use_trash=True)
+        new_info = remote.get_info(old_info.uid)
         assert remote.exists(new_info.parent_uid)
         assert local.exists(file_path)
 
@@ -222,7 +222,7 @@ class TestLocalDeletion(OneUserTest):
         local.make_file("/ToDelete", file1, content=b"This is a content")
         self.wait_sync()
         assert remote.exists(file_path)
-        old_info = remote.get_info(file_path, use_trash=True)
+        old_info = remote.get_info(file_path)
         abs_path = local.abspath(file_path)
         # Pretend we had trash the file
         shutil.move(abs_path, self.local_test_folder_1 / file1)

--- a/tests/old_functional/test_local_move_and_rename.py
+++ b/tests/old_functional/test_local_move_and_rename.py
@@ -75,8 +75,8 @@ class TestLocalMoveAndRename(OneUserTest):
             assert local.exists("/Renamed Folder")
             assert not local.exists("/New Folder")
 
-            # Path doesn't change on Nuxeo
-            info = remote.get_info("/New Folder")
+            # Path is updated on Nuxeo
+            info = remote.get_info("/Renamed Folder")
             assert info.name == "Renamed Folder"
             assert len(local.get_children_info("/")) == 5
             assert len(remote.get_children_info(self.workspace)) == 5
@@ -101,8 +101,8 @@ class TestLocalMoveAndRename(OneUserTest):
             assert local.exists("/Renamed File.txt")
             assert not local.exists("/File.txt")
 
-            # Path doesn't change on Nuxeo
-            info = remote.get_info("/File.txt")
+            # Path is updated on Nuxeo
+            info = remote.get_info("/Renamed File.txt")
             assert info.name == "Renamed File.txt"
             assert len(local.get_children_info("/")) == 5
             assert len(remote.get_children_info(self.workspace)) == 5
@@ -127,8 +127,8 @@ class TestLocalMoveAndRename(OneUserTest):
             assert local.exists("/Renamed File.txt")
             assert not local.exists("/File.txt")
 
-            # Path doesn't change on Nuxeo
-            info = remote.get_info("/File.txt")
+            # Path is updated on Nuxeo
+            info = remote.get_info("/Renamed File.txt")
             assert info.name == "Renamed File.txt"
             assert len(local.get_children_info("/")) == 5
             assert len(remote.get_children_info(self.workspace)) == 5
@@ -154,8 +154,8 @@ class TestLocalMoveAndRename(OneUserTest):
             assert local.exists("/Renamed File.txt")
             assert not local.exists("/File.txt")
 
-            # Path doesn't change on Nuxeo
-            info = remote.get_info("/File.txt")
+            # Path is updated on Nuxeo
+            info = remote.get_info("/Renamed File.txt")
             assert info.name == "Renamed File.txt"
             assert len(local.get_children_info("/")) == 5
             assert len(remote.get_children_info(self.workspace)) == 5

--- a/tests/old_functional/test_nxdrive_903.py
+++ b/tests/old_functional/test_nxdrive_903.py
@@ -60,9 +60,9 @@ class Test(TwoUsersTest):
         for folder in folders:
             assert local_1.exists(folder)
             assert remote.exists(f"/{folder.as_posix()}")
-            for file_ in files[folder]:
-                assert local_1.exists(file_)
-                assert remote.exists(f"/{file_.as_posix()}")
+            for file in files[folder]:
+                assert local_1.exists(file)
+                assert remote.exists(f"/{file.as_posix()}")
 
         engine_2.start()
         self.wait_sync(
@@ -70,8 +70,8 @@ class Test(TwoUsersTest):
         )
         for folder in folders:
             assert local_2.exists(folder)
-            for file_ in files[folder]:
-                assert local_2.exists(file_)
+            for file in files[folder]:
+                assert local_2.exists(file)
 
         # Steps 14 -> 15
         engine_2.suspend()
@@ -91,12 +91,15 @@ class Test(TwoUsersTest):
                 new_files[new_folder].append(new_file)
         self.wait_sync()
 
-        for folder, new_folder in zip(folders, new_folders):
+        for new_folder in new_folders:
             assert local_1.exists(new_folder)
-            assert remote.get_info(f"/{folder.as_posix()}").name == new_folder.name
-            for file_, new_file in zip(files[folder], new_files[new_folder]):
+            assert remote.get_info(f"/{new_folder.name}").name == new_folder.name
+            for new_file in new_files[new_folder]:
                 assert local_1.exists(new_file)
-                assert remote.get_info(f"/{file_.as_posix()}").name == new_file.name
+                assert (
+                    remote.get_info(f"/{new_folder.name}/{new_file.name}").name
+                    == new_file.name
+                )
 
         # Steps 19 -> 21
         engine_2.resume()

--- a/tests/old_functional/test_remote_deletion.py
+++ b/tests/old_functional/test_remote_deletion.py
@@ -199,7 +199,7 @@ class TestRemoteDeletion(OneUserTest):
         assert remote.get_info(test_folder_uid).name == "Test folder renamed"
 
         # Delete remote folder then synchronize
-        remote.delete("/Test folder")
+        remote.delete("/Test folder renamed")
 
         self.wait_sync(wait_for_async=True)
         assert not remote.exists("/Test folder renamed")

--- a/tests/old_functional/test_special_characters.py
+++ b/tests/old_functional/test_special_characters.py
@@ -29,10 +29,10 @@ class TestSpecialCharacters(OneUserTest):
         local.rename(f"/{new_folder_name}/{file_name}", new_file_name)
 
         self.wait_sync()
-        # Paths don't change server-side
-        info = remote.get_info(f"/{folder_name}")
+        # Paths is updated server-side
+        info = remote.get_info(f"/{new_folder_name}")
         assert info.name == new_folder_name
-        info = remote.get_info(f"/{folder_name}/{file_name}")
+        info = remote.get_info(f"/{new_folder_name}/{new_file_name}")
         assert info.name == new_file_name
 
     @not_windows(reason="Explorer prevents using those characters")
@@ -61,10 +61,10 @@ class TestSpecialCharacters(OneUserTest):
         self.wait_sync()
         new_folder_name = "- * ? < > |"
         new_file_name = "| > < ? * -.txt"
-        # Paths don't change server-side
-        info = remote.get_info(f"/{folder_name}")
+        # Paths is updated server-side
+        info = remote.get_info(f"/{new_folder_name}")
         assert info.name == new_folder_name
-        info = remote.get_info(f"/{folder_name}/{file_name}")
+        info = remote.get_info(f"/{new_folder_name}/{new_file_name}")
         assert info.name == new_file_name
 
     def test_create_remote(self):

--- a/tests/old_functional/test_versioning.py
+++ b/tests/old_functional/test_versioning.py
@@ -38,6 +38,7 @@ class TestVersioning2(TwoUsersTest):
 
         # Create a file as user 2
         remote.make_file("/", "Test versioning.txt", content=b"This is version 0")
+        self.wait_sync()
         assert remote.exists("/Test versioning.txt")
         doc = self.root_remote.fetch(f"{self.ws.path}/Test versioning.txt")
         self._assert_version(doc, 0, 0)

--- a/tests/old_functional/test_watchers.py
+++ b/tests/old_functional/test_watchers.py
@@ -256,12 +256,12 @@ class TestWatchers(OneUserTest):
         self.wait_sync(wait_for_async=True)
         self.engine_1.stop()
         assert (
-            remote.get_info("/Accentue\u0301.odt").name
+            remote.get_info("/Accentue\u0301 avec un e\u0302 et un \xe9.odt").name
             == "Accentu\xe9 avec un \xea et un \xe9.odt"
         )
-        assert remote.get_info("/P\xf4le applicatif").name == "P\xf4le appliqu\xe9"
+        assert remote.get_info("/P\xf4le applique\u0301").name == "P\xf4le appliqu\xe9"
         assert (
-            remote.get_info("/P\xf4le applicatif/e\u0302tre ou ne pas \xeatre.odt").name
+            remote.get_info("/P\xf4le appliqu\xe9/avoir et e\u0302tre.odt").name
             == "avoir et \xeatre.odt"
         )
         # Check content update
@@ -276,11 +276,14 @@ class TestWatchers(OneUserTest):
         self.engine_1.start()
         self.wait_sync()
         self.engine_1.stop()
-        assert remote.get_content("/Accentue\u0301.odt") == b"Updated content"
+        assert (
+            remote.get_content("/Accentue\u0301 avec un e\u0302 et un \xe9.odt")
+            == b"Updated content"
+        )
         # NXDRIVE-389: Will be Content and not Updated content
         # it is not consider as synced, so conflict is generated
         assert (
-            remote.get_content("/P\xf4le applicatif/e\u0302tre ou ne pas \xeatre.odt")
+            remote.get_content("/P\xf4le appliqu\xe9/avoir et e\u0302tre.odt")
             == b"Updated content"
         )
 
@@ -291,7 +294,9 @@ class TestWatchers(OneUserTest):
         self.wait_sync()
         self.engine_1.stop()
         assert not remote.exists("/Accentue\u0301.odt")
+        assert not remote.exists("/Accentu\xe9 avec un \xea et un \xe9.odt")
         assert not remote.exists("/P\xf4le applicatif/e\u0302tre ou ne pas \xeatre.odt")
+        assert not remote.exists("/P\xf4le applicatif/avoir et e\u0302tre.odt")
 
     @not_windows(reason="Windows cannot have file ending with a space.")
     def test_watchdog_space_remover(self):
@@ -313,7 +318,7 @@ class TestWatchers(OneUserTest):
         local.rename("/Accentu\xe9.odt", "Accentu\xe9 avec un \xea et un \xe9.odt ")
         self.wait_sync()
         assert (
-            remote.get_info("/Accentue\u0301.odt").name
+            remote.get_info("/Accentu\xe9 avec un \xea et un \xe9.odt").name
             == "Accentu\xe9 avec un \xea et un \xe9.odt"
         )
 
@@ -351,11 +356,11 @@ class TestWatchers(OneUserTest):
         )
         self.wait_sync()
         assert (
-            remote.get_info("/Accentue\u0301.odt").name
+            remote.get_info("/Accentue\u0301 avec un e\u0302 et un \xe9.odt").name
             == "Accentu\xe9 avec un \xea et un \xe9.odt"
         )
-        assert remote.get_info("/P\xf4le applicatif").name == "P\xf4le appliqu\xe9"
-        info = remote.get_info("/Sub folder/e\u0302tre ou ne pas \xeatre.odt")
+        assert remote.get_info("/P\xf4le applique\u0301").name == "P\xf4le appliqu\xe9"
+        info = remote.get_info("/Sub folder/avoir et e\u0302tre.odt")
         assert info.name == "avoir et \xeatre.odt"
 
         # Check content update
@@ -364,8 +369,11 @@ class TestWatchers(OneUserTest):
         )
         local.update_content("/Sub folder/avoir et \xeatre.odt", b"Updated content")
         self.wait_sync()
-        assert remote.get_content("/Accentue\u0301.odt") == b"Updated content"
-        content = remote.get_content("/Sub folder/e\u0302tre ou ne pas \xeatre.odt")
+        assert (
+            remote.get_content("/Accentue\u0301 avec un e\u0302 et un \xe9.odt")
+            == b"Updated content"
+        )
+        content = remote.get_content("/Sub folder/avoir et e\u0302tre.odt")
         assert content == b"Updated content"
 
         # Check delete
@@ -373,6 +381,8 @@ class TestWatchers(OneUserTest):
         local.delete_final("/Sub folder/avoir et \xeatre.odt")
         self.wait_sync()
         assert not remote.exists("/Accentue\u0301.odt")
+        assert not remote.exists("/Accentue\u0301 avec un e\u0302 et un \xe9.odt")
+        assert not remote.exists("/Sub folder/avoir et e\u0302tre.odt")
         assert not remote.exists("/Sub folder/e\u0302tre ou ne pas \xeatre.odt")
 
     def test_watcher_remote_id_setter(self):


### PR DESCRIPTION
* Introduced `Remove.move2()` to call `Document.Move`. (name not very original, but I did as it is done with `shutil`: `shutil.copy()` and `shutil.copy2()`)

The trick here is to call `move2()` inside the same parent but with a new name. It will update the name and so the URL.

**WARNING**: this is a big change as it will invalidate any shared URL containing the document's name. In other words, if one shared a simple URL, and if the document is renamed by anyone, the URL will end on a 404 error (not found). This is not the case if one used the official mecanism and shared the document using the "Share link" that is using the document's UID.

---

And some bugfixes/improvements:
* Fix several escaping errors in SQL and NXQL queries.
* Improve `Remote.get_info()`: by removing a HTTP call to the server to check if a given document exists.
* `LocalClient.get_children_info()` not more raises on `FileNotFoundError`.