### PR TITLE
NXDRIVE-1673: Use native dialog when Qt is unavailable (for the fatal…

### DIFF
--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -12,6 +12,7 @@ Release date: `2019-xx-xx`
 
 ## GUI
 
+- [NXDRIVE-1673](https://jira.nuxeo.com/browse/NXDRIVE-1673): Use native dialog when Qt is unavailable (for the fatal error screen only)
 - [NXDRIVE-1681](https://jira.nuxeo.com/browse/NXDRIVE-1681): Make server URL and local folder clickable in the Accounts settings
 - [NXDRIVE-1683](https://jira.nuxeo.com/browse/NXDRIVE-1683): Display a notification when DirectEdit'ing an inexistant document
 - [NXDRIVE-1684](https://jira.nuxeo.com/browse/NXDRIVE-1684): Display the file size in the systray
@@ -37,4 +38,8 @@ Release date: `2019-xx-xx`
 - Removed `BlackListItem.get()`. Use `name` attribute instead.
 - Added `BlacklistQueue.repush()`
 - Added `FileModel.ID` role
+- Moved \_\_main__.py::`check_executable_path` to fatal_error.py
+- Moved \_\_main__.py::`show_critical_error` to fatal_error.py
+- Removed \_\_main__.py::`section`
+- Added fatal_error.py
 - Added utils.py::`sizeof_fmt()`

--- a/nxdrive/__main__.py
+++ b/nxdrive/__main__.py
@@ -9,43 +9,9 @@ import sys
 from contextlib import suppress
 from typing import Any, Set
 
-from nxdrive.constants import APP_NAME, COMPANY, MAC
+from nxdrive.constants import APP_NAME
+from nxdrive.fatal_error import check_executable_path, show_critical_error
 from nxdrive.options import Options
-
-
-def check_executable_path() -> bool:
-    """ Check that the app runs from the right path, and quit if not. """
-    import re
-    import sys
-    from pathlib import Path
-
-    exe_path = sys.executable
-    m = re.match(r"(.*\.app).*", exe_path)
-    path = Path(m.group(1) if m else exe_path)
-
-    if not Options.is_frozen or path == Path(f"/Applications/{APP_NAME}.app"):
-        return True
-
-    from nxdrive.translator import Translator
-    from nxdrive.utils import find_icon, find_resource
-
-    from PyQt5.QtGui import QPixmap
-    from PyQt5.QtWidgets import QApplication, QMessageBox
-
-    app = QApplication([])
-    app.setQuitOnLastWindowClosed(True)
-
-    Translator(find_resource("i18n"))
-    content = Translator.get("RUNNING_FROM_WRONG_PATH", [str(path), f"{APP_NAME}.app"])
-
-    icon = QPixmap(str(find_icon("app_icon.svg")))
-    msg = QMessageBox()
-    msg.setIconPixmap(icon)
-    msg.setText(content)
-    msg.setWindowTitle(APP_NAME)
-    msg.addButton(Translator.get("QUIT"), QMessageBox.AcceptRole)
-    msg.exec_()
-    return False
 
 
 def before_send(event: Any, hint: Any) -> Any:
@@ -74,11 +40,6 @@ def before_send(event: Any, hint: Any) -> Any:
     return event
 
 
-def section(header: str, content: str) -> str:
-    """Format a "section" of information."""
-    return f"{header}\n```\n{content.strip()}\n```"
-
-
 def setup_sentry() -> None:
     """ Setup Sentry. """
 
@@ -103,130 +64,6 @@ def setup_sentry() -> None:
     )
 
 
-def show_critical_error() -> None:
-    """ Display a "friendly" dialog box on fatal error. """
-
-    import traceback
-
-    from PyQt5.QtCore import Qt, QUrl
-    from PyQt5.QtGui import QDesktopServices, QIcon
-    from PyQt5.QtWidgets import (
-        QApplication,
-        QDialog,
-        QDialogButtonBox,
-        QLabel,
-        QTextEdit,
-        QVBoxLayout,
-    )
-
-    from nxdrive.translator import Translator
-    from nxdrive.utils import find_icon, find_resource
-
-    Translator(find_resource("i18n"))
-    tr = Translator.get
-
-    app = QApplication([])
-    app.setQuitOnLastWindowClosed(True)
-
-    dialog = QDialog()
-    dialog.setWindowTitle(tr("FATAL_ERROR_TITLE", [APP_NAME]))
-    dialog.setWindowIcon(QIcon(str(find_icon("app_icon.svg"))))
-    dialog.resize(800, 600)
-    layout = QVBoxLayout()
-    css = "font-family: monospace; font-size: 12px;"
-    details = []
-
-    # Display a little message to apologize
-    info = QLabel(tr("FATAL_ERROR_MSG", [APP_NAME, COMPANY]))
-    info.setAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
-    layout.addWidget(info)
-
-    # Display CLI arguments
-    if sys.argv[1:]:
-        text = tr("FATAL_ERROR_CLI_ARGS")
-        label_cli = QLabel(text)
-        label_cli.setAlignment(Qt.AlignVCenter)
-        cli_args = QTextEdit()
-        cli_args.setStyleSheet(css)
-        cli_args.setReadOnly(True)
-        args = "\n".join(arg for arg in sys.argv[1:])
-        details.append(section(text, args))
-        cli_args.setText(args)
-        cli_args.setSizeAdjustPolicy(QTextEdit.AdjustToContents)
-        layout.addWidget(label_cli)
-        layout.addWidget(cli_args)
-
-    # Display the exception
-    text = tr("FATAL_ERROR_EXCEPTION")
-    label_exc = QLabel(text)
-    label_exc.setAlignment(Qt.AlignVCenter)
-    exception = QTextEdit()
-    exception.setStyleSheet(css)
-    exception.setReadOnly(True)
-    exc_formatted = "".join(traceback.format_exception(*sys.exc_info()))
-    details.append(section(text, exc_formatted))
-    exception.setText(exc_formatted)
-    layout.addWidget(label_exc)
-    layout.addWidget(exception)
-
-    # Display last lines from the memory log
-    with suppress(Exception):
-        from nxdrive.report import Report
-
-        # Last 20th lines
-        raw_lines = Report.export_logs(-20)
-        lines = b"\n".join(raw_lines).decode(errors="replace")
-
-        if lines:
-            text = tr("FATAL_ERROR_LOGS")
-            label_log = QLabel(text)
-            details.append(section(text, lines))
-            label_log.setAlignment(Qt.AlignVCenter)
-            layout.addWidget(label_log)
-
-            logs = QTextEdit()
-            logs.setStyleSheet(css)
-            logs.setReadOnly(True)
-            logs.setLineWrapColumnOrWidth(4096)
-            logs.setLineWrapMode(QTextEdit.FixedPixelWidth)
-            logs.setText(lines)
-            layout.addWidget(logs)
-
-    def open_update_site() -> None:
-        """Open the update web site."""
-        with suppress(Exception):
-            QDesktopServices.openUrl(QUrl(Options.update_site_url))
-
-    # Buttons
-    buttons = QDialogButtonBox()
-    buttons.setStandardButtons(QDialogButtonBox.Ok)
-    buttons.accepted.connect(dialog.close)
-    update_button = buttons.addButton(
-        tr("FATAL_ERROR_UPDATE_BTN"), QDialogButtonBox.ActionRole
-    )
-    update_button.setToolTip(tr("FATAL_ERROR_UPDATE_TOOLTIP", [APP_NAME]))
-    update_button.clicked.connect(open_update_site)
-    layout.addWidget(buttons)
-
-    def copy() -> None:
-        """Copy details to the clipboard and change the text of the button. """
-        copy_to_clipboard("\n".join(details))
-        copy_paste.setText(tr("FATAL_ERROR_DETAILS_COPIED"))
-
-    # "Copy details" button
-    with suppress(Exception):
-        from nxdrive.utils import copy_to_clipboard
-
-        copy_paste = buttons.addButton(
-            tr("FATAL_ERROR_DETAILS_COPY"), QDialogButtonBox.ActionRole
-        )
-        copy_paste.clicked.connect(copy)
-
-    dialog.setLayout(layout)
-    dialog.show()
-    app.exec_()
-
-
 def main() -> int:
     """ Entry point. """
 
@@ -236,8 +73,8 @@ def main() -> int:
         if sys.version_info < (3, 6):
             raise RuntimeError(f"{APP_NAME} requires Python 3.6+")
 
-        if MAC and not check_executable_path():
-            ret = 1
+        if not check_executable_path():
+            return 1
 
         # Setup Sentry even if the user did not allow it because it can be tweaked
         # later via the "use-sentry" parameter. It will be useless if Sentry is not installed first.

--- a/nxdrive/fatal_error.py
+++ b/nxdrive/fatal_error.py
@@ -1,0 +1,254 @@
+"""
+Fatal error screen management using either Qt or native dialogs.
+"""
+import sys
+from contextlib import suppress
+from pathlib import Path
+
+from nxdrive.constants import APP_NAME, COMPANY, MAC, WINDOWS
+from nxdrive.options import Options
+
+
+__all__ = ("check_executable_path", "show_critical_error")
+
+
+def check_executable_path_error_qt(path: Path) -> None:
+    """Display an error using Qt about the app not running from the right path."""
+
+    from nxdrive.translator import Translator
+    from nxdrive.utils import find_icon, find_resource
+
+    from PyQt5.QtGui import QPixmap
+    from PyQt5.QtWidgets import QApplication, QMessageBox
+
+    app = QApplication([])
+    app.setQuitOnLastWindowClosed(True)
+
+    Translator(find_resource("i18n"))
+    content = Translator.get("RUNNING_FROM_WRONG_PATH", [str(path), f"{APP_NAME}.app"])
+
+    icon = QPixmap(str(find_icon("app_icon.svg")))
+    msg = QMessageBox()
+    msg.setIconPixmap(icon)
+    msg.setText(content)
+    msg.setWindowTitle(APP_NAME)
+    msg.addButton(Translator.get("QUIT"), QMessageBox.AcceptRole)
+    msg.exec_()
+
+
+def fatal_error_qt(exc_formatted: str) -> None:
+    """Display a "friendly" dialog box on fatal error using Qt."""
+
+    from PyQt5.QtCore import Qt, QUrl
+    from PyQt5.QtGui import QDesktopServices, QIcon
+    from PyQt5.QtWidgets import (
+        QApplication,
+        QDialog,
+        QDialogButtonBox,
+        QLabel,
+        QTextEdit,
+        QVBoxLayout,
+    )
+
+    from nxdrive.translator import Translator
+    from nxdrive.utils import find_icon, find_resource
+
+    def section(header: str, content: str) -> str:
+        """Format a "section" of information."""
+        return f"{header}\n```\n{content.strip()}\n```"
+
+    Translator(find_resource("i18n"))
+    tr = Translator.get
+
+    app = QApplication([])
+    app.setQuitOnLastWindowClosed(True)
+
+    dialog = QDialog()
+    dialog.setWindowTitle(tr("FATAL_ERROR_TITLE", [APP_NAME]))
+    dialog.setWindowIcon(QIcon(str(find_icon("app_icon.svg"))))
+    dialog.resize(800, 600)
+    layout = QVBoxLayout()
+    css = "font-family: monospace; font-size: 12px;"
+    details = []
+
+    # Display a little message to apologize
+    info = QLabel(tr("FATAL_ERROR_MSG", [APP_NAME, COMPANY]))
+    info.setAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
+    layout.addWidget(info)
+
+    # Display CLI arguments
+    if sys.argv[1:]:
+        text = tr("FATAL_ERROR_CLI_ARGS")
+        label_cli = QLabel(text)
+        label_cli.setAlignment(Qt.AlignVCenter)
+        cli_args = QTextEdit()
+        cli_args.setStyleSheet(css)
+        cli_args.setReadOnly(True)
+        args = "\n".join(arg for arg in sys.argv[1:])
+        details.append(section(text, args))
+        cli_args.setText(args)
+        cli_args.setSizeAdjustPolicy(QTextEdit.AdjustToContents)
+        layout.addWidget(label_cli)
+        layout.addWidget(cli_args)
+
+    # Display the exception
+    text = tr("FATAL_ERROR_EXCEPTION")
+    label_exc = QLabel(text)
+    label_exc.setAlignment(Qt.AlignVCenter)
+    exception = QTextEdit()
+    exception.setStyleSheet(css)
+    exception.setReadOnly(True)
+    details.append(section(text, exc_formatted))
+    exception.setText(exc_formatted)
+    layout.addWidget(label_exc)
+    layout.addWidget(exception)
+
+    # Display last lines from the memory log
+    with suppress(Exception):
+        from nxdrive.report import Report
+
+        # Last 20th lines
+        raw_lines = Report.export_logs(-20)
+        lines = b"\n".join(raw_lines).decode(errors="replace")
+
+        if lines:
+            text = tr("FATAL_ERROR_LOGS")
+            label_log = QLabel(text)
+            details.append(section(text, lines))
+            label_log.setAlignment(Qt.AlignVCenter)
+            layout.addWidget(label_log)
+
+            logs = QTextEdit()
+            logs.setStyleSheet(css)
+            logs.setReadOnly(True)
+            logs.setLineWrapColumnOrWidth(4096)
+            logs.setLineWrapMode(QTextEdit.FixedPixelWidth)
+            logs.setText(lines)
+            layout.addWidget(logs)
+
+    def open_update_site() -> None:
+        """Open the update web site."""
+        with suppress(Exception):
+            QDesktopServices.openUrl(QUrl(Options.update_site_url))
+
+    # Buttons
+    buttons = QDialogButtonBox()
+    buttons.setStandardButtons(QDialogButtonBox.Ok)
+    buttons.accepted.connect(dialog.close)
+    update_button = buttons.addButton(
+        tr("FATAL_ERROR_UPDATE_BTN"), QDialogButtonBox.ActionRole
+    )
+    update_button.setToolTip(tr("FATAL_ERROR_UPDATE_TOOLTIP", [APP_NAME]))
+    update_button.clicked.connect(open_update_site)
+    layout.addWidget(buttons)
+
+    def copy() -> None:
+        """Copy details to the clipboard and change the text of the button. """
+        copy_to_clipboard("\n".join(details))
+        copy_paste.setText(tr("FATAL_ERROR_DETAILS_COPIED"))
+
+    # "Copy details" button
+    with suppress(Exception):
+        from nxdrive.utils import copy_to_clipboard
+
+        copy_paste = buttons.addButton(
+            tr("FATAL_ERROR_DETAILS_COPY"), QDialogButtonBox.ActionRole
+        )
+        copy_paste.clicked.connect(copy)
+
+    dialog.setLayout(layout)
+    dialog.show()
+    app.exec_()
+
+
+def fatal_error_win(text: str) -> None:
+    """
+    Display a fatal error using Windows native dialog.
+    Taken from https://stackoverflow.com/a/27257176/1117028.
+    """
+
+    import ctypes
+
+    MB_OK = 0x0
+    ICON_STOP = 0x10
+
+    title = f"{APP_NAME} Fatal Error"
+    ctypes.windll.user32.MessageBoxW(0, text, title, MB_OK | ICON_STOP)  # type: ignore
+
+
+def fatal_error_mac(text: str) -> None:
+    """Display a fatal error using macOS native dialog."""
+
+    import subprocess
+
+    title = f"{APP_NAME} Fatal Error"
+    text = text.replace('"', r"\"")
+    msg = (
+        f'Tell me to display dialog "{text}" with title "{title}"'
+        ' buttons {"OK"} with icon stop'
+    )
+    cmd = ["osascript", "-e", msg]
+
+    subprocess.Popen(cmd)
+
+
+def check_executable_path() -> bool:
+    """Check that the app runs from the right path, and quit if not."""
+
+    if not MAC:
+        return True
+
+    import re
+    import sys
+    from pathlib import Path
+
+    exe_path = sys.executable
+    m = re.match(r"(.*\.app).*", exe_path)
+    path = Path(m.group(1) if m else exe_path)
+
+    if not Options.is_frozen or path == Path(f"/Applications/{APP_NAME}.app"):
+        return True
+
+    try:
+        check_executable_path_error_qt(path)
+    except Exception as exc:
+        full_error = (
+            f"You are running this app from {path}. However, "
+            "for all features to run normally, the application"
+            f" must be named '{APP_NAME}.app' and located in "
+            "the /Applications directory."
+        )
+        text = (
+            f"{APP_NAME} cannot start, the entire installation is broken."
+            f"\n\nOriginal error:\n{full_error}"
+            f"\n\nDetails:\n{exc}"
+        )
+        fatal_error_mac(text)
+
+    return False
+
+
+def show_critical_error() -> None:
+    """Display a "friendly" dialog box on fatal error."""
+
+    import traceback
+
+    full_error = "".join(traceback.format_exception(*sys.exc_info()))
+
+    try:
+        fatal_error_qt(full_error)
+    except Exception as exc:
+        # Fallback to native dialog but only to prompt the user for installation error.
+        text = (
+            f"{APP_NAME} cannot start, the entire installation is broken."
+            f"\n\nOriginal error:\n{full_error}"
+            f"\n\nDetails:\n{exc}"
+        )
+
+        if WINDOWS:
+            fatal_error_win(text)
+        elif MAC:
+            fatal_error_mac(text)
+        else:
+            # Best effort on GNU/Linux
+            print(text, file=sys.stderr)


### PR DESCRIPTION
… error screen only)

* On Windows, `MessageBoxW()` will be used.
* On macOs, `osascript` will be used.
* On GNU/Linux, our best effort will be to print to `STDERR`.

Note: I attached screenshots to the JIRA ticket.