### PR TITLE
NXDRIVE-1682: Make the updater more robust against inappropriate server response

### DIFF
--- a/docs/changes/4.1.3.md
+++ b/docs/changes/4.1.3.md
@@ -42,6 +42,7 @@ Changes in command line arguments:
 - [NXDRIVE-1667](https://jira.nuxeo.com/browse/NXDRIVE-1667): Filter out any error in `get_opened_files()`
 - [NXDRIVE-1668](https://jira.nuxeo.com/browse/NXDRIVE-1668): Handle `TrashPermissionError` when moving a file to the trash
 - [NXDRIVE-1677](https://jira.nuxeo.com/browse/NXDRIVE-1677): [Windows] Copy-paste and rename a local file while Drive is running does not work
+- [NXDRIVE-1682](https://jira.nuxeo.com/browse/NXDRIVE-1682): Make the updater more robust against inappropriate server response
 
 ## GUI
 

--- a/nxdrive/updater/base.py
+++ b/nxdrive/updater/base.py
@@ -203,6 +203,8 @@ class BaseUpdater(PollWorker):
         except yaml.YAMLError as exc:
             raise UpdateError(f"Parsing error: {exc}")
         else:
+            if not isinstance(versions, dict):
+                versions = {}
             self.versions = versions
 
     def _get_update_status(self) -> None:

--- a/nxdrive/updater/utils.py
+++ b/nxdrive/updater/utils.py
@@ -106,6 +106,12 @@ def get_update_status(
 ) -> Tuple[str, str]:
     """Given a Drive version, determine the definitive status of the application."""
 
+    if not isinstance(versions, dict):
+        log.warning(
+            f"versions has invalid type: {type(versions).__name__}, dict required"
+        )
+        return "", ""
+
     if current_version not in versions:
         log.info(
             "Unknown version: this is the case when the current packaged application "

--- a/tests/integration/windows/utils.py
+++ b/tests/integration/windows/utils.py
@@ -1,7 +1,6 @@
 from logging import getLogger
 from time import sleep
 
-import win32clipboard
 from nxdrive.constants import APP_NAME
 
 
@@ -10,6 +9,10 @@ log = getLogger(__name__)
 
 def copy_clipboard() -> str:
     """Get content of the clip board."""
+    # Use the import there to prevent pytest --last-failed to crash
+    # when running on non Windows platforms
+    import win32clipboard
+
     win32clipboard.OpenClipboard()
     details = win32clipboard.GetClipboardData(win32clipboard.CF_UNICODETEXT)
     win32clipboard.CloseClipboard()

--- a/tests/unit/test_updater.py
+++ b/tests/unit/test_updater.py
@@ -89,3 +89,12 @@ def test_get_update_status(current, server, nature, action_required, new):
     action, version = get_update_status(current, VERSIONS, nature, server, Login.NEW)
     assert action == action_required
     assert version == new
+
+
+def test_get_update_status_versions_is_none():
+    """BaseUpdater.versions may be set to None, before NXDRIVE-1682."""
+    # No version
+    current, server, nature, action_required, new = "3.1.2", "", "release", "", ""
+    action, version = get_update_status(current, None, nature, server, Login.NONE)
+    assert action == action_required
+    assert version == new


### PR DESCRIPTION
Also fix `pytest --last-failed` trying to import Windows module on non Windows OS.