### PR TITLE
NXDRIVE-1641: Fix bind-server CLI without the --password argument

### DIFF
--- a/docs/changes/4.1.3.md
+++ b/docs/changes/4.1.3.md
@@ -20,6 +20,7 @@ Changes in command line arguments:
 - [NXDRIVE-1636](https://jira.nuxeo.com/browse/NXDRIVE-1636): Reduce ScrollDescendants calls for each folder
 - [NXDRIVE-1637](https://jira.nuxeo.com/browse/NXDRIVE-1637): [macOS] Skip unsaved documents in Photoshop and Illustrator
 - [NXDRIVE-1639](https://jira.nuxeo.com/browse/NXDRIVE-1639): Do not allow DirectEdit on older versions of document
+- [NXDRIVE-1641](https://jira.nuxeo.com/browse/NXDRIVE-1641): Fix `bind-server` CLI without the `--password` argument
 
 ## GUI
 

--- a/nxdrive/data/qml/AccountsTab.qml
+++ b/nxdrive/data/qml/AccountsTab.qml
@@ -129,10 +129,29 @@ Rectangle {
                     text: qsTr("CONFLICTS_AND_ERRORS") + tl.tr
                     color: mediumGray
                 }
-
                 Link {
                     text: qsTr("OPEN_WINDOW") + tl.tr
                     onClicked: api.show_conflicts_resolution(uid)
+                }
+
+                ScaledText {
+                    id: invalidCredsLabel
+                    visible: api.has_invalid_credentials(uid)
+                    text: qsTr("AUTH_EXPIRED") + tl.tr
+                    color: mediumRed
+                }
+                Link {
+                    id: invalidCredsAction
+                    visible: api.has_invalid_credentials(uid)
+                    text: qsTr("AUTH_UPDATE_ACTION") + tl.tr
+                    color: red
+                    onClicked: {
+                        api.web_update_token(uid);
+                        if (!api.has_invalid_credentials(uid)) {
+                            invalidCredsLabel.visible = false;
+                            invalidCredsAction.visible = false;
+                        }
+                    }
                 }
             }
         }

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -801,6 +801,7 @@ class Engine(QObject):
         self._remote_password = binder.password
         self._remote_token = binder.token
         self._web_authentication = self._remote_token is not None
+        self.remote = None  # type: ignore
 
         # Check first if the folder is on a supported FS
         if check_fs:
@@ -822,9 +823,8 @@ class Engine(QObject):
         self._ssl_verify = not Options.ssl_no_verify
         self._ca_bundle = Options.ca_bundle
 
-        self.remote = self.init_remote()
-
         if check_credentials and self._remote_token is None:
+            self.remote = self.init_remote()
             self._remote_token = self.remote.request_token()
 
         if self._remote_token is not None:

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -688,6 +688,11 @@ class Application(QApplication):
                 token = ""
             finally:
                 del nuxeo
+
+            # Check we have a token and not a HTML response
+            if "\n" in token:
+                token = ""
+
             self.api.handle_token(token, user)
             dialog.close()
 
@@ -717,7 +722,7 @@ class Application(QApplication):
         self.change_systray_icon()
 
     def init_checks(self) -> None:
-        for _, engine in self.manager.get_engines().items():
+        for engine in self.manager.get_engines().values():
             self._connect_engine(engine)
 
         self.manager.newEngine.connect(self._connect_engine)
@@ -735,7 +740,7 @@ class Application(QApplication):
             for engine in self.manager.get_engines().values():
                 # Prompt for settings if needed
                 if engine.has_invalid_credentials():
-                    self.show_settings("Accounts_" + engine.uid)
+                    self.show_settings("Accounts")  # f"Account_{engine.uid}"
                     break
 
         self.manager.start()

--- a/nxdrive/objects.py
+++ b/nxdrive/objects.py
@@ -320,6 +320,7 @@ class DocPair(Row):
         return (
             f"<{type(self).__name__}[{self.id!r}]"
             f" local_path={self.local_path!r},"
+            f" local_parent_path={self.local_parent_path!r},"
             f" remote_ref={self.remote_ref!r},"
             f" local_state={self.local_state!r},"
             f" remote_state={self.remote_state!r},"
@@ -331,7 +332,7 @@ class DocPair(Row):
     def __getattr__(self, name: str) -> Optional[Union[str, Path]]:
         with suppress(IndexError):
             if name in {"local_path", "local_parent_path"}:
-                return Path(self[name].lstrip("/"))
+                return Path((self[name] or "").lstrip("/"))
             if name == "remote_ref":
                 return self[name] or ""
             return self[name]

--- a/nxdrive/options.py
+++ b/nxdrive/options.py
@@ -140,6 +140,11 @@ class MetaOptions(type):
         "command",
         "file",
         "log_filename",
+        # From the CLI: bind-server sub-command
+        "password",
+        "nuxeo_url",
+        "local_folder",
+        "username",
         # From the Manager
         "client_version",
         "light_icons",

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -448,7 +448,7 @@ def normalized_path(path: Union[bytes, str, Path]) -> Path:
     return Path(path).expanduser().resolve()
 
 
-def normalize_event_filename(filename: str, action: bool = True) -> Path:
+def normalize_event_filename(filename: Union[str, Path], action: bool = True) -> Path:
     """
     Normalize a file name.
 


### PR DESCRIPTION
This needed several fixes (each one appearing after a fix was done).

* Rework `Manager.bind_engine()` to path releated handle error  and start watching the folder only if the Engine has started.
* Fix `Engine.bind()` to use a Remote client only if we can   login to the server.
* Fix a `TypeError` in `DocPair.__getattr__()` when the `local_path` or `local_parent_path` is not defined or set to `None`.
* Handle bad token value in `Application._web_auth_not_frozen()`.
* Fix `Application.init_checks()` not show the Accounts window if any Engine has invalid credentials. This will show the 1st Engine in the list, not the faultive one.
* Display a link to re-authenticate in the Account tab.