### PR TITLE
NXDRIVE-1665: Ensure coherent response of ScrollDescendants

### DIFF
--- a/docs/changes/4.1.3.md
+++ b/docs/changes/4.1.3.md
@@ -36,6 +36,7 @@ Changes in command line arguments:
 - [NXDRIVE-1663](https://jira.nuxeo.com/browse/NXDRIVE-1663): [Windows] Lower logging level of `WindowsIntegration._create_shortcut()`
 - [NXDRIVE-1664](https://jira.nuxeo.com/browse/NXDRIVE-1664): Add OS and Python versions to Sentry events
 - [NXDRIVE-1665](https://jira.nuxeo.com/browse/NXDRIVE-1665): Ensure coherent response of ScrollDescendants
+- [NXDRIVE-1667](https://jira.nuxeo.com/browse/NXDRIVE-1667): Filter out any error in `get_opened_files()`
 
 ## GUI
 

--- a/docs/changes/4.1.3.md
+++ b/docs/changes/4.1.3.md
@@ -35,6 +35,7 @@ Changes in command line arguments:
 - [NXDRIVE-1662](https://jira.nuxeo.com/browse/NXDRIVE-1662): [macOS] Handle `NSRangeException` while fetching opened documents in Adobe
 - [NXDRIVE-1663](https://jira.nuxeo.com/browse/NXDRIVE-1663): [Windows] Lower logging level of `WindowsIntegration._create_shortcut()`
 - [NXDRIVE-1664](https://jira.nuxeo.com/browse/NXDRIVE-1664): Add OS and Python versions to Sentry events
+- [NXDRIVE-1665](https://jira.nuxeo.com/browse/NXDRIVE-1665): Ensure coherent response of ScrollDescendants
 
 ## GUI
 
@@ -106,6 +107,7 @@ Changes in command line arguments:
 - Removed data/icons/overlay/win32/
 - Deleted engine/next
 - Added exceptions.py::`DocumentAlreadyLocked`
+- Added exceptions.py::`ScrollDescendantsError`
 - Moved gui/api.py::`get_date_from_sqlite()` to utils.py
 - Moved gui/api.py::`get_timestamp_from_date()` to utils.py
 - Added gui/folders_treeview.py::`ContentLoader`

--- a/docs/changes/4.1.3.md
+++ b/docs/changes/4.1.3.md
@@ -37,6 +37,7 @@ Changes in command line arguments:
 - [NXDRIVE-1664](https://jira.nuxeo.com/browse/NXDRIVE-1664): Add OS and Python versions to Sentry events
 - [NXDRIVE-1665](https://jira.nuxeo.com/browse/NXDRIVE-1665): Ensure coherent response of ScrollDescendants
 - [NXDRIVE-1667](https://jira.nuxeo.com/browse/NXDRIVE-1667): Filter out any error in `get_opened_files()`
+- [NXDRIVE-1668](https://jira.nuxeo.com/browse/NXDRIVE-1668): Handle `TrashPermissionError` when moving a file to the trash
 
 ## GUI
 

--- a/nxdrive/autolocker.py
+++ b/nxdrive/autolocker.py
@@ -155,9 +155,9 @@ def get_open_files() -> Iterator[Item]:
     """
 
     for proc in psutil.process_iter():
-        with suppress(psutil.Error, OSError, MemoryError):
+        with suppress(Exception):
             for handler in proc.open_files():
-                with suppress(PermissionError):
+                with suppress(Exception):
                     yield proc.pid, Path(handler.path)
 
     yield from get_other_opened_files()

--- a/nxdrive/client/local_client.py
+++ b/nxdrive/client/local_client.py
@@ -17,6 +17,7 @@ from time import mktime, strptime
 from typing import Any, List, Optional, Tuple, Union
 
 from send2trash import send2trash
+from send2trash.exceptions import TrashPermissionError
 
 from nuxeo.utils import get_digest_algorithm, get_digest_hash
 
@@ -574,6 +575,11 @@ FolderType=Generic
         locker = self.unlock_ref(os_path, is_abs=True)
         try:
             send2trash(str(os_path))
+        except TrashPermissionError:
+            log.warning(
+                f"Trash not possible, deleting permanently {os_path!r}", exc_info=True
+            )
+            self.delete_final(ref)
         except OSError as exc:
             log.warning(f"Cannot trash {os_path!r}")
             with suppress(Exception):

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -28,7 +28,7 @@ from ..constants import (
     BATCH_SIZE,
 )
 from ..engine.activity import Action, FileAction
-from ..exceptions import Forbidden, NotFound
+from ..exceptions import Forbidden, NotFound, ScrollDescendantsError
 from ..objects import NuxeoDocumentInfo, RemoteFileInfo
 from ..options import Options
 from ..utils import get_device, lock_path, unlock_path, version_le
@@ -360,6 +360,9 @@ class Remote(Nuxeo):
             scrollId=scroll_id,
             batchSize=batch_size,
         )
+        if not isinstance(res, dict) or not res:
+            raise ScrollDescendantsError(res)
+
         return {
             "scroll_id": res["scrollId"],
             "descendants": [

--- a/nxdrive/exceptions.py
+++ b/nxdrive/exceptions.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from typing import Any
 
 
 class DriveError(Exception):
@@ -101,6 +102,19 @@ class RootAlreadyBindWithDifferentAccount(DriveError):
     def __init__(self, username: str, url: str) -> None:
         self.username = username
         self.url = url
+
+
+class ScrollDescendantsError(DriveError):
+    """ Rasied when NuxeoDrive.ScrollDescendants returns something we cannot work with. """
+
+    def __init__(self, response: Any) -> None:
+        self.response = response
+
+    def __repr__(self) -> str:
+        return f"ScrollDescendants returned a bad value: {self.response!r}"
+
+    def __str__(self) -> str:
+        return repr(self)
 
 
 class StartupPageConnectionError(DriveError):

--- a/tests/old_functional/test_remote_client.py
+++ b/tests/old_functional/test_remote_client.py
@@ -150,12 +150,9 @@ class TestRemoteFileSystemClient(OneUserTest):
 
         # Check workspace descendants in one breath, ordered by remote path
         scroll_res = remote.scroll_descendants(self.workspace_id, None)
-        assert scroll_res is not None
-        assert scroll_res.get("scroll_id") is not None
-        descendants = sorted(
-            scroll_res.get("descendants"), key=operator.attrgetter("name")
-        )
-        assert descendants is not None
+        assert isinstance(scroll_res, dict)
+        assert "scroll_id" in scroll_res
+        descendants = sorted(scroll_res["descendants"], key=operator.attrgetter("name"))
         assert len(descendants) == 4
 
         # File 1.txt
@@ -182,11 +179,9 @@ class TestRemoteFileSystemClient(OneUserTest):
             scroll_res = remote.scroll_descendants(
                 self.workspace_id, scroll_id=scroll_id, batch_size=2
             )
-            assert scroll_res is not None
-            scroll_id = scroll_res.get("scroll_id")
-            assert scroll_id is not None
-            partial_descendants = scroll_res.get("descendants")
-            assert partial_descendants is not None
+            assert isinstance(scroll_res, dict)
+            scroll_id = scroll_res["scroll_id"]
+            partial_descendants = scroll_res["descendants"]
             if not partial_descendants:
                 break
             descendants.extend(partial_descendants)


### PR DESCRIPTION
Also:
* remove usage of lambdas for `operator.attrgetter()`
* use `time.monotonic()` instead of `datetime.datetime.now()`