### PR TITLE
NXDRIVE-1684: Display the file size in the systray

### DIFF
--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -9,7 +9,7 @@ Release date: `2019-xx-xx`
 
 ## GUI
 
-- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-): ...
+- [NXDRIVE-1684](https://jira.nuxeo.com/browse/NXDRIVE-1684): Display the file size in the systray
 
 ## Packaging / Build
 
@@ -22,3 +22,5 @@ Release date: `2019-xx-xx`
 ## Minor Changes
 
 ## Technical Changes
+
+- Added utils.py::`sizeof_fmt()`

--- a/nxdrive/data/qml/SystrayFile.qml
+++ b/nxdrive/data/qml/SystrayFile.qml
@@ -37,6 +37,11 @@ Rectangle {
                         pointSize: 10
                         color: mediumGray
                     }
+                    ScaledText {
+                        text: size
+                        pointSize: 10
+                        color: mediumGray
+                    }
                 }
             }
 

--- a/nxdrive/gui/view.py
+++ b/nxdrive/gui/view.py
@@ -12,7 +12,7 @@ from PyQt5.QtCore import (
     pyqtSlot,
 )
 
-from ..utils import force_decode
+from ..utils import force_decode, sizeof_fmt
 
 if TYPE_CHECKING:
     from .application import Application  # noqa
@@ -236,6 +236,7 @@ class FileModel(QAbstractListModel):
     REMOTE_NAME = Qt.UserRole + 11
     REMOTE_REF = Qt.UserRole + 12
     STATE = Qt.UserRole + 13
+    SIZE = Qt.UserRole + 14
 
     def __init__(self, parent: QObject = None) -> None:
         super(FileModel, self).__init__(parent)
@@ -254,6 +255,7 @@ class FileModel(QAbstractListModel):
             self.REMOTE_NAME: b"remote_name",
             self.REMOTE_REF: b"remote_ref",
             self.STATE: b"state",
+            self.SIZE: b"size",
         }
 
     def roleNames(self) -> Dict[int, bytes]:
@@ -274,6 +276,11 @@ class FileModel(QAbstractListModel):
             return str(row["local_parent_path"])
         elif role == self.LOCAL_PATH:
             return str(row["local_path"])
+        elif role == self.SIZE:
+            size = row["size"]
+            if size == 0:
+                return ""
+            return f"({sizeof_fmt(size)})"
         return row[self.names[role].decode()]
 
     def setData(self, index: QModelIndex, value: Any, role: int = None) -> None:

--- a/nxdrive/objects.py
+++ b/nxdrive/objects.py
@@ -350,6 +350,7 @@ class DocPair(Row):
             "remote_ref": self.remote_ref,
             "folderish": self.folderish,
             "id": self.id,
+            "size": self.size,
         }
 
         if self.last_local_updated or "" > self.last_remote_updated or "":

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -62,6 +62,7 @@ __all__ = (
     "safe_filename",
     "safe_long_path",
     "set_path_readonly",
+    "sizeof_fmt",
     "short_name",
     "simplify_url",
     "unlock_path",
@@ -925,6 +926,32 @@ def lock_path(path: Path, locker: int) -> None:
 
     if locker & 2 == 2:
         set_path_readonly(path.parent)
+
+
+def sizeof_fmt(num: int, suffix: str = "o") -> str:
+    """
+    Human readable version of file size.
+    Supports:
+        - all currently known binary prefixes (https://en.wikipedia.org/wiki/Binary_prefix)
+        - negative and positive numbers
+        - numbers larger than 1,000 Yobibytes
+        - arbitrary units
+
+    Examples:
+
+        >>> sizeof_fmt(168963795964)
+        "157.4 Gio"
+        >>> sizeof_fmt(168963795964, suffix="B")
+        "157.4 GiB"
+
+    Source: https://stackoverflow.com/a/1094933/1117028
+    """
+    val = float(num)
+    for unit in ("", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"):
+        if abs(val) < 1024.0:
+            return f"{val:3.1f} {unit}{suffix}"
+        val /= 1024.0
+    return f"{val:.1f} Yi{suffix}"
 
 
 def short_name(name: Union[bytes, str]) -> str:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 import os
 import re
+from math import pow
 from unittest.mock import patch
 
 import pytest
@@ -329,6 +330,34 @@ def test_simplify_url(url, result):
 )
 def test_safe_filename(invalid, valid):
     assert nxdrive.utils.safe_filename(invalid) == valid
+
+
+@pytest.mark.parametrize(
+    "size, result",
+    [
+        (0, "0.0 o"),
+        (1, "1.0 o"),
+        (-1024, "-1.0 Kio"),
+        (1024, "1.0 Kio"),
+        (1024 * 1024, "1.0 Mio"),
+        (pow(1024, 2), "1.0 Mio"),
+        (pow(1024, 3), "1.0 Gio"),
+        (pow(1024, 4), "1.0 Tio"),
+        (pow(1024, 5), "1.0 Pio"),
+        (pow(1024, 6), "1.0 Eio"),
+        (pow(1024, 7), "1.0 Zio"),
+        (pow(1024, 8), "1.0 Yio"),
+        (pow(1024, 9), "1024.0 Yio"),
+        (pow(1024, 10), "1048576.0 Yio"),
+        (168963795964, "157.4 Gio"),
+    ],
+)
+def test_sizeof_fmt(size, result):
+    assert nxdrive.utils.sizeof_fmt(size) == result
+
+
+def test_sizeof_fmt_arg():
+    assert nxdrive.utils.sizeof_fmt(168963795964, suffix="B") == "157.4 GiB"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Introduced `sizeof_fmt()` to pretty display the file size.