### PR TITLE
NXDRIVE-1694: Add the SKIP envar to bypass specific actions

### DIFF
--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -30,6 +30,7 @@ Release date: `2019-xx-xx`
 ## Tests
 
 - [NXDRIVE-1693](https://jira.nuxeo.com/browse/NXDRIVE-1693): Fix file paths in the coverage report
+- [NXDRIVE-1694](https://jira.nuxeo.com/browse/NXDRIVE-1694): Add the SKIP envar to bypass specific actions
 
 ## Minor Changes
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -77,6 +77,14 @@ If you get an error message complaining about the lack of signature for this scr
     test_local_client.py::TestLocalClient (a whole class)
     test_local_client.py::TestLocalClient::test_make_documents (only one method)
 ```
+- `SKIP` is used to tweak tests checks:
+```
+    - SKIP=flake8 to skip code style
+    - SKIP=mypy to skip type annotations
+    - SKIP=rerun to not rerun failed test(s)
+    - SKIP=integration to not run integration tests on Windows
+    - SKIP=all to skip all (equivalent to flake8,mypy,rerun,integration)
+```
 
 #### MacOS Specific
 


### PR DESCRIPTION
* `SKIP=flake8` to skip code style
* `SKIP=mypy` to skip type annotations
* `SKIP=rerun` to not rerun failed test(s)
* `SKIP=integration` to not run integration tests on Windows
* `SKIP=all` to skip all (equivalent to `flake8,mypy,rerun,integration`)