### PR TITLE
NXDRIVE-1148: Better handle no space left on the device

### DIFF
--- a/docs/changes/4.1.3.md
+++ b/docs/changes/4.1.3.md
@@ -10,6 +10,7 @@ Changes in command line arguments:
 ## Core
 
 - [NXDRIVE-1074](https://jira.nuxeo.com/browse/NXDRIVE-1074): Remove the Next engine source tree
+- [NXDRIVE-1148](https://jira.nuxeo.com/browse/NXDRIVE-1148): Better handle no space left on the device
 - [NXDRIVE-1277](https://jira.nuxeo.com/browse/NXDRIVE-1277): Review objects state export
 - [NXDRIVE-1353](https://jira.nuxeo.com/browse/NXDRIVE-1353): When "invalid credentials" occurs, display a direct link to log in in the account settings
 - [NXDRIVE-1616](https://jira.nuxeo.com/browse/NXDRIVE-1616): Prevent double lock when DirectEdit'ing a document
@@ -99,6 +100,7 @@ Changes in command line arguments:
 - Removed `include_versions` keyword argument from `Remote.get_info()`
 - Added `Worker.export()`
 - Added constants.py::`BATCH_SIZE`
+- Added constants.py::`NO_SPACE_ERRORS`
 - Removed data/icons/loader.gif
 - Removed data/icons/overlay/win32/
 - Deleted engine/next

--- a/nxdrive/constants.py
+++ b/nxdrive/constants.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import errno
 from enum import Enum
 from pathlib import Path
 from sys import platform
@@ -29,6 +30,19 @@ TOKEN_PERMISSION = "ReadWrite"
 
 # The registry key from the HKCU hive where to look for local configuration on Windows
 CONFIG_REGISTRY_KEY = "Software\\Nuxeo\\Drive"
+
+# OSError indicating a lack of disk space
+# >>> import errno, os
+# >>> for no, label in sorted(errno.errorcode.items()):
+# >>>     print(f"{label} (n°{no}): {os.strerror(no)}")
+NO_SPACE_ERRORS = {
+    errno.EDQUOT,  # Disk quota exceeded
+    errno.EFBIG,  # File too large
+    errno.ENOMEM,  # Cannot allocate memory
+    errno.ENOSPC,  # No space left on device
+    errno.ENOBUFS,  # No buffer space available
+    errno.ERANGE,  # Result too large
+}
 
 
 class DelAction(Enum):

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -749,6 +749,7 @@ class Application(QApplication):
             self._handle_notification_action
         )
         self.manager.updater.updateAvailable.connect(self._update_notification)
+        self.manager.updater.noSpaceLeftOnDevice.connect(self._no_space_left)
 
         if not self.manager.get_engines():
             self.show_settings()

--- a/nxdrive/manager.py
+++ b/nxdrive/manager.py
@@ -15,7 +15,12 @@ from . import __version__
 from .autolocker import ProcessAutoLockerWorker
 from .client.local_client import LocalClient
 from .client.proxy import get_proxy, load_proxy, save_proxy, validate_proxy
-from .constants import APP_NAME, STARTUP_PAGE_CONNECTION_TIMEOUT, DelAction
+from .constants import (
+    APP_NAME,
+    NO_SPACE_ERRORS,
+    STARTUP_PAGE_CONNECTION_TIMEOUT,
+    DelAction,
+)
 from .engine.dao.sqlite import ManagerDAO
 from .engine.engine import Engine
 from .exceptions import (
@@ -381,10 +386,14 @@ class Manager(QObject):
         log.info(f"Launching editor on {file_path!r}")
         try:
             self.osi.open_local_file(file_path)
+        except OSError as exc:
+            if exc.errno in NO_SPACE_ERRORS:
+                log.warning("Cannot open local file, disk space needed", exc_info=True)
+                raise
+            log.exception(f"[OS] Failed to find an editor for {file_path!r}")
         except Exception:
             # Log the exception now, will see later if we need to adapt
             log.exception(f"Failed to find an editor for {file_path!r}")
-            return
 
     @property
     def device_id(self) -> str:

--- a/nxdrive/osi/windows/windows.py
+++ b/nxdrive/osi/windows/windows.py
@@ -216,7 +216,7 @@ class WindowsIntegration(AbstractOSIntegration):
             shortcut.IconLocation = str(path)
             shortcut.save()
         except Exception:
-            log.warning(f"Could not create the favorite for {path!r}", exc_info=1)
+            log.warning(f"Could not create the favorite for {path!r}", exc_info=True)
         else:
             log.info(f"Registered new favorite in Explorer for {path!r}")
 


### PR DESCRIPTION
Introduced `NO_SPACE_ERRORS` to handle different kind of disk space related errors.

Different scenarii:

* On database backup: log a warning
* On database restore: raise a fatal error
* On upgrade: alert the user
* On local file opening: raise a fatal error
* Anytime while syncing: alert the user and pause the sync