### PR TITLE
NXDRIVE-1697: Fix tests

### DIFF
--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -32,6 +32,7 @@ Release date: `2019-xx-xx`
 
 - [NXDRIVE-1693](https://jira.nuxeo.com/browse/NXDRIVE-1693): Fix file paths in the coverage report
 - [NXDRIVE-1694](https://jira.nuxeo.com/browse/NXDRIVE-1694): Add the SKIP envar to bypass specific actions
+- [NXDRIVE-1702](https://jira.nuxeo.com/browse/NXDRIVE-1702): Enable concurrent pipeline builds
 
 ## Minor Changes
 

--- a/tests/old_functional/common.py
+++ b/tests/old_functional/common.py
@@ -493,7 +493,7 @@ class TwoUsersTest(TestCase):
                     self.engine_1.get_queue_manager().requeue_errors
                 )
                 self.engine_2.syncPartialCompleted.connect(
-                    self.engine_1.get_queue_manager().requeue_errors
+                    self.engine_2.get_queue_manager().requeue_errors
                 )
                 self.connected = True
         elif self.connected:
@@ -501,7 +501,7 @@ class TwoUsersTest(TestCase):
                 self.engine_1.get_queue_manager().requeue_errors
             )
             self.engine_2.syncPartialCompleted.disconnect(
-                self.engine_1.get_queue_manager().requeue_errors
+                self.engine_2.get_queue_manager().requeue_errors
             )
             self.connected = False
 

--- a/tests/old_functional/test_remote_deletion.py
+++ b/tests/old_functional/test_remote_deletion.py
@@ -80,12 +80,12 @@ class TestRemoteDeletion(OneUserTest):
         remote = self.remote_document_client_1
         self.engine_1.start()
 
-        def check_suspended(*_):
+        def callback(*_):
             """ Add delay when upload and download. """
             time.sleep(1)
             Engine.suspend_client(self.engine_1)
 
-        with patch.object(self.engine_1.remote, "check_suspended", new=check_suspended):
+        with patch.object(self.engine_1.remote, "download_callback", new=callback):
             # Create documents in the remote root workspace
             remote.make_folder("/", "Test folder")
             self.wait_sync(wait_for_async=True)
@@ -106,7 +106,7 @@ class TestRemoteDeletion(OneUserTest):
         local = self.local_1
         remote = self.remote_document_client_1
 
-        def check_suspended(*_):
+        def callback(*_):
             """ Add delay when upload and download. """
             if not self.engine_1.has_delete:
                 # Delete remote file while downloading
@@ -124,7 +124,7 @@ class TestRemoteDeletion(OneUserTest):
 
         filepath = self.location / "resources" / "testFile.pdf"
 
-        with patch.object(self.engine_1.remote, "check_suspended", new=check_suspended):
+        with patch.object(self.engine_1.remote, "download_callback", new=callback):
             remote.make_folder("/", "Test folder")
             remote.make_file("/Test folder", "testFile.pdf", filepath.read_bytes())
 

--- a/tests/unit/test_action.py
+++ b/tests/unit/test_action.py
@@ -17,7 +17,7 @@ def test_action():
 
     # Will test .get_percent()
     details = action.export()
-    assert details["last_transfer"] == "Testing"
+    assert details["action_type"] == "Testing"
     assert details["progress"] == 0.0
     assert isinstance(details["uid"], str)
 
@@ -46,7 +46,7 @@ def test_file_action(tmp):
 
     # Will test .get_percent()
     details = action.export()
-    assert details["last_transfer"] == "Mocking"
+    assert details["action_type"] == "Mocking"
     assert details["progress"] == 0.0
     assert isinstance(details["uid"], str)
     assert details["size"] == size

--- a/tools/jenkins/tests.groovy
+++ b/tools/jenkins/tests.groovy
@@ -3,7 +3,6 @@
 
 // Pipeline properties
 properties([
-    disableConcurrentBuilds(),
     pipelineTriggers([[$class: 'GitHubPushTrigger']]),
     [$class: 'BuildDiscarderProperty', strategy:
         [$class: 'LogRotator', daysToKeepStr: '60', numToKeepStr: '60', artifactNumToKeepStr: '1']],

--- a/tools/jenkins/tests_os.groovy
+++ b/tools/jenkins/tests_os.groovy
@@ -3,7 +3,6 @@
 
 // Pipeline properties
 properties([
-    disableConcurrentBuilds(),
     [$class: 'BuildDiscarderProperty', strategy:
         [$class: 'LogRotator', daysToKeepStr: '60', numToKeepStr: '60', artifactNumToKeepStr: '1']],
     [$class: 'SchedulerPreference', preferEvenload: true],

--- a/tools/windows/deploy_jenkins_slave.ps1
+++ b/tools/windows/deploy_jenkins_slave.ps1
@@ -190,7 +190,7 @@ function check_vars {
 		$Env:ISCC_PATH = "C:\Program Files (x86)\Inno Setup 5"
 	}
 	if (-Not ($Env:SKIP)) {
-		$Env:ISCC_SKIPPATH = ""
+		$Env:SKIP = ""
 	}
 	if (-Not ($Env:PYTHON_DIR)) {
 		$ver_major, $ver_minor = $Env:PYTHON_DRIVE_VERSION.split('.')[0,1]


### PR DESCRIPTION
* `test_action.py`
* `test_remote_deletion.py`
* `test_remote_move_and_rename.py`

Also fixed an old copy/paster error in `wait_sync()`.

---

And others interesting things:
* NXDRIVE-1702: Enable concurrent pipeline builds
* NXDRIVE-1694: Fix DirectEdit checksum verification with downloaded tmp files