### PR TITLE
NXDRIVE-1578: DirectEdit'ing a doc and saving multiple times by secon…

### DIFF
--- a/docs/changes/4.1.2.md
+++ b/docs/changes/4.1.2.md
@@ -4,7 +4,7 @@ Release date: `2019-xx-xx`
 
 ## Core
 
-- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-): ...
+- [NXDRIVE-1578](https://jira.nuxeo.com/browse/NXDRIVE-1578): DirectEdit'ing a doc and saving multiple times by second fails
 
 ## GUI
 
@@ -21,3 +21,5 @@ Release date: `2019-xx-xx`
 ## Minor Changes
 
 ## Technical Changes
+
+- Added objects.py::`DirectEditDetails`

--- a/nxdrive/engine/tracker.py
+++ b/nxdrive/engine/tracker.py
@@ -11,7 +11,6 @@ from UniversalAnalytics import Tracker as UATracker
 
 from .workers import Worker
 from ..constants import APP_NAME, MAC, WINDOWS
-from ..objects import Blob
 from ..utils import get_arch, get_current_os
 
 if MAC:
@@ -121,9 +120,9 @@ class Tracker(Worker):
         except:
             log.exception("Error sending analytics")
 
-    @pyqtSlot(object)
-    def _send_directedit_open(self, blob: Blob) -> None:
-        _, extension = os.path.splitext(blob.name)
+    @pyqtSlot(str)
+    def _send_directedit_open(self, name: str) -> None:
+        _, extension = os.path.splitext(name)
         if not extension:
             extension = "unknown"
 
@@ -134,9 +133,9 @@ class Tracker(Worker):
             value=self._manager.direct_edit.get_metrics()["last_action_timing"],
         )
 
-    @pyqtSlot(object)
-    def _send_directedit_edit(self, blob: Blob) -> None:
-        _, extension = os.path.splitext(blob.name)
+    @pyqtSlot(str)
+    def _send_directedit_edit(self, name: str) -> None:
+        _, extension = os.path.splitext(name)
         if not extension:
             extension = "unknown"
 

--- a/nxdrive/engine/watcher/remote_watcher.py
+++ b/nxdrive/engine/watcher/remote_watcher.py
@@ -893,13 +893,13 @@ class RemoteWatcher(EngineWorker):
 
                         if lock_update:
                             locked_pair = self._dao.get_state_from_id(doc_pair.id)
-                            try:
-                                if locked_pair:
+                            if locked_pair:
+                                try:
                                     self._handle_readonly(locked_pair)
-                            except OSError as exc:
-                                log.debug(
-                                    f"Cannot handle readonly for {locked_pair!r} ({exc!r})"
-                                )
+                                except OSError as exc:
+                                    log.warning(
+                                        f"Cannot handle readonly for {locked_pair!r} ({exc!r})"
+                                    )
 
                 pair = self._dao.get_state_from_id(doc_pair.id)
                 if pair and pair.last_error != "DEDUP":

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -334,6 +334,7 @@ class Application(QApplication):
             )
             msg.addButton(Translator.get("CANCEL"), QMessageBox.RejectRole)
             msg.setIcon(QMessageBox.Warning)
+            msg.exec_()
             if msg.clickedButton() == overwrite:
                 self.manager.direct_edit.force_update(ref, digest)
             del self._conflicts_modals[filename]

--- a/nxdrive/objects.py
+++ b/nxdrive/objects.py
@@ -18,6 +18,11 @@ Binder = namedtuple(
     "binder", ["username", "password", "token", "url", "no_check", "no_fscheck"]
 )
 
+# DirectEdit details, returned from DirectEdit._extract_edit_info()
+DirectEditDetails = namedtuple(
+    "details", ["uid", "engine", "digest_func", "digest", "xpath", "editing"]
+)
+
 # List of filters from the database
 Filters = List[str]
 

--- a/tests/functional/test_tracker.py
+++ b/tests/functional/test_tracker.py
@@ -1,4 +1,3 @@
-from nuxeo.models import Blob
 from nxdrive.engine.tracker import Tracker
 
 
@@ -26,15 +25,12 @@ def test_tracker_send_methods(manager_factory, monkeypatch):
         "speed": 42,
         "handler": "test_tracker_send_methods",
     }
-    blob = Blob(
-        uploaded=False, name="Jean-Michel Jarre - Oxygen", size=42, mimetype="audio/ogg"
-    )
 
     with manager:
         tracker = Tracker(manager, uid="")
         monkeypatch.setattr(tracker._tracker, "send", send)
 
-        tracker._send_directedit_open(blob)
-        tracker._send_directedit_edit(blob)
+        tracker._send_directedit_open("Jean-Michel Jarre - Oxygen")
+        tracker._send_directedit_edit("Jean-Michel Jarre - Oxygen.ogg")
         tracker._send_sync_event(metrics)
         tracker._send_stats()

--- a/tests/unit/test_commandline.py
+++ b/tests/unit/test_commandline.py
@@ -141,8 +141,11 @@ def test_default_override(cmd):
 @Options.mock()
 def test_malformatted_line(cmd):
     create_ini_bad()
-    with pytest.raises(TypeError):
-        cmd.parse_cli([])
+    cmd.parse_cli([])
+    # The malformed line will display a warning:
+    # Unknown logging level ('=', 'DEBUG', 'False', 'debug'), need to be one of ...
+    # Callback check for 'log_level_console' denied modification. Value is still 'WARNING'.
+    assert Options.log_level_console == "WARNING"
 
 
 def test_z_last_ensure_options_not_modified():


### PR DESCRIPTION
…d fails

The fix is to skip the comparison with the blob on the server when the document is being DirectEdit'ed: as it should be locked, the document cannot be modifed by anyone else.
This check was creating several conflicts (that were not displayed because of another bug) and finally the original version was restored when the DirectEdit'ion was over.

As a bonus, we save 2 HTTP calls: now only 1 call for each and every modification!

* Introduce `DirectEditDetails` to simplify `DirectEdit._extrac_edit_infos()` usage.
* Fix message box not displayed in `Application._direct_edit_conflict()`.
* Move out an if condition outside try...except in `RemoteWatcher._update_remote_states()`.