### PR TITLE
NXDRIVE-1618: Remove inexistant engines from the Manager engines list

### DIFF
--- a/docs/changes/4.1.3.md
+++ b/docs/changes/4.1.3.md
@@ -10,6 +10,7 @@ Changes in command line arguments:
 
 - [NXDRIVE-1074](https://jira.nuxeo.com/browse/NXDRIVE-1074): Remove the Next engine source tree
 - [NXDRIVE-1277](https://jira.nuxeo.com/browse/NXDRIVE-1277): Review objects state export
+- [NXDRIVE-1618](https://jira.nuxeo.com/browse/NXDRIVE-1618): Remove inexistant engines from the Manager engines list
 - [NXDRIVE-1624](https://jira.nuxeo.com/browse/NXDRIVE-1624): Ensure the lock file integrity is correct
 - [NXDRIVE-1636](https://jira.nuxeo.com/browse/NXDRIVE-1636): Reduce ScrollDescendants calls for each folder
 - [NXDRIVE-1637](https://jira.nuxeo.com/browse/NXDRIVE-1637): [macOS] Skip unsaved documents in Photoshop and Illustrator

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -1105,11 +1105,12 @@ class Application(QApplication):
         if not url:
             # This is not an event for us!
             return super().event(event)
+
+        final_url = unquote(event.url().toString())
         try:
-            final_url = unquote(event.url().toString())
             return self._handle_nxdrive_url(final_url)
         except:
-            log.exception(f"Error handling URL event {url!r}")
+            log.exception(f"Error handling URL event {final_url!r}")
             return False
 
     def _show_msgbox_restart_needed(self) -> None:

--- a/tests/functional/test_behavior.py
+++ b/tests/functional/test_behavior.py
@@ -15,7 +15,7 @@ AttributeError: 'Engine' object has no attribute '_local_watcher'
     manager, engine = manager_factory()
 
     with manager:
-        # There is no bound engine
+        # There is 1 bound engine
         assert manager._engines
 
         # Simulate the database file removal
@@ -33,3 +33,19 @@ AttributeError: 'Engine' object has no attribute '_local_watcher'
         os.rename(f"{db_file}.or", db_file)
         manager.load()
         assert manager._engines
+
+
+def test_mananger_engine_removal(manager_factory):
+    """NXDIVE-1618: Remove inexistant engines from the Manager engines list."""
+
+    manager, engine = manager_factory()
+
+    # Remove the database file
+    os.remove(engine._get_db_file())
+
+    with manager:
+        # Trigger engines reload as it is done in __init__()
+        manager.load()
+
+        # There should be no engine
+        assert not manager.get_engines()


### PR DESCRIPTION
* Make database backups when adding and removing an account.
* Display the file URL in `Application.event()`.