### PR TITLE
NXDRIVE-1694: Add SKIP=tests to run only code quality checks

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -83,7 +83,8 @@ If you get an error message complaining about the lack of signature for this scr
     - SKIP=mypy to skip type annotations
     - SKIP=rerun to not rerun failed test(s)
     - SKIP=integration to not run integration tests on Windows
-    - SKIP=all to skip all (equivalent to flake8,mypy,rerun,integration)
+    - SKIP=all to skip all above (equivalent to flake8,mypy,rerun,integration)
+    - SKIP=tests tu run only code checks
 ```
 
 #### MacOS Specific

--- a/tools/posix/deploy_jenkins_slave.sh
+++ b/tools/posix/deploy_jenkins_slave.sh
@@ -18,7 +18,8 @@
 #    - SKIP=flake8 to skip code style
 #    - SKIP=mypy to skip type annotations
 #    - SKIP=rerun to not rerun failed test(s)
-#    - SKIP=all to skip all (equivalent to flake8,mypy,rerun)
+#    - SKIP=all to skip all above (equivalent to flake8,mypy,rerun)
+#    - SKIP=tests tu run only code checks
 #
 # There is no strict syntax about multiple skips (coma, coma + space, no separator, ... ).
 #
@@ -217,6 +218,11 @@ launch_tests() {
     if [[ ! "${SKIP}" = *"mypy"* ]] && [[ ! "${SKIP}" = *"all"* ]]; then
         echo ">>> Checking type annotations"
         ${PYTHON} -m mypy nxdrive
+    fi
+
+    if [[ "${SKIP}" = *"tests"* ]]; then
+        # Skip all test cases
+        return
     fi
 
     echo ">>> Launching unit tests"

--- a/tools/windows/deploy_jenkins_slave.ps1
+++ b/tools/windows/deploy_jenkins_slave.ps1
@@ -15,7 +15,8 @@
 #    - SKIP=mypy to skip type annotations
 #    - SKIP=rerun to not rerun failed test(s)
 #    - SKIP=integration to not run integration tests on Windows
-#    - SKIP=all to skip all (equivalent to flake8,mypy,rerun,integration)
+#    - SKIP=all to skip all above (equivalent to flake8,mypy,rerun,integration)
+#    - SKIP=tests tu run only code checks
 #
 # There is no strict syntax about multiple skips (coma, coma + space, no separator, ... ).
 #
@@ -368,6 +369,11 @@ function launch_tests {
 		if ($lastExitCode -ne 0) {
 			ExitWithCode $lastExitCode
 		}
+	}
+
+	if ($Env:SKIP -match 'tests') {
+		# Skip all test cases
+		return
 	}
 
 	Write-Output ">>> Launching unit tests"


### PR DESCRIPTION
Now, if you want to only check code quality, you can use `SKIP=tests`. It will run flake8, then mypy and quit.