### PR TITLE
NXDRIVE-1623: [Windows] Add CLI sub-commands tests: clean-folder, con…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Note: this documentation follows the Drive version of the master branch, which c
 
 ```shell
 # For Drive 2.1.113 go to:
-https://github.com/nuxeo/nuxeo-drive/release-2.1.113/README.md
+https://github.com/nuxeo/nuxeo-drive/tree/release-2.1.113
 ```
 
 ## License
@@ -110,11 +110,13 @@ The desktop synchronization client can also be operated from the command-line:
     ```shell
     alias ndrive="/Applications/Nuxeo\ Drive.app/Contents/MacOS/ndrive"
     ```
-2. Launch Nuxeo Drive (no automatic background mode yet, this will come in future versions):
+
+2. Launch Nuxeo Drive:
 
     ```shell
     ndrive
     ```
+
     Under Windows you can launch `ndrive.exe` instead to avoid keeping the cmd console open while Nuxeo Drive is running instead.
 
 3. The first time you run this command a dialog window will open asking for the URL of the Nuxeo server and your user credentials.
@@ -122,8 +124,9 @@ The desktop synchronization client can also be operated from the command-line:
     Alternatively you can bind to a Nuxeo server with your user credentials using the following commandline arguments:
 
     ```shell
-    ndrive bind-server nuxeo-username https://server:port/nuxeo --password secret
+    ndrive bind-server nuxeo-username https://server:port/nuxeo [--password="secret"] [--local-folder="~/Nuxeo Drive"]
     ```
+
     This will create a new folder called Nuxeo Drive in your home folder on GNU/Linux & macOS and under the Documents folder on Windows.
 
 4. Go to your Nuxeo with your browser, navigate to workspaces or folder where you have permission to create new documents.
@@ -134,6 +137,7 @@ The desktop synchronization client can also be operated from the command-line:
     ```shell
     ndrive bind-root "/default-domain/workspaces/My Workspace"
     ```
+
     You can now create office documents and folders locally or inside Nuxeo and watch them getting synchronized both ways automatically.
 
 ## Localization
@@ -171,9 +175,9 @@ The [sync-nuxeo-drive-crowdin](https://qa.nuxeo.org/jenkins/job/Private/job/Crow
 
     By default the location of the log file is: `~/.nuxeo-drive/logs/` where `~` stands for the location of the user folder. For instance:
 
-    * Under Windows 7 and 8: `C:\Users\username\.nuxeo-drive\logs`
-    * Under macOS: `/Users/username/.nuxeo-drive/logs`
-    * Under GNU/Linux: `/home/username/.nuxeo-drive/logs`
+    * GNU/Linux: `/home/username/.nuxeo-drive/logs`
+    * macOS: `/Users/username/.nuxeo-drive/logs`
+    * Windows: `C:\Users\username\.nuxeo-drive\logs`
 
 ## Roadmap
 

--- a/docs/changes/4.1.3.md
+++ b/docs/changes/4.1.3.md
@@ -21,6 +21,7 @@ Changes in command line arguments:
 - [NXDRIVE-1637](https://jira.nuxeo.com/browse/NXDRIVE-1637): [macOS] Skip unsaved documents in Photoshop and Illustrator
 - [NXDRIVE-1639](https://jira.nuxeo.com/browse/NXDRIVE-1639): Do not allow DirectEdit on older versions of document
 - [NXDRIVE-1641](https://jira.nuxeo.com/browse/NXDRIVE-1641): Fix `bind-server` CLI without the `--password` argument
+- [NXDRIVE-1651](https://jira.nuxeo.com/browse/NXDRIVE-1651): Expand environment variables in paths given to CLI arguments
 
 ## GUI
 

--- a/docs/changes/4.1.3.md
+++ b/docs/changes/4.1.3.md
@@ -5,6 +5,7 @@ Release date: `2019-xx-xx`
 Changes in command line arguments:
 
 - Deleted `max-sync-step`.
+- Renamed `clean_folder` to `clean-folder`.
 
 ## Core
 
@@ -36,6 +37,7 @@ Changes in command line arguments:
 ## Tests
 
 - [NXDRIVE-1583](https://jira.nuxeo.com/browse/NXDRIVE-1583): [Windows] Add first integration tests: CLI arguments
+- [NXDRIVE-1623](https://jira.nuxeo.com/browse/NXDRIVE-1623): [Windows] Add CLI sub-commands tests: clean-folder, console, bind-server and unbind-server
 
 ## Doc
 
@@ -68,3 +70,4 @@ Changes in command line arguments:
 - Added exceptions.py::`DocumentAlreadyLocked`
 - Moved gui/api.py::`get_date_from_sqlite()` to utils.py
 - Moved gui/api.py::`get_timestamp_from_date()` to utils.py
+- Added utils.py::`normalize_and_expand_path()`

--- a/nxdrive/client/local_client.py
+++ b/nxdrive/client/local_client.py
@@ -545,7 +545,7 @@ FolderType=Generic
         self, ref: Path, unlock_parent: bool = True, is_abs: bool = False
     ) -> int:
         path = ref if is_abs else self.abspath(ref)
-        return unlock_path(path, unlock_parent)
+        return unlock_path(path, unlock_parent=unlock_parent)
 
     def lock_ref(self, ref: Path, locker: int, is_abs: bool = False) -> None:
         path = ref if is_abs else self.abspath(ref)

--- a/nxdrive/commandline.py
+++ b/nxdrive/commandline.py
@@ -9,6 +9,7 @@ from argparse import ArgumentParser, Namespace
 from configparser import DEFAULTSECT, ConfigParser
 from datetime import datetime
 from logging import getLogger
+from pathlib import Path
 from typing import List, TYPE_CHECKING, Union
 
 from . import __version__
@@ -453,6 +454,10 @@ class CliHandler:
     def uninstall(self, options: Namespace = None) -> None:
         AbstractOSIntegration.get(None).uninstall()
 
+    def normalize_path(self, path: str) -> Path:
+        """Convert options that need to be Path and expand environment variables."""
+        return normalized_path(os.path.expandvars(path))
+
     def handle(self, argv: List[str]) -> int:
         """ Parse options, setup logs and manager and dispatch execution. """
 
@@ -461,11 +466,10 @@ class CliHandler:
 
         options = self.parse_cli(argv)
 
-        # Convert options that need to be Path
-        if getattr(options, "local_folder", ""):
-            options.local_folder = normalized_path(options.local_folder)
-        if getattr(options, "nxdrive_home", ""):
-            options.nxdrive_home = normalized_path(options.nxdrive_home)
+        if hasattr(options, "local_folder"):
+            options.local_folder = self.normalize_path(options.local_folder)
+        if hasattr(options, "nxdrive_home"):
+            options.nxdrive_home = self.normalize_path(options.nxdrive_home)
 
         command = getattr(options, "command", "launch")
         handler = getattr(self, command, None)

--- a/nxdrive/data/i18n/i18n.json
+++ b/nxdrive/data/i18n/i18n.json
@@ -112,6 +112,7 @@
     "FATAL_ERROR_DETAILS_COPY": "Copy details",
     "FATAL_ERROR_LOGS": "Logs before the crash:",
     "FATAL_ERROR_MSG": "Ooops! Unfortunately, a fatal error occurred and %1 has stopped.<br>Please share the following informations with %2 support: we’ll do our best to fix it!",
+    "FATAL_ERROR_OUTPUT": "Console output:",
     "FATAL_ERROR_TITLE": "%1 - Fatal error",
     "FEEDBACK_LINK": "Something is missing? Share your feedback here.",
     "FILE_ALREADY_EXISTS": "There is already a file named „%1“ in  this folder. Do you want to replace it with the one you're moving?",

--- a/nxdrive/data/qml/AccountsTab.qml
+++ b/nxdrive/data/qml/AccountsTab.qml
@@ -138,7 +138,7 @@ Rectangle {
                     id: invalidCredsLabel
                     visible: api.has_invalid_credentials(uid)
                     text: qsTr("AUTH_EXPIRED") + tl.tr
-                    color: mediumRed
+                    color: red
                 }
                 Link {
                     id: invalidCredsAction

--- a/nxdrive/poll_workers.py
+++ b/nxdrive/poll_workers.py
@@ -5,6 +5,7 @@ from PyQt5.QtCore import pyqtSlot
 
 from .engine.workers import PollWorker
 from .options import Options
+from .utils import normalize_and_expand_path
 
 log = logging.getLogger(__name__)
 
@@ -59,6 +60,12 @@ class ServerOptionsUpdater(PollWorker):
                 beta = conf.pop("beta_channel", False)
                 if beta:
                     conf["channel"] = "beta"
+
+                if "nxdrive_home" in conf:
+                    # Expand potential envars
+                    conf["nxdrive_home"] = normalize_and_expand_path(
+                        conf["nxdrive_home"]
+                    )
 
                 # We cannot use fail_on_error=True because the server may
                 # be outdated and still have obsolete options.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-
+import os
 import shutil
 import sys
 
@@ -7,6 +7,9 @@ import pytest
 
 
 pytest_plugins = "tests.pytest_random"
+
+
+DEFAULT_NUXEO_URL = "http://localhost:8080/nuxeo"
 
 
 @pytest.hookimpl(trylast=True, hookwrapper=True)
@@ -93,3 +96,18 @@ def cleanup_attrs(request):
             if engine.remote:
                 engine.remote.client._session.close()
         delattr(test_case, attr)
+
+
+@pytest.fixture(scope="session")
+def version() -> str:
+    import nxdrive
+
+    return nxdrive.__version__
+
+
+@pytest.fixture(scope="session")
+def nuxeo_url() -> str:
+    """Retrieve the Nuxeo URL."""
+    url = os.getenv("NXDRIVE_TEST_NUXEO_URL", DEFAULT_NUXEO_URL)
+    url = url.split("#")[0]
+    return url

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-import os
 from logging import getLogger
 from typing import Callable
 from random import randint
@@ -14,7 +13,6 @@ from nuxeo.client import Nuxeo
 from nuxeo.documents import Document
 from nuxeo.users import User
 
-import nxdrive
 from nxdrive.manager import Manager
 
 
@@ -22,21 +20,7 @@ from nxdrive.manager import Manager
 OPS_CACHE = None
 SERVER_INFO = None
 
-DEFAULT_NUXEO_URL = "http://localhost:8080/nuxeo"
 log = getLogger(__name__)
-
-
-@pytest.fixture(scope="session")
-def version() -> str:
-    return nxdrive.__version__
-
-
-@pytest.fixture(scope="session")
-def nuxeo_url() -> str:
-    """Retrieve the Nuxeo URL."""
-    url = os.getenv("NXDRIVE_TEST_NUXEO_URL", DEFAULT_NUXEO_URL)
-    url = url.split("#")[0]
-    return url
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/windows/conftest.py
+++ b/tests/integration/windows/conftest.py
@@ -1,9 +1,13 @@
 from contextlib import contextmanager
+from logging import getLogger
 
 import pytest
 
 from nxdrive.options import Options
 from pywinauto.application import Application
+
+
+log = getLogger(__name__)
 
 
 def pytest_addoption(parser):
@@ -30,10 +34,12 @@ def exe(final_exe, tmp):
 
     @contextmanager
     def execute(cmd=final_exe, args=None):
+        log.info(f"Starting {cmd!r} with args={args!r}")
+
         if args:
             cmd += " " + args
 
-        app = Application().start(cmd)
+        app = Application(backend="uia").start(cmd, timeout=30)
         try:
             yield app
         finally:

--- a/tests/integration/windows/test_cli_sub_command.py
+++ b/tests/integration/windows/test_cli_sub_command.py
@@ -1,0 +1,91 @@
+import os.path
+import shutil
+import stat
+from logging import getLogger
+
+import pytest
+
+from .utils import fatal_error_dlg
+
+
+log = getLogger(__name__)
+
+
+def launch(exe, args: str) -> None:
+    try:
+        with exe(args=args) as app:
+            return not fatal_error_dlg(app)
+    except Exception:
+        return False
+
+
+def bind(exe, args: str) -> None:
+    """bind-server option. Used at several places so moved out test functions."""
+    return launch(exe, f"bind-server {args}")
+
+
+def unbind(exe, args: str) -> None:
+    """unbind-server option. Used at several places so moved out test functions."""
+    return launch(exe, f"unbind-server {args}")
+
+
+def test_console(exe):
+    assert launch(exe, "console")
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        "{user} {url}",
+        "{user} {url} --password=BadP@ssw0rd",
+        # --local-folder argument is tested in test_unbind()
+    ],
+)
+def test_bind_server(nuxeo_url, exe, args):
+    """
+    Test only with no access to the server to prevent useless binds.
+    Real binds are tested in test_unbind_server().
+    """
+    assert bind(exe, args.format(user="Administrator", url=nuxeo_url))
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        "",
+        "Administrator",
+        "http://localhost:8080/nuxeo",
+        "--password=Administrator",
+        "--local-folder=foo",
+    ],
+)
+def test_bind_server_missing_arguments(exe, args):
+    assert not bind(exe, args)
+
+
+@pytest.mark.parametrize(
+    "folder", ["%temp%\\Léa$", "%temp%\\this folder is good enough こん ツリ ^^"]
+)
+def test_unbind_server(nuxeo_url, exe, folder):
+    """Will also test clean-folder."""
+    expanded_folder = os.path.expandvars(folder)
+    local_folder = f'--local-folder="{folder}"'
+    args = f"Administrator {nuxeo_url} {local_folder}"
+
+    try:
+        assert bind(exe, args)
+        assert os.path.isdir(expanded_folder)
+        assert unbind(exe, local_folder)
+    finally:
+        assert launch(exe, f"clean-folder {local_folder}")
+
+        os.chmod(expanded_folder, stat.S_IWUSR)
+        shutil.rmtree(expanded_folder)
+        assert not os.path.isdir(expanded_folder)
+
+
+@pytest.mark.parametrize("folder", ["", "this folder does not exist こん ツリ ^^ Léa$"])
+def test_unbind_server_missing_argument(exe, folder):
+    """Without (or invalid) argument must not fail at all."""
+    local_folder = f'--local-folder="{folder}"'
+    assert unbind(exe, local_folder)

--- a/tests/integration/windows/utils.py
+++ b/tests/integration/windows/utils.py
@@ -1,0 +1,50 @@
+from logging import getLogger
+from time import sleep
+
+import win32clipboard
+from nxdrive.constants import APP_NAME
+
+
+log = getLogger(__name__)
+
+
+def copy_clipboard() -> str:
+    """Get content of the clip board."""
+    win32clipboard.OpenClipboard()
+    details = win32clipboard.GetClipboardData(win32clipboard.CF_UNICODETEXT)
+    win32clipboard.CloseClipboard()
+    return details
+
+
+def fatal_error_dlg(app, with_details: bool = True) -> bool:
+    # Check if the fatal error dialog is prompted.
+    # XXX: Keep synced with FATAL_ERROR_TITLE.
+    dlg = app.window(title=f"{APP_NAME} - Fatal error")
+    if dlg.exists():
+        if with_details:
+            # Copy details
+            sleep(1)
+            dlg.child_window(title="Copy details").wait("visible").click()
+            sleep(1)
+            log.warning(f"Fatal error screen detected! Details:\n{copy_clipboard()}")
+        else:
+            log.warning(f"Fatal error screen detected!")
+
+        dlg.close()
+        return True
+    return False
+
+
+def main_window(app):
+    # Return the main windows when visible.
+    return app.window(title=APP_NAME).wait("visible")
+
+
+def share_metrics_dlg(app) -> bool:
+    # Check if the pop-up to share metrics is prompted and close it.
+    # XXX: Keep synced with SHARE_METRICS_TITLE.
+    dlg = app.window(title=f"{APP_NAME} - Share debug info with developers")
+    if dlg.exists():
+        dlg.close()
+        return True
+    return False


### PR DESCRIPTION
…sole, bind-server and unbind-server

Those sub-commands are not easily testable, so they will not be covered now:

* bind-root (need dynamic UID)
* unbind-root (need dynamic UID)
* access-online (need browser manipulations)
* copy-share-link (need dynamic UID)
* edit-metadata (need browser manipulations)

Changes:

* CLI: renamed `clean_folder` to `clean-folder`.
* Lower several `logging.error()` in `commandline.py` to `logging.warning()`.
* Simplfy `set_path_readonly()` and `unset_path_readonly()` implementations.
* Refactor some test fixtures.

Also including:

* NXDRIVE-1651: Expand environment variables in paths given to CLI arguments. This is cool to be able to pass `--local-folder="%temp%\testing"` for instance (when Windows cannot expand itself the variable).