### PR TITLE
NXDRIVE-1671: Only cleanup well-formed folders in DirectEdit directory

### DIFF
--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -7,6 +7,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-695](https://jira.nuxeo.com/browse/NXDRIVE-695): File is not deleted on the server when the parent folder is renamed, while offline
 - [NXDRIVE-1392](https://jira.nuxeo.com/browse/NXDRIVE-1392): Processor loops when a file is not found and locally created
 - [NXDRIVE-1660](https://jira.nuxeo.com/browse/NXDRIVE-1660): Cannot rename root at the top level folder
+- [NXDRIVE-1671](https://jira.nuxeo.com/browse/NXDRIVE-1671): Only cleanup well-formed folders in DirectEdit directory
 
 ## GUI
 
@@ -24,8 +25,9 @@ Release date: `2019-xx-xx`
 
 ## Technical Changes
 
-- Added utils.py::`sizeof_fmt()`
 - Added `BlackListItem.increase()`
 - Added `BlackListItem.uid`
 - Removed `BlackListItem.get()`. Use `name` attribute instead.
 - Added `BlacklistQueue.repush()`
+- Added utils.py::`is_valid_uid()`
+- Added utils.py::`sizeof_fmt()`

--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -29,5 +29,4 @@ Release date: `2019-xx-xx`
 - Added `BlackListItem.uid`
 - Removed `BlackListItem.get()`. Use `name` attribute instead.
 - Added `BlacklistQueue.repush()`
-- Added utils.py::`is_valid_uid()`
 - Added utils.py::`sizeof_fmt()`

--- a/nxdrive/constants.py
+++ b/nxdrive/constants.py
@@ -30,6 +30,9 @@ UNACCESSIBLE_HASH = "TO_COMPUTE"
 
 TOKEN_PERMISSION = "ReadWrite"
 
+# Document's UID and token regexp
+DOC_UID_REG = "[0-f]{8}-[0-f]{4}-[0-f]{4}-[0-f]{4}-[0-f]{12}"
+
 # The registry key from the HKCU hive where to look for local configuration on Windows
 CONFIG_REGISTRY_KEY = "Software\\Nuxeo\\Drive"
 

--- a/nxdrive/direct_edit.py
+++ b/nxdrive/direct_edit.py
@@ -44,6 +44,7 @@ from .objects import DirectEditDetails, Metrics, NuxeoDocumentInfo
 from .utils import (
     current_milli_time,
     force_decode,
+    is_valid_uid,
     normalize_event_filename,
     parse_protocol_url,
     safe_os_filename,
@@ -170,12 +171,25 @@ class DirectEdit(Worker):
             self._folder.mkdir(exist_ok=True)
             return
 
-        def purge(path):
-            shutil.rmtree(self.local.abspath(path), ignore_errors=True)
+        def purge(rel_path: Path) -> None:
+            """Helper to skip errors while deleting a folder and its content."""
+            path = self.local.abspath(rel_path)
+            log.debug(f"Removing {path!r}")
+            shutil.rmtree(path, ignore_errors=True)
 
         log.info("Cleanup DirectEdit folder")
 
         for child in self.local.get_children_info(ROOT):
+            # We need a folder and its name must be a valid UID
+            if not child.folderish:
+                log.debug(f"Skipping clean-up of {child.path!r} (not a folder)")
+                continue
+
+            # We also need a valid folder name (it is a document's UID)
+            if not is_valid_uid(child.name):
+                log.debug(f"Skipping clean-up of {child.path!r} (invalid folder name)")
+                continue
+
             children = self.local.get_children_info(child.path)
             if not children:
                 purge(child.path)
@@ -204,7 +218,7 @@ class DirectEdit(Worker):
                 log.exception("Unhandled clean-up error")
                 continue
 
-            # Place for handle reopened of interrupted Edit
+            # Place for handle reopened of interrupted DirectEdit
             purge(child.path)
 
     def __get_engine(self, url: str, user: str = None) -> Optional["Engine"]:

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -534,17 +534,19 @@ def safe_filename(
     return re.sub(pattern, replacement, name)
 
 
-def safe_os_filename(name: str) -> str:
+def safe_os_filename(name: str, pattern: Pattern = re.compile(r"([/:])")) -> str:
     """
     Replace characters that are forbidden in file or folder names by the OS.
 
-    On Windows, they are  " | * / : < > ? \\
-    On Unix, they are  / :
+    On Windows, they are:
+        " | * / : < > ? \\
+    On Unix, they are:
+        / :
     """
     if WINDOWS:
         return safe_filename(name)
     else:
-        return safe_filename(name, pattern=re.compile(r"([/:])"))
+        return safe_filename(name, pattern=pattern)
 
 
 def safe_long_path(path: Path) -> Path:

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -52,7 +52,6 @@ __all__ = (
     "guess_server_url",
     "if_frozen",
     "is_generated_tmp_file",
-    "is_valid_uid",
     "lock_path",
     "normalize_event_filename",
     "normalized_path",
@@ -337,15 +336,6 @@ def is_generated_tmp_file(name: str) -> Tuple[bool, Optional[bool]]:
         return ignore, do_not_delay
 
     return do_not_ignore, no_delay_effect
-
-
-def is_valid_uid(uid: str, pattern: Pattern = re.compile(f"^{DOC_UID_REG}$")) -> bool:
-    """Return True if the given *uid* is a valid document UID."""
-    # Prevent TypeError when given uid is None
-    if not uid:
-        return False
-
-    return bool(pattern.match(uid))
 
 
 def version_compare(x: str, y: str) -> int:

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -23,7 +23,7 @@ from typing import (
 )
 from urllib.parse import urlsplit, urlunsplit
 
-from .constants import APP_NAME, MAC, WINDOWS
+from .constants import APP_NAME, DOC_UID_REG, MAC, WINDOWS
 from .exceptions import InvalidSSLCertificate
 from .options import Options
 
@@ -52,6 +52,7 @@ __all__ = (
     "guess_server_url",
     "if_frozen",
     "is_generated_tmp_file",
+    "is_valid_uid",
     "lock_path",
     "normalize_event_filename",
     "normalized_path",
@@ -336,6 +337,15 @@ def is_generated_tmp_file(name: str) -> Tuple[bool, Optional[bool]]:
         return ignore, do_not_delay
 
     return do_not_ignore, no_delay_effect
+
+
+def is_valid_uid(uid: str, pattern: Pattern = re.compile(f"^{DOC_UID_REG}$")) -> bool:
+    """Return True if the given *uid* is a valid document UID."""
+    # Prevent TypeError when given uid is None
+    if not uid:
+        return False
+
+    return bool(pattern.match(uid))
 
 
 def version_compare(x: str, y: str) -> int:
@@ -824,7 +834,7 @@ def parse_protocol_url(url_string: str) -> Optional[Dict[str, str]]:
         # Event to acquire the login token from the server
         (
             r"nxdrive://(?P<cmd>token)/"
-            r"(?P<token>[0-F]{8}-[0-F]{4}-[0-F]{4}-[0-F]{4}-[0-F]{12})/"
+            fr"(?P<token>{DOC_UID_REG})/"
             r"user/(?P<username>.*)"
         ),
     )

--- a/tests/functional/test_direct_edit.py
+++ b/tests/functional/test_direct_edit.py
@@ -1,13 +1,27 @@
 import shutil
+from collections import namedtuple
+from pathlib import Path
 
 import pytest
+
+from nxdrive.constants import ROOT
+from nxdrive.engine.engine import Engine, ServerBindingSettings
+
+
+class MockUrlTestEngine(Engine):
+    def __init__(self, url: str, user: str):
+        self._url = url
+        self._user = user
+        self._stopped = True
+        self._invalid_credentials = False
+
+    def get_binder(self):
+        return ServerBindingSettings(self._url, None, self._user, ROOT, True)
 
 
 @pytest.fixture()
 def direct_edit(manager_factory):
-    manager, _ = manager_factory()
-
-    with manager:
+    with manager_factory(with_engine=False) as manager:
         manager.direct_edit._folder.mkdir()
         yield manager.direct_edit
 
@@ -51,3 +65,61 @@ def test_cleanup_bad_folder_name(direct_edit):
 
 def test_direct_edit_metrics(direct_edit):
     assert isinstance(direct_edit.get_metrics(), dict)
+
+
+def test_handle_url_empty(direct_edit):
+    assert not direct_edit.handle_url(None)
+    assert not direct_edit.handle_url("")
+
+
+def test_handle_url_malformed(direct_edit):
+    assert not direct_edit.handle_url("https://example.org")
+
+
+def test_send_lock_status(direct_edit):
+    Engine = namedtuple("Engine", ["local_folder", "engine", "uid", "name"])
+
+    local_path = Path("doc_id_xpath/testfile.txt")
+    direct_edit._manager._engine_definitions.insert(
+        0, Engine(Path(), None, "invalid_uid", "bla")
+    )
+    direct_edit._send_lock_status(local_path)
+
+
+def test_url_resolver(manager_factory, nuxeo_url):
+    manager, engine = manager_factory()
+
+    with manager:
+        direct_edit = manager.direct_edit
+        direct_edit._folder.mkdir()
+
+        user = engine.remote_user
+        get_engine = direct_edit._get_engine
+
+        assert get_engine(nuxeo_url, user)
+
+        manager._engine_types["NXDRIVETESTURL"] = MockUrlTestEngine
+
+        # HTTP explicit
+        manager._engines["0"] = MockUrlTestEngine("http://localhost:80/nuxeo", user)
+        assert not get_engine("http://localhost:8080/nuxeo", user=user)
+        assert get_engine("http://localhost:80/nuxeo", user=user)
+        assert get_engine("http://localhost/nuxeo/", user=user)
+
+        # HTTP implicit
+        manager._engines["0"] = MockUrlTestEngine("http://localhost/nuxeo", user)
+        assert not get_engine("http://localhost:8080/nuxeo", user=user)
+        assert get_engine("http://localhost:80/nuxeo/", user=user)
+        assert get_engine("http://localhost/nuxeo", user=user)
+
+        # HTTPS explicit
+        manager._engines["0"] = MockUrlTestEngine("https://localhost:443/nuxeo", user)
+        assert not get_engine("http://localhost:8080/nuxeo", user=user)
+        assert get_engine("https://localhost:443/nuxeo", user=user)
+        assert get_engine("https://localhost/nuxeo/", user=user)
+
+        # HTTPS implicit
+        manager._engines["0"] = MockUrlTestEngine("https://localhost/nuxeo", user)
+        assert not get_engine("http://localhost:8080/nuxeo", user=user)
+        assert get_engine("https://localhost:443/nuxeo/", user=user)
+        assert get_engine("https://localhost/nuxeo", user=user)

--- a/tests/functional/test_direct_edit.py
+++ b/tests/functional/test_direct_edit.py
@@ -1,0 +1,53 @@
+import shutil
+
+import pytest
+
+
+@pytest.fixture()
+def direct_edit(manager_factory):
+    manager, _ = manager_factory()
+
+    with manager:
+        manager.direct_edit._folder.mkdir()
+        yield manager.direct_edit
+
+
+def test_cleanup_no_local_folder(direct_edit):
+    """If local folder does not exist, it should be created."""
+
+    shutil.rmtree(direct_edit._folder)
+    assert not direct_edit._folder.is_dir()
+
+    direct_edit._cleanup()
+    assert direct_edit._folder.is_dir()
+
+
+def test_cleanup_file(direct_edit):
+    """There should be not files, but in that case, just ignore them."""
+
+    file = direct_edit._folder / "this is a file.txt"
+    file.touch()
+    file.write_text("bla" * 3)
+    assert file.is_file()
+
+    direct_edit._cleanup()
+
+    # The file should still be present as it is ignored by the clean-up
+    assert file.is_file()
+
+
+def test_cleanup_bad_folder_name(direct_edit):
+    """Subfolders must be named with valid document UID. Ignore others."""
+
+    folder = direct_edit._folder / "bad folder name"
+    folder.mkdir()
+    assert folder.is_dir()
+
+    direct_edit._cleanup()
+
+    # The folder should still be present as it is ignored by the clean-up
+    assert folder.is_dir()
+
+
+def test_direct_edit_metrics(direct_edit):
+    assert isinstance(direct_edit.get_metrics(), dict)

--- a/tests/old_functional/test_direct_edit.py
+++ b/tests/old_functional/test_direct_edit.py
@@ -147,21 +147,6 @@ class TestDirectEdit(OneUserTest, DirectEditSetup):
             doc_info = self.remote.get_info(doc_id)
             assert self.remote.get_blob(doc_info, xpath=xpath) == content
 
-    def test_binder(self):
-        engine = list(self.manager_1._engines.items())[0][1]
-        binder = engine.get_binder()
-        assert repr(binder)
-        assert not binder.server_version
-        assert not binder.password
-        assert not binder.pwd_update_required
-        assert binder.server_url
-        assert binder.username
-        assert binder.initialized
-        assert binder.local_folder
-
-        # Trigger the thread stop manually
-        self.direct_edit.stop()
-
     def test_cleanup(self):
         filename = "Mode op\xe9ratoire.txt"
         doc_id = self.remote.make_file("/", filename, content=b"Some content.")

--- a/tests/old_functional/test_direct_edit.py
+++ b/tests/old_functional/test_direct_edit.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 import time
-from collections import namedtuple
 from logging import getLogger
 from pathlib import Path
 from typing import Any, Dict
@@ -11,8 +10,7 @@ from unittest.mock import patch
 from nuxeo.exceptions import HTTPError
 from nuxeo.models import User
 
-from nxdrive.constants import ROOT
-from nxdrive.engine.engine import Engine, ServerBindingSettings
+from nxdrive.engine.engine import Engine
 from nxdrive.exceptions import (
     DocumentAlreadyLocked,
     Forbidden,
@@ -34,16 +32,6 @@ def direct_edit_is_starting(*args, **kwargs):
 
 def open_local_file(*args, **kwargs):
     log.info("Opening local file: args=%r, kwargs=%r", args, kwargs)
-
-
-class MockUrlTestEngine(Engine):
-    def __init__(self, url):
-        self._url = url
-        self._stopped = True
-        self._invalid_credentials = False
-
-    def get_binder(self):
-        return ServerBindingSettings(self._url, None, "Administrator", ROOT, True)
 
 
 class DirectEditSetup:
@@ -445,68 +433,11 @@ class TestDirectEdit(OneUserTest, DirectEditSetup):
             self.direct_edit._prepare_edit(self.nuxeo_url, doc_id)
             assert received
 
-    def test_send_lock_status(self):
-        Engine = namedtuple("Engine", ["local_folder", "engine", "uid", "name"])
-
-        local_path = Path("doc_id_xpath/testfile.txt")
-        self.direct_edit._manager._engine_definitions.insert(
-            0, Engine(Path(), None, "invalid_uid", "bla")
-        )
-        self.direct_edit._send_lock_status(local_path)
-
-    def test_url_resolver(self):
-        user = "Administrator"
-        get_engine = self.direct_edit._get_engine
-
-        assert get_engine(self.nuxeo_url, self.user_1)
-
-        self.manager_1._engine_types["NXDRIVETESTURL"] = MockUrlTestEngine
-
-        # HTTP explicit
-        self.manager_1._engines["0"] = MockUrlTestEngine("http://localhost:80/nuxeo")
-        assert not get_engine("http://localhost:8080/nuxeo", user=user)
-        assert get_engine("http://localhost:80/nuxeo", user=user)
-        assert get_engine("http://localhost/nuxeo/", user=user)
-
-        # HTTP implicit
-        self.manager_1._engines["0"] = MockUrlTestEngine("http://localhost/nuxeo")
-        assert not get_engine("http://localhost:8080/nuxeo", user=user)
-        assert get_engine("http://localhost:80/nuxeo/", user=user)
-        assert get_engine("http://localhost/nuxeo", user=user)
-
-        # HTTPS explicit
-        self.manager_1._engines["0"] = MockUrlTestEngine("https://localhost:443/nuxeo")
-        assert not get_engine("http://localhost:8080/nuxeo", user=user)
-        assert get_engine("https://localhost:443/nuxeo", user=user)
-        assert get_engine("https://localhost/nuxeo/", user=user)
-
-        # HTTPS implicit
-        self.manager_1._engines["0"] = MockUrlTestEngine("https://localhost/nuxeo")
-        assert not get_engine("http://localhost:8080/nuxeo", user=user)
-        assert get_engine("https://localhost:443/nuxeo/", user=user)
-        assert get_engine("https://localhost/nuxeo", user=user)
-
-        # Trigger the thread stop manually
-        self.direct_edit.stop()
-
     def test_self_locked_file(self):
         filename = "Mode operatoire.txt"
         doc_id = self.remote.make_file("/", filename, content=b"Some content.")
         self.remote.lock(doc_id)
         self._direct_edit_update(doc_id, filename, b"Test")
-
-    def test_handle_url_empty(self):
-        assert not self.direct_edit.handle_url(None)
-        assert not self.direct_edit.handle_url("")
-
-        # Trigger the thread stop manually
-        self.direct_edit.stop()
-
-    def test_handle_url_malformed(self):
-        assert not self.direct_edit.handle_url("https://example.org")
-
-        # Trigger the thread stop manually
-        self.direct_edit.stop()
 
     def test_url_with_spaces(self):
         scheme, host = self.nuxeo_url.split("://")

--- a/tests/old_functional/test_direct_edit.py
+++ b/tests/old_functional/test_direct_edit.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 import time
-import shutil
 from collections import namedtuple
 from logging import getLogger
 from pathlib import Path
@@ -24,7 +23,6 @@ from nxdrive.objects import NuxeoDocumentInfo
 from nxdrive.utils import safe_os_filename
 from . import LocalTest, make_tmp_file
 from .common import OneUserTest, TwoUsersTest
-from ..markers import not_windows
 from ..utils import random_png
 
 log = getLogger(__name__)
@@ -209,18 +207,8 @@ class TestDirectEdit(OneUserTest, DirectEditSetup):
             self.direct_edit._cleanup()
             assert not self.local.exists(local_path)
 
-    @not_windows(reason="Watchdog failure")
-    def test_cleanup_no_local_folder(self):
-        """"If local folder does not exist, it should be created."""
-
-        shutil.rmtree(self.direct_edit._folder)
-        assert not self.direct_edit._folder.is_dir()
-
-        self.direct_edit._cleanup()
-        assert self.direct_edit._folder.is_dir()
-
     def test_cleanup_document_not_found(self):
-        """"If a file does not exist on the server, it should be deleted locally."""
+        """If a file does not exist on the server, it should be deleted locally."""
 
         def extract_edit_info(ref: Path):
             raise NotFound()
@@ -247,12 +235,6 @@ class TestDirectEdit(OneUserTest, DirectEditSetup):
             self.direct_edit.start()
             self.wait_sync(timeout=2, fail_if_timeout=False)
             assert not self.local.exists(local_path)
-
-    def test_direct_edit_metrics(self):
-        assert isinstance(self.direct_edit.get_metrics(), dict)
-
-        # Trigger the thread stop manually
-        self.direct_edit.stop()
 
     def test_filename_encoding(self):
         filename = "Mode op\xe9ratoire.txt"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -194,20 +194,6 @@ def test_get_current_os_full():
     assert ver
 
 
-def test_is_valid_uid():
-    func = nxdrive.utils.is_valid_uid
-
-    # Valid
-    assert func("37b1502b-26ff-430f-9f20-4bd0d803191e")
-
-    # Invalid
-    assert not func("37b1502b-26ff-430f-9f20-4bd0d803191z")  # z is not hexa
-    assert not func("37b1502b-26ff-430f-9f20-4bd0d803191ee")  # 1 extra char
-    assert not func("is this a real file name.jpeg")
-    assert not func("")
-    assert not func(None)
-
-
 @pytest.mark.parametrize("hostname", BAD_HOSTNAMES)
 def test_retrieve_ssl_certificate_unknown(hostname):
     from ssl import SSLError

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -194,6 +194,20 @@ def test_get_current_os_full():
     assert ver
 
 
+def test_is_valid_uid():
+    func = nxdrive.utils.is_valid_uid
+
+    # Valid
+    assert func("37b1502b-26ff-430f-9f20-4bd0d803191e")
+
+    # Invalid
+    assert not func("37b1502b-26ff-430f-9f20-4bd0d803191z")  # z is not hexa
+    assert not func("37b1502b-26ff-430f-9f20-4bd0d803191ee")  # 1 extra char
+    assert not func("is this a real file name.jpeg")
+    assert not func("")
+    assert not func(None)
+
+
 @pytest.mark.parametrize("hostname", BAD_HOSTNAMES)
 def test_retrieve_ssl_certificate_unknown(hostname):
     from ssl import SSLError
@@ -349,7 +363,7 @@ def test_safe_filename(invalid, valid):
         (pow(1024, 8), "1.0 Yio"),
         (pow(1024, 9), "1024.0 Yio"),
         (pow(1024, 10), "1048576.0 Yio"),
-        (168963795964, "157.4 Gio"),
+        (168_963_795_964, "157.4 Gio"),
     ],
 )
 def test_sizeof_fmt(size, result):
@@ -357,7 +371,7 @@ def test_sizeof_fmt(size, result):
 
 
 def test_sizeof_fmt_arg():
-    assert nxdrive.utils.sizeof_fmt(168963795964, suffix="B") == "157.4 GiB"
+    assert nxdrive.utils.sizeof_fmt(168_963_795_964, suffix="B") == "157.4 GiB"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Alos moved tests from "old_functional" to "functional" and some clean-up.