### PR TITLE
NXDRIVE-1224: Upgrade Python from 3.6.8 to 3.7.3

### DIFF
--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -33,7 +33,7 @@ Release date: `2019-xx-xx`
 
 ## Packaging / Build
 
-- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-): ...
+- [NXDRIVE-1224](https://jira.nuxeo.com/browse/NXDRIVE-1224): Upgrade from Python 3.6.8 to 3.7.3
 
 ## Tests
 
@@ -46,6 +46,8 @@ Release date: `2019-xx-xx`
 ## Minor Changes
 
 - Packaging: Added `junitparser` 1.3.2
+- Packaging: Added `requests` 2.2.0
+- Packaging: Removed `dataclasses` 0.6
 - Packaging: Updated `markdown` from 3.1 to 3.1.1
 - Packaging: Updated `nuxeo` from 2.0.5 to 2.1.1
 - Packaging: Updated `pre-commit` from 1.16.1 to 1.17.0

--- a/docs/support.md
+++ b/docs/support.md
@@ -60,10 +60,13 @@ If you want to use the module version as a basic module for your own software, p
 
 It may evolve quickly without notification as we are following the Python development cycle.
 
-As of now, we are using the __Python 3.6.8__.
+[//]: # (XXX_PYTHON)
+
+As of now, we are using the __Python 3.7.3__.
 
 History:
 
+- `2019-06-17` (v4.1.4): dropped support for Python 3.6
 - `2018-10-30` (v4.0.0): dropped support for Python 2.7
 - `2014-??-??`: dropped support for Python 2.6
 

--- a/nxdrive/__main__.py
+++ b/nxdrive/__main__.py
@@ -70,8 +70,9 @@ def main() -> int:
     ret = 0
 
     try:
-        if sys.version_info < (3, 6):
-            raise RuntimeError(f"{APP_NAME} requires Python 3.6+")
+        # XXX_PYTHON
+        if sys.version_info < (3, 7):
+            raise RuntimeError(f"{APP_NAME} requires Python 3.7+")
 
         if not check_executable_path():
             return 1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,4 @@
 # nuitka==0.6.3; sys_platform == 'win32'
-pyinstaller==3.4.0
+# pyinstaller==3.5.0 or newer
+# https://github.com/pyinstaller/pyinstaller/issues/3942
+https://github.com/pyinstaller/pyinstaller/archive/9e1f05ba22ee797b6914d85ac11fe9dc425ad649.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 appdirs==1.4.3
-dataclasses==0.6
 distro==1.4.0; sys_platform == 'linux'
 https://github.com/GoodRx/universal-analytics-python/archive/77ce628c56de1ba51a9bf0774794fd687f785803.zip
 https://github.com/gorakhargosh/watchdog/archive/8b94506c3156a3b66faef7aac9a139f603772506.zip
@@ -16,8 +15,10 @@ pypac==0.12.0
 pypiwin32==223; sys_platform == 'win32'
 # Ignore PyQt5 updates until NXDRIVE-1391 is done
 PyQt5==5.11.2  # pyup: ignore
+# NXDRIVE-1560: issue with codesign on macOS and sip > 4.19.13
 PyQt5-sip==4.19.13
 python-dateutil==2.8.0
+requests==2.22.0
 rfc3987==1.3.8
 Send2Trash==1.5.0
 sentry-sdk==0.9.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,7 +18,7 @@ nuxeo.constants.CHECK_PARAMS = True
 def _basename(path: str) -> str:
     """
     Patch shutil._basename for pathlib compatibility.
-    TODO: remove when https://bugs.python.org/issue32689 is fixed (Python 3.7.3 or newer)
+    TODO: remove when https://bugs.python.org/issue32689 is fixed (Python 3.7.4 or newer)
     """
     if isinstance(path, os.PathLike):
         return path.name

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -84,6 +84,9 @@ def manager_factory(
                 conf_folder, nuxeo_url, user.uid, user.password, start_engine=False
             )
 
+            # Let the possibility to access user's attributes from the manager
+            manager.user_details = user
+
             engine = None
             for uid, engine_ in manager.get_engines().items():
                 engine = engine_

--- a/tests/old_functional/test_direct_edit.py
+++ b/tests/old_functional/test_direct_edit.py
@@ -7,8 +7,6 @@ from urllib.error import URLError
 
 import pytest
 from unittest.mock import patch
-from nuxeo.exceptions import HTTPError
-from nuxeo.models import User
 
 from nxdrive.exceptions import (
     DocumentAlreadyLocked,
@@ -436,46 +434,6 @@ class TestDirectEdit(OneUserTest, DirectEditSetup):
         )
 
         self._direct_edit_update(doc_id, filename, b"Test", url=url)
-
-    def test_url_missing_username(self):
-        """ The username must be in the URL. """
-        url = (
-            "nxdrive://edit/https/server.cloud.nuxeo.com/nuxeo"
-            "/repo/default"
-            "/nxdocid/xxxxxxxx-xxxx-xxxx-xxxx"
-            "/filename/lebron-james-beats-by-dre-powerb.psd"
-            "/downloadUrl/nxfile/default/xxxxxxxx-xxxx-xxxx-xxxx"
-            "/file:content/lebron-james-beats-by-dre-powerb.psd"
-        )
-        with pytest.raises(ValueError):
-            self._direct_edit_update("", "", b"", url=url)
-
-    def test_user_name(self):
-        # Create a complete user
-        remote = self.root_remote
-        try:
-            user = remote.users.create(
-                User(
-                    properties={
-                        "username": "john",
-                        "firstName": "John",
-                        "lastName": "Doe",
-                    }
-                )
-            )
-        except HTTPError as exc:
-            assert exc.status != 409
-            user = remote.users.get("john")
-
-        try:
-            username = self.engine_1.get_user_full_name("john")
-            assert username == "John Doe"
-        finally:
-            user.delete()
-
-        # Unknown user
-        username = self.engine_1.get_user_full_name("unknown")
-        assert username == "unknown"
 
     def test_double_lock_same_user(self):
         filename = "Mode opératoire¹.txt"

--- a/tools/osx/fix_app_qt_folder_names_for_codesign.py
+++ b/tools/osx/fix_app_qt_folder_names_for_codesign.py
@@ -85,8 +85,16 @@ def move_contents_to_resources(folder: Path) -> Generator[Path, None, None]:
             yield from move_contents_to_resources(path)
         else:
             sibbling = Path(str(path).replace("MacOS", "Resources"))
+
+            # Create the parent if it does not exist yet
+            sibbling.parent.mkdir(parents=True, exist_ok=True)
+
+            # Make the move
             shutil.move(path, sibbling)
-            yield sibbling
+
+            # Yield the DLL if it is one
+            if sibbling.name.endswith(".dylib"):
+                yield sibbling
 
 
 def main(args: List[str]) -> int:

--- a/tools/posix/deploy_jenkins_slave.sh
+++ b/tools/posix/deploy_jenkins_slave.sh
@@ -87,7 +87,7 @@ check_import() {
 check_vars() {
     # Check required variables
     if [ "${PYTHON_DRIVE_VERSION:=unset}" = "unset" ]; then
-        export PYTHON_DRIVE_VERSION="3.6.8"  # XXX_PYTHON
+        export PYTHON_DRIVE_VERSION="3.7.3"  # XXX_PYTHON
     fi
     if [ "${WORKSPACE:=unset}" = "unset" ]; then
         echo "WORKSPACE not defined. Aborting."
@@ -130,10 +130,6 @@ check_vars() {
 
 install_deps() {
     echo ">>> Installing requirements"
-    # Do not delete, it fixes "Could not import setuptools which is required to install from a source distribution."
-    ${PIP} setuptools
-    # NXDRIVE-1521: pip 19.0.1 prevents PyInstaller installation
-    ${PIP} pip==18.1
     ${PIP} -r requirements.txt
     ${PIP} -r requirements-dev.txt
     if [ "${INSTALL_RELEASE_ARG:=0}" != "1" ]; then

--- a/tools/windows/deploy_jenkins_slave.ps1
+++ b/tools/windows/deploy_jenkins_slave.ps1
@@ -173,7 +173,7 @@ function check_import($import) {
 function check_vars {
 	# Check required variables
 	if (-Not ($Env:PYTHON_DRIVE_VERSION)) {
-		$Env:PYTHON_DRIVE_VERSION = '3.6.8'  # XXX_PYTHON
+		$Env:PYTHON_DRIVE_VERSION = '3.7.3'  # XXX_PYTHON
 	} elseif (-Not ($Env:WORKSPACE)) {
 		Write-Output ">>> WORKSPACE not defined. Aborting."
 		ExitWithCode 1


### PR DESCRIPTION
* Add `requests` requirement to bypass a bug with old version and `urllib3` >= 1.25;
  (see https://github.com/kennethreitz/requests/issues/5067)
* Use a development branch of PyInstaller to bypass a venv bug;
  (see https://github.com/pyinstaller/pyinstaller/issues/3942)
* Remove `setuptools` and `pip` 18 requirement, there is no more issue here;
* Fixed `fix_app_qt_folder_names_for_codesign.py` as it was yielding
  files and folders in a random manner and was trying to fix non-DLL files.