### PR TITLE
NXDRIVE-1697: Add tests for the transfers pause/resume feature

### DIFF
--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -35,6 +35,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1687](https://jira.nuxeo.com/browse/NXDRIVE-1687): Improve test results visualization
 - [NXDRIVE-1693](https://jira.nuxeo.com/browse/NXDRIVE-1693): Fix file paths in the coverage report
 - [NXDRIVE-1694](https://jira.nuxeo.com/browse/NXDRIVE-1694): Add the SKIP envar to bypass specific actions
+- [NXDRIVE-1697](https://jira.nuxeo.com/browse/NXDRIVE-1697): Add tests for the transfers pause/resume feature
 - [NXDRIVE-1702](https://jira.nuxeo.com/browse/NXDRIVE-1702): Enable concurrent pipeline builds
 
 ## Minor Changes

--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -86,6 +86,7 @@ Release date: `2019-xx-xx`
 - Added `QMLDriveApi.pause_transfer()`
 - Added `QMLDriveApi.resume_transfer()`
 - Added `Remote.check_integrity()`
+- Added `Remote.upload_callback()`
 - Renamed `check_suspended` keyword argument of `Remote.__init__()` to `download_callback`
 - Moved \_\_main__.py::`check_executable_path` to fatal_error.py
 - Moved \_\_main__.py::`show_critical_error` to fatal_error.py

--- a/nxdrive/engine/dao/sqlite.py
+++ b/nxdrive/engine/dao/sqlite.py
@@ -782,8 +782,8 @@ class EngineDAO(ConfigurationDAO):
             c.execute(
                 "UPDATE States  SET processor = 0 WHERE processor = ?", (processor_id,)
             )
-        log.debug(f"Released processor {processor_id}")
-        return c.rowcount > 0
+            log.debug(f"Released processor {processor_id}")
+            return c.rowcount > 0
 
     def acquire_processor(self, thread_id: int, row_id: int) -> bool:
         with self._lock:
@@ -796,7 +796,7 @@ class EngineDAO(ConfigurationDAO):
                 "   AND processor IN (0, ?)",
                 (thread_id, row_id, thread_id),
             )
-        return c.rowcount == 1
+            return c.rowcount == 1
 
     def _reinit_states(self, cursor: Cursor) -> None:
         cursor.execute("DROP TABLE States")
@@ -913,7 +913,7 @@ class EngineDAO(ConfigurationDAO):
 
             self._items_count += 1
 
-        return row_id
+            return row_id
 
     def get_last_files(
         self, number: int, direction: str = "", duration: int = None
@@ -1462,7 +1462,7 @@ class EngineDAO(ConfigurationDAO):
             ):
                 self._queue_pair_state(row_id, info.folderish, pair_state)
             self._items_count += 1
-        return row_id
+            return row_id
 
     def queue_children(self, row: DocPair) -> None:
         with self._lock:
@@ -1496,8 +1496,8 @@ class EngineDAO(ConfigurationDAO):
                 " WHERE id = ?",
                 (error, error_date, incr, details, row.id),
             )
-        row.last_error = error
-        row.error_count += incr
+            row.last_error = error
+            row.error_count += incr
 
     def reset_error(self, row: DocPair, last_error: str = None) -> None:
         with self._lock:
@@ -1514,8 +1514,8 @@ class EngineDAO(ConfigurationDAO):
             )
             self._queue_pair_state(row.id, row.folderish, row.pair_state)
             self._items_count += 1
-        row.last_error = None
-        row.error_count = 0
+            row.last_error = None
+            row.error_count = 0
 
     def _force_sync(self, row: DocPair, local: str, remote: str, pair: str) -> bool:
         with self._lock:
@@ -1652,11 +1652,10 @@ class EngineDAO(ConfigurationDAO):
                     version,
                 ),
             )
-        result = c.rowcount == 1
+            result = c.rowcount == 1
 
-        # Retry without version for folder
-        if not result and row.folderish:
-            with self._lock:
+            # Retry without version for folder
+            if not result and row.folderish:
                 con = self._get_write_connection()
                 c = con.cursor()
                 c.execute(
@@ -1688,21 +1687,21 @@ class EngineDAO(ConfigurationDAO):
                 )
             result = c.rowcount == 1
 
-        if not result:
-            log.debug(f"Was not able to synchronize state: {row!r}")
-            c = self._get_read_connection().cursor()
-            row2: DocPair = c.execute(
-                "SELECT * FROM States WHERE id = ?", (row.id,)
-            ).fetchone()
-            if row2 is None:
-                log.debug("No more row")
-            else:
-                log.debug(f"Current row={row2!r} (version={row2.version!r})")
-            log.debug(f"Previous row={row!r} (version={row.version!r})")
-        elif row.folderish:
-            self.queue_children(row)
+            if not result:
+                log.debug(f"Was not able to synchronize state: {row!r}")
+                c = self._get_read_connection().cursor()
+                row2: DocPair = c.execute(
+                    "SELECT * FROM States WHERE id = ?", (row.id,)
+                ).fetchone()
+                if row2 is None:
+                    log.debug("No more row")
+                else:
+                    log.debug(f"Current row={row2!r} (version={row2.version!r})")
+                log.debug(f"Previous row={row!r} (version={row.version!r})")
+            elif row.folderish:
+                self.queue_children(row)
 
-        return result
+            return result
 
     def update_remote_state(
         self,

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -463,7 +463,7 @@ class Processor(EngineWorker):
             if duration <= 0:
                 return
             speed = action.size / duration / 1024
-            log.debug(f"Transfer speed {speed:.2f} kib/s")
+            log.debug(f"Transfer speed {speed:,.2f} Kib/s")
             self._current_metrics["speed"] = speed
 
     def _synchronize_if_not_remotely_dirty(

--- a/nxdrive/engine/watcher/remote_watcher.py
+++ b/nxdrive/engine/watcher/remote_watcher.py
@@ -331,6 +331,7 @@ class RemoteWatcher(EngineWorker):
         # Delete remaining
         for deleted in descendants.values():
             self._dao.delete_remote_state(deleted)
+            self.remove_void_transfers(deleted)
 
     def _scan_remote_recursive(
         self,
@@ -393,6 +394,7 @@ class RemoteWatcher(EngineWorker):
         # Delete remaining
         for deleted in children.values():
             self._dao.delete_remote_state(deleted)
+            self.remove_void_transfers(deleted)
 
         for pair, info in to_scan:
             # TODO Optimize by multithreading this too ?
@@ -782,6 +784,7 @@ class RemoteWatcher(EngineWorker):
                             "denying Read access, marking it as deleted"
                         )
                         self._dao.delete_remote_state(doc_pair)
+                        self.remove_void_transfers(doc_pair)
                     else:
                         log.warning(f"Unknown event: {event_id!r}")
                 else:
@@ -805,6 +808,7 @@ class RemoteWatcher(EngineWorker):
                         # delete from local sync root
                         log.info(f"Marking doc_pair {doc_pair_repr!r} as deleted")
                         self._dao.delete_remote_state(doc_pair)
+                        self.remove_void_transfers(doc_pair)
                     else:
                         """
                         Make new_info consistent with actual doc pair parent
@@ -970,6 +974,7 @@ class RemoteWatcher(EngineWorker):
             delete_processed.append(delete_pair)
             log.info(f"Marking doc_pair {delete_pair!r} as deleted")
             self._dao.delete_remote_state(delete_pair)
+            self.remove_void_transfers(delete_pair)
 
     def filtered(self, info: Optional[RemoteFileInfo]) -> bool:
         """ Check if a remote document is locally ignored. """

--- a/nxdrive/engine/workers.py
+++ b/nxdrive/engine/workers.py
@@ -230,8 +230,8 @@ class EngineWorker(Worker):
             return
 
         fullpath = self.engine.local.abspath(doc_pair.local_path)
-        for transfer in {"download", "upload"}:
-            self._dao.remove_transfer(transfer, fullpath)
+        for nature in ("download", "upload"):
+            self._dao.remove_transfer(nature, fullpath)
 
 
 class PollWorker(Worker):

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -1099,6 +1099,8 @@ def compute_digest(path: Path, digest_func: str, callback: Callable = None) -> s
                 if not buf:
                     break
                 h.update(buf)
-    except OSError:
+    except (OSError, MemoryError):
+        # MemoryError happens randomly, dunno why but this is
+        # not an issue as the hash will be recomputed later
         return UNACCESSIBLE_HASH
     return h.hexdigest()

--- a/tests/old_functional/test_transfer.py
+++ b/tests/old_functional/test_transfer.py
@@ -1,0 +1,377 @@
+"""
+Test pause/resume transfers in differents scenarii.
+"""
+from unittest.mock import patch
+
+import pytest
+from nxdrive.constants import FILE_BUFFER_SIZE, TransferStatus, WINDOWS
+from nxdrive.options import Options
+
+from .. import ensure_no_exception
+from .common import OneUserTest, SYNC_ROOT_FAC_ID
+
+
+class TestDownload(OneUserTest):
+    def setUp(self):
+        self.engine_1.start()
+        self.wait_sync(wait_for_async=True)
+
+    def test_pause_download_manually(self):
+        """
+        Pause the transfer by simulating a click on the pause/resume icon
+        on the current download in the systray menu.
+        """
+
+        def callback(*_, **__):
+            """
+            This will mimic what is done in SystrayTranfer.qml:
+                - call API.pause_transfer() that will call:
+                    - engine.get_dao().pause_transfer(nature, transfer_uid)
+            Then the download will be paused by the Engine:
+                - Engine.suspend_client() (== Remote.download_callback) will:
+                    - raise DownloadPaused(download.uid)
+            """
+            # Ensure we have 1 ongoing download
+            downloads = dao.get_downloads()
+            assert downloads
+            download = downloads[0]
+            assert download.status == TransferStatus.ONGOING
+
+            # Pause the download
+            dao.pause_transfer("download", download.uid)
+
+            # Call the original function to make the paused download effective
+            callback_orig()
+
+        engine = self.engine_1
+        dao = self.engine_1.get_dao()
+        callback_orig = engine.remote.download_callback
+
+        # Remotely create a file that will be downloaded locally
+        self.remote_1.make_file(
+            f"{SYNC_ROOT_FAC_ID}{self.workspace}",
+            "test.bin",
+            content=b"0" * FILE_BUFFER_SIZE * 2,
+        )
+
+        # There is no download, right now
+        assert not dao.get_downloads()
+
+        with patch.object(engine.remote, "download_callback", new=callback):
+            with ensure_no_exception():
+                self.wait_sync(wait_for_async=True)
+            assert dao.get_downloads_with_status(TransferStatus.PAUSED)
+
+        # Resume the download
+        engine.resume_transfer("download", dao.get_downloads()[0].uid)
+        self.wait_sync(wait_for_async=True)
+        assert not dao.get_downloads()
+
+    def test_pause_download_automatically(self):
+        """
+        Pause the transfer by simulating an application exit
+        or clicking on the Suspend menu entry from the systray.
+        """
+
+        def callback(*_, **__):
+            """This will mimic what is done in SystrayMenu.qml: suspend the app."""
+            # Ensure we have 1 ongoing download
+            downloads = dao.get_downloads()
+            assert downloads
+            download = downloads[0]
+            assert download.status == TransferStatus.ONGOING
+
+            # Suspend!
+            self.manager_1.suspend()
+
+            # Call the original function to make the suspended download effective
+            callback_orig()
+
+        engine = self.engine_1
+        dao = self.engine_1.get_dao()
+        callback_orig = engine.remote.download_callback
+
+        # Remotely create a file that will be downloaded locally
+        self.remote_1.make_file(
+            f"{SYNC_ROOT_FAC_ID}{self.workspace}",
+            "test.bin",
+            content=b"0" * FILE_BUFFER_SIZE * 2,
+        )
+
+        # There is no download, right now
+        assert not dao.get_downloads()
+
+        with patch.object(engine.remote, "download_callback", new=callback):
+            with ensure_no_exception():
+                self.wait_sync(wait_for_async=True)
+            assert dao.get_downloads_with_status(TransferStatus.SUSPENDED)
+
+        # Resume the download
+        self.manager_1.resume()
+        self.wait_sync(wait_for_async=True)
+        assert not dao.get_downloads()
+
+    def test_modifying_paused_download(self):
+        """Modifying a paused download should discard the current download."""
+
+        def callback(*_, **__):
+            """Pause the download and apply changes to the document."""
+            nonlocal count
+            count += 1
+
+            if count == 1:
+                # Ensure we have 1 ongoing download
+                downloads = dao.get_downloads()
+                assert downloads
+                download = downloads[0]
+                assert download.status == TransferStatus.ONGOING
+
+                # Pause the download
+                dao.pause_transfer("download", download.uid)
+
+                # Apply changes to the document
+                remote.update_content(file.uid, b"remotely changed")
+
+            # Call the original function to make the paused download effective
+            callback_orig()
+
+        count = 0
+        remote = self.remote_1
+        engine = self.engine_1
+        dao = self.engine_1.get_dao()
+        callback_orig = engine.remote.download_callback
+
+        # Remotely create a file that will be downloaded locally
+        file = remote.make_file(
+            f"{SYNC_ROOT_FAC_ID}{self.workspace}",
+            "test.bin",
+            content=b"0" * FILE_BUFFER_SIZE * 2,
+        )
+
+        # There is no download, right now
+        assert not dao.get_downloads()
+
+        with patch.object(engine.remote, "download_callback", new=callback):
+            with ensure_no_exception():
+                self.wait_sync(wait_for_async=True)
+
+        # Resync and check the local content is correct
+        self.wait_sync(wait_for_async=True)
+        assert not dao.get_downloads()
+        assert self.local_1.get_content("/test.bin") == b"remotely changed"
+
+    def test_deleting_paused_download(self):
+        """Deleting a paused download should discard the current download."""
+
+        def callback(*_, **__):
+            """Pause the download and delete the document."""
+            # Ensure we have 1 ongoing download
+            downloads = dao.get_downloads()
+            assert downloads
+            download = downloads[0]
+            assert download.status == TransferStatus.ONGOING
+
+            # Pause the download
+            dao.pause_transfer("download", download.uid)
+
+            # Remove the document
+            remote.delete(file.uid)
+
+            # Call the original function to make the paused download effective
+            callback_orig()
+
+        remote = self.remote_1
+        engine = self.engine_1
+        dao = self.engine_1.get_dao()
+        callback_orig = engine.remote.download_callback
+
+        # Remotely create a file that will be downloaded locally
+        file = remote.make_file(
+            f"{SYNC_ROOT_FAC_ID}{self.workspace}",
+            "test.bin",
+            content=b"0" * FILE_BUFFER_SIZE * 2,
+        )
+
+        # There is no download, right now
+        assert not dao.get_downloads()
+
+        with patch.object(engine.remote, "download_callback", new=callback):
+            with ensure_no_exception():
+                self.wait_sync(wait_for_async=True)
+
+        # Resync and check the file does not exist
+        self.wait_sync(wait_for_async=True)
+        assert not dao.get_downloads()
+        assert not self.local_1.exists("/test.bin")
+
+
+class TestUpload(OneUserTest):
+    def setUp(self):
+        self.engine_1.start()
+        self.wait_sync(wait_for_async=True)
+
+        # Lower chunk_* options to have chunked uploads without having to create big files
+        self.default_chunk_limit = Options.chunk_limit
+        self.default_chunk_size = Options.chunk_size
+        Options.chunk_limit = 1
+        Options.chunk_size = 1
+
+    def tearDown(self):
+        Options.chunk_limit = self.default_chunk_limit
+        Options.chunk_size = self.default_chunk_size
+
+    def test_pause_upload_manually(self):
+        """
+        Pause the transfer by simulating a click on the pause/resume icon
+        on the current upload in the systray menu.
+        """
+
+        def callback(*_):
+            """
+            This will mimic what is done in SystrayTranfer.qml:
+                - call API.pause_transfer() that will call:
+                    - engine.get_dao().pause_transfer(nature, transfer_uid)
+            Then the upload will be paused in Remote.upload().
+            """
+            # Ensure we have 1 ongoing upload
+            uploads = dao.get_uploads()
+            assert uploads
+            upload = uploads[0]
+            assert upload.status == TransferStatus.ONGOING
+
+            # Pause the upload
+            dao.pause_transfer("upload", upload.uid)
+
+        engine = self.engine_1
+        dao = self.engine_1.get_dao()
+
+        # Locally create a file that will be uploaded remotely
+        self.local_1.make_file("/", "test.bin", content=b"0" * FILE_BUFFER_SIZE * 2)
+
+        # There is no upload, right now
+        assert not dao.get_uploads()
+
+        with patch.object(engine.remote, "upload_callback", new=callback):
+            with ensure_no_exception():
+                self.wait_sync()
+            assert dao.get_uploads_with_status(TransferStatus.PAUSED)
+
+        # Resume the upload
+        engine.resume_transfer("upload", dao.get_uploads()[0].uid)
+        self.wait_sync()
+        assert not dao.get_uploads()
+
+    def test_pause_upload_automatically(self):
+        """
+        Pause the transfer by simulating an application exit
+        or clicking on the Suspend menu entry from the systray.
+        """
+
+        def callback(*_):
+            """This will mimic what is done in SystrayMenu.qml: suspend the app."""
+            # Ensure we have 1 ongoing upload
+            uploads = dao.get_uploads()
+            assert uploads
+            upload = uploads[0]
+            assert upload.status == TransferStatus.ONGOING
+
+            # Suspend!
+            self.manager_1.suspend()
+
+        engine = self.engine_1
+        dao = self.engine_1.get_dao()
+
+        # Locally create a file that will be uploaded remotely
+        self.local_1.make_file("/", "test.bin", content=b"0" * FILE_BUFFER_SIZE * 2)
+
+        # There is no upload, right now
+        assert not dao.get_uploads()
+
+        with patch.object(engine.remote, "upload_callback", new=callback):
+            with ensure_no_exception():
+                self.wait_sync()
+            assert dao.get_uploads_with_status(TransferStatus.SUSPENDED)
+
+        # Resume the upload
+        self.manager_1.resume()
+        self.wait_sync()
+        assert not dao.get_uploads()
+
+    def test_modifying_paused_upload(self):
+        """Modifying a paused upload should discard the current upload."""
+
+        def callback(*_):
+            """Pause the upload and apply changes to the document."""
+            # Ensure we have 1 ongoing upload
+            uploads = dao.get_uploads()
+            assert uploads
+            upload = uploads[0]
+            assert upload.status == TransferStatus.ONGOING
+
+            # Pause the upload
+            dao.pause_transfer("upload", upload.uid)
+
+            # Apply changes to the document
+            local.update_content("/test.bin", b"locally changed")
+
+        local = self.local_1
+        engine = self.engine_1
+        dao = self.engine_1.get_dao()
+
+        # Locally create a file that will be uploaded remotely
+        self.local_1.make_file("/", "test.bin", content=b"0" * FILE_BUFFER_SIZE * 2)
+
+        # There is no upload, right now
+        assert not dao.get_uploads()
+
+        with patch.object(engine.remote, "upload_callback", new=callback):
+            with ensure_no_exception():
+                self.wait_sync()
+
+        # Resync and check the local content is correct
+        self.wait_sync()
+        assert not dao.get_uploads()
+        assert self.local_1.get_content("/test.bin") == b"locally changed"
+
+    @pytest.mark.skipif(
+        WINDOWS,
+        reason="Cannot test the behavior as the local deletion is blocked by the OS.",
+    )
+    def test_deleting_paused_upload(self):
+        """Deleting a paused upload should discard the current upload."""
+
+        def callback(*_):
+            """Pause the upload and delete the document."""
+            # Ensure we have 1 ongoing upload
+            uploads = dao.get_uploads()
+            assert uploads
+            upload = uploads[0]
+            assert upload.status == TransferStatus.ONGOING
+
+            # Pause the upload
+            dao.pause_transfer("upload", upload.uid)
+
+            # Remove the document
+            # (this is the problematic part on Windows, because for the
+            #  file descriptor to be released we need to escape from
+            #  Remote.upload(), which is not possible from here)
+            local.delete("/test.bin")
+
+        local = self.local_1
+        engine = self.engine_1
+        dao = self.engine_1.get_dao()
+
+        # Locally create a file that will be uploaded remotely
+        self.local_1.make_file("/", "test.bin", content=b"0" * FILE_BUFFER_SIZE * 2)
+
+        # There is no upload, right now
+        assert not dao.get_uploads()
+
+        with patch.object(engine.remote, "upload_callback", new=callback):
+            with ensure_no_exception():
+                self.wait_sync()
+
+        # Resync and check the file does not exist
+        self.wait_sync()
+        assert not dao.get_uploads()
+        assert not self.remote_1.exists("/test.bin")


### PR DESCRIPTION
Also:
* Remove obsolete downloads on remote changes;
* Minor code clean-up;
* Introduce `Remote.upload_callback()`.