### PR TITLE
NXDRIVE-1362: Reduce the complexity of LocalWatcher._handle_watchdog_…

### DIFF
--- a/docs/changes/4.1.3.md
+++ b/docs/changes/4.1.3.md
@@ -62,6 +62,7 @@ Changes in command line arguments:
 - Added `DocPair.export()`
 - Added `Engine.export()`
 - Added `Engine.fileAlreadyExists` signal
+- Removed `LocalClient.CASE_RENAME_PREFIX`
 - Added `LocalWatcher.fileAlreadyExists` signal
 - Added `Notification.export()`
 - Added `NuxeoDocumentInfo.is_version`

--- a/nxdrive/client/local_client.py
+++ b/nxdrive/client/local_client.py
@@ -128,7 +128,6 @@ class FileInfo:
 class LocalClient:
     """ Client API implementation for the local file system. """
 
-    CASE_RENAME_PREFIX = "driveCaseRename_"
     _case_sensitive = None
 
     def __init__(self, base_folder: Path, **kwargs: Any) -> None:
@@ -641,7 +640,9 @@ FolderType=Generic
                 and old_name.lower() == new_name.lower()
                 and not self.is_case_sensitive()
             ):
-                # Must use a temp rename as FS is not case sensitive
+                # The filesystem is not sensitive, so we cannot rename
+                # from "a" to "A". We need to use a temporary filename
+                # inbetween, which allows us to do "a" -> <tempname> -> "A".
                 temp_path = normalized_path(tempfile.gettempdir()) / str(uuid.uuid4())
                 source_os_path.rename(temp_path)
                 source_os_path = temp_path


### PR DESCRIPTION
…event_on_known_pair()

NXDRIVE-1363: Reduce the complexity of `LocalWatcher._handle_watchdog_event_on_known_acquired_pair()`

`_handle_watchdog_event_on_known_pair()` was rated D and is now B.
`_handle_watchdog_event_on_acquired_pair()` was rated D and is now C.

In the meantime we:
* added `_handle_move_on_known_pair()` rated C;
* added `_handle_delete_on_known_pair()` rated A.