### PR TITLE
NXDRIVE-695: File is not deleted on the server when the parent folder is renamed, while offline

### DIFF
--- a/nxdrive/engine/blacklist_queue.py
+++ b/nxdrive/engine/blacklist_queue.py
@@ -14,10 +14,10 @@ class BlacklistItem:
         self._item = item
         self._interval = next_try
 
-        self._next_try = self._interval + time.monotonic()
+        self._next_try = self._interval + int(time.monotonic())
         self.count = 1
 
-    def check(self, cur_time: float) -> bool:
+    def check(self, cur_time: int) -> bool:
         return cur_time > self._next_try
 
     def get(self):
@@ -38,7 +38,7 @@ class BlacklistQueue:
             self._queue[item.uid] = item
 
     def get(self) -> Generator[BlacklistItem, None, None]:
-        cur_time = time.monotonic()
+        cur_time = int(time.monotonic())
         with self._lock:
             for item in self._queue.copy().values():
                 if item.check(cur_time):

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -324,6 +324,7 @@ class Engine(QObject):
         if not doc_pair:
             log.info(f"Unable to delete non-existant doc {path}")
             return
+
         if mode is DelAction.DEL_SERVER:
             # Delete on server
             doc_pair.update_state("deleted", doc_pair.remote_state)

--- a/nxdrive/engine/watcher/local_watcher.py
+++ b/nxdrive/engine/watcher/local_watcher.py
@@ -690,7 +690,7 @@ class LocalWatcher(EngineWorker):
 
         ignore, _ = is_generated_tmp_file(dest_filename)
         if ignore:
-            log.info(f"Ignoring generated temporary file: {evt.dest_path!r}")
+            log.info(f"Ignoring file: {evt.dest_path!r}")
             return
 
         dao, client = self._dao, self.local
@@ -699,7 +699,7 @@ class LocalWatcher(EngineWorker):
 
         pair = dao.get_state_from_local(rel_path)
         remote_ref = client.get_remote_id(rel_path)
-        if pair is not None and pair.remote_ref == remote_ref:
+        if pair and pair.remote_ref == remote_ref:
             local_info = client.try_get_info(rel_path)
             if local_info:
                 digest = local_info.get_digest()
@@ -738,7 +738,7 @@ class LocalWatcher(EngineWorker):
             return
 
         old_local_path = None
-        rel_parent_path = client.get_path(src_path.parent) or ROOT
+        rel_parent_path = client.get_path(src_path.parent)
 
         # Ignore inner movement
         versioned = False
@@ -1059,10 +1059,8 @@ class LocalWatcher(EngineWorker):
             # the creation has been catched by scan
             # As Windows send a delete / create event for reparent
             local_info = client.try_get_info(rel_path)
-            if local_info is None:
-                log.debug(
-                    f"Event on a disappeared file: {evt!r} {rel_path!r} {src_path.name!r}"
-                )
+            if not local_info:
+                log.debug(f"Event on a disappeared file: {evt!r}")
                 return
 
             # This might be a move but Windows don't emit this event...

--- a/nxdrive/engine/watcher/local_watcher.py
+++ b/nxdrive/engine/watcher/local_watcher.py
@@ -19,7 +19,7 @@ from watchdog.observers import Observer
 from ..activity import tooltip
 from ..workers import EngineWorker, Worker
 from ...client.local_client import FileInfo
-from ...constants import DOWNLOAD_TMP_FILE_SUFFIX, MAC, ROOT, WINDOWS
+from ...constants import DOWNLOAD_TMP_FILE_SUFFIX, LINUX, MAC, ROOT, WINDOWS
 from ...exceptions import ThreadInterrupt
 from ...objects import DocPair, Metrics
 from ...options import Options
@@ -766,8 +766,15 @@ class LocalWatcher(EngineWorker):
 
         dao.update_local_state(doc_pair, local_info, versioned=versioned)
 
-        # Update local paths of all children
+        # Reflect local path changes of all impacted children in the database
         if doc_pair.folderish:
+            if LINUX:
+                # This does not make it on GNU/Linux, and it would break
+                # test_move_and_copy_paste_folder_original_location_from_child_stopped().
+                # The call to dao.replace_local_paths() is revelant on macOS and Windows only.
+                # See NXDRIVE-1690 for more informations.
+                return
+
             dao.replace_local_paths(doc_pair.local_path, local_info.path)
 
         if (

--- a/nxdrive/engine/watcher/remote_watcher.py
+++ b/nxdrive/engine/watcher/remote_watcher.py
@@ -831,20 +831,11 @@ class RemoteWatcher(EngineWorker):
                                 new_info.lock_created,
                                 new_info.can_scroll_descendants,
                             )
-                        # Perform a regular document update on a document
-                        # that has been updated, renamed or moved
-                        log.info(
-                            f"Refreshing remote state info for "
-                            f"doc_pair={doc_pair_repr!r}, "
-                            f"event_id={event_id!r}, "
-                            f"new_info={new_info!r} "
-                            f"(force_recursion={event_id == 'securityUpdated'})"
-                        )
 
                         # Force remote state update in case of a
                         # locked / unlocked event since lock info is not
                         # persisted, so not part of the dirty check
-                        lock_update = event_id in {"documentLocked", "documentUnlocked"}
+                        lock_update = event_id in ("documentLocked", "documentUnlocked")
 
                         # Perform a regular document update on a document
                         # that has been updated, renamed or moved

--- a/tests/old_functional/test_synchronization_suspend.py
+++ b/tests/old_functional/test_synchronization_suspend.py
@@ -1,7 +1,8 @@
 # coding: utf-8
+import pytest
+from nxdrive.constants import LINUX, WINDOWS
 
-from nxdrive.constants import WINDOWS
-from .common import OneUserTest
+from .common import OneUserTest, SYNC_ROOT_FAC_ID
 
 
 class TestSynchronizationSuspend(OneUserTest):
@@ -95,3 +96,62 @@ class TestSynchronizationSuspend(OneUserTest):
         # Should not try to sync therefor it should not timeout
         self.wait_sync(wait_for_async=True)
         assert len(remote.get_children_info(self.workspace)) == 4
+
+    @pytest.mark.xfail(LINUX, reason="NXDRIVE-1690", strict=True)
+    def test_folder_renaming_while_offline(self):
+        """
+        Scenario:
+            - create a folder with a subfolder and a file, on the server
+            - launch Drive
+            - wait for sync completion
+            - pause Drive
+            - locally rename the parent folder
+            - locally rename the sub folder
+            - locally relete the file
+            - resume Drive
+
+        Result before NXDRIVE-695:
+            - sub folder is renamed on the server
+            - the deleted file is not removed on the server (incorrect)
+        """
+
+        local = self.local_1
+        remote = self.remote_1
+        engine = self.engine_1
+
+        # Create a folder with a subfolder and a file on the server
+        folder = remote.make_folder(f"{SYNC_ROOT_FAC_ID}{self.workspace}", "folder").uid
+        subfolder = remote.make_folder(folder, "subfolder").uid
+        remote.make_file(subfolder, "file.txt", content=b"42")
+
+        # Start the sync
+        engine.start()
+        self.wait_sync(wait_for_async=True)
+
+        # Checks
+        assert remote.exists("/folder/subfolder/file.txt")
+        assert local.exists("/folder/subfolder/file.txt")
+
+        # Suspend the sync
+        engine.suspend()
+        assert engine.is_paused()
+
+        # Rename the parent folder and its subfolder; delete the file
+        local.rename("/folder", "folder-renamed")
+        local.rename("/folder-renamed/subfolder", "subfolder-renamed")
+        local.delete("/folder-renamed/subfolder-renamed/file.txt")
+
+        # Resume the sync
+        engine.resume()
+        assert not engine.is_paused()
+        self.wait_sync()
+
+        # Local checks
+        assert local.exists("/folder-renamed/subfolder-renamed")
+        assert not local.exists("/folder-renamed/subfolder-renamed/file.txt")
+        assert not local.exists("/folder")
+
+        # Remote checks
+        assert remote.exists("/folder-renamed/subfolder-renamed")
+        assert not remote.exists("/folder-renamed/subfolder-renamed/file.txt")
+        assert not remote.exists("/folder")

--- a/tests/old_functional/test_synchronization_suspend.py
+++ b/tests/old_functional/test_synchronization_suspend.py
@@ -107,7 +107,7 @@ class TestSynchronizationSuspend(OneUserTest):
             - pause Drive
             - locally rename the parent folder
             - locally rename the sub folder
-            - locally relete the file
+            - locally delete the file
             - resume Drive
 
         Result before NXDRIVE-695:

--- a/tests/unit/test_blacklist_queue.py
+++ b/tests/unit/test_blacklist_queue.py
@@ -28,12 +28,12 @@ def repush(
 def test_delay():
     sleep_time = 3
 
-    # Push two items with a delay of 2s
-    queue = BlacklistQueue(delay=2)
+    # Push two items with a delay of 1s
+    queue = BlacklistQueue(delay=1)
     queue.push("1", "Item1")
     queue.push("2", "Item2")
 
-    # Verify no item is returned back before 2s
+    # Verify no item is returned back before 1s
     assert not list(queue.get())
     sleep(sleep_time)
 
@@ -51,7 +51,7 @@ def test_delay():
     assert not list(queue.get())
     sleep(sleep_time)
 
-    # We should get the repushed item after 2s wait
+    # We should get the repushed item after 1s wait
     item = next(queue.get())
     assert item.get() == "Item2"
     assert item.uid == "2"

--- a/tests/unit/test_blacklist_queue.py
+++ b/tests/unit/test_blacklist_queue.py
@@ -6,7 +6,7 @@ from nxdrive.engine.blacklist_queue import BlacklistItem, BlacklistQueue
 
 def increase(item: BlacklistItem, next_try: int = None) -> None:
     item.count += 1
-    cur_time = monotonic()
+    cur_time = int(monotonic())
     if next_try is not None:
         item._next_try = next_try + cur_time
     else:


### PR DESCRIPTION
This fixes the issue on macOS and Windows.

On GNU/Linux, the deleted event is against the old `/folder/subfolder/file.txt` instead of `/folder-renamed/subfolder-renamed/file.txt`.

This is a corner case and I have no idea how to fix it. So the fix is postponed on GNU/Linux. To follow with [NXDRIVE-1690](https://jira.nuxeo.com/browse/NXDRIVE-1690).