### PR TITLE
NXDRIVE-1720: Fix a crash when selecting a root to sync

### DIFF
--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -69,16 +69,16 @@ Release date: `2019-xx-xx`
 - Removed `BlackListItem.get()`. Use `name` attribute instead.
 - Added `BlacklistQueue.repush()`
 - Removed `Engine.get_dao()`. Use `dao` attribute instead.
+- Removed `Engine.get_last_files()`. Use `dao.get_last_files()` instead.
+- Removed `Engine.get_last_files_count()`. Use `dao.get_last_files_count()` instead.
 - Removed `Engine.get_queue_manager()`. Use `queue_manager` attribute instead.
 - Renamed `Engine.newSync` signal to `Engine.newSyncEnded`
 - Added `Engine.newSyncStarted`
 - Added `Engine.resume_suspended_transfers()`
 - Added `Engine.resume_transfer()`
-- Added `EngineDAO.transferUpdated` signal
 - Added `EngineDAO.get_download()`
 - Added `EngineDAO.get_downloads()`
 - Added `EngineDAO.get_downloads_with_status()`
-- Added `EngineDAO.get_transfers()`
 - Added `EngineDAO.get_upload()`
 - Added `EngineDAO.get_uploads()`
 - Added `EngineDAO.get_uploads_with_status()`
@@ -89,6 +89,7 @@ Release date: `2019-xx-xx`
 - Added `EngineDAO.save_upload()`
 - Added `EngineDAO.set_transfer_doc()`
 - Added `EngineDAO.suspend_transfers()`
+- Removed `state_factory` keyworkd argument from `EngineDAO.__init__()`
 - Changed `EngineDAO.update_remote_state()` return type from `None` to `bool`
 - Added `FileModel.ID` role
 - Renamed `check_suspended` keyword argument of `LocalClient.__init__()` to `digest_callback`

--- a/nxdrive/data/qml/Systray.qml
+++ b/nxdrive/data/qml/Systray.qml
@@ -109,7 +109,7 @@ Rectangle {
                         id: accountSelect
                         // When picking an account, refresh the file list.
                         onActivated: {
-                            api.get_last_files(accountSelect.getRole("uid"))
+                            api.get_last_files(accountSelect.getRole("uid"), 10)
                             updateCounts()
                         }
                     }

--- a/nxdrive/engine/activity.py
+++ b/nxdrive/engine/activity.py
@@ -169,24 +169,18 @@ class FileAction(Action):
 
 
 class DownloadAction(FileAction):
-    action_type = "Download"
-
     def __init__(
         self, filepath: Path, filename: str = None, reporter: Any = None
     ) -> None:
-        super().__init__(
-            self.action_type, filepath, filename=filename, reporter=reporter
-        )
+        super().__init__("Download", filepath, filename=filename, reporter=reporter)
 
 
 class UploadAction(FileAction):
-    action_type = "Upload"
-
     def __init__(
         self, filepath: Path, filename: str = None, reporter: Any = None
     ) -> None:
         super().__init__(
-            self.action_type,
+            "Upload",
             filepath,
             filename=filename,
             size=filepath.stat().st_size,
@@ -195,13 +189,11 @@ class UploadAction(FileAction):
 
 
 class VerificationAction(FileAction):
-    action_type = "Verification"
-
     def __init__(
         self, filepath: Path, filename: str = None, reporter: Any = None
     ) -> None:
         super().__init__(
-            self.action_type,
+            "Verification",
             filepath,
             filename=filename,
             size=filepath.stat().st_size,

--- a/nxdrive/engine/activity.py
+++ b/nxdrive/engine/activity.py
@@ -93,9 +93,9 @@ class IdleAction(Action):
 
 
 class FileAction(Action):
-    started = pyqtSignal(Action)
-    progressing = pyqtSignal(Action)
-    done = pyqtSignal(Action)
+    started = pyqtSignal(object)
+    progressing = pyqtSignal(object)
+    done = pyqtSignal(object)
 
     def __init__(
         self,
@@ -124,7 +124,7 @@ class FileAction(Action):
     def _connect_reporter(self, reporter):
         if not reporter:
             return
-        for evt in {"started", "progressing", "done"}:
+        for evt in ("started", "progressing", "done"):
             signal = getattr(reporter, f"action_{evt}", None)
             if signal:
                 getattr(self, evt).connect(signal)

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -83,7 +83,6 @@ class Engine(QObject):
     newSyncEnded = pyqtSignal(object)
     newError = pyqtSignal(object)
     newQueueItem = pyqtSignal(object)
-    transferUpdated = pyqtSignal()
     offline = pyqtSignal()
     online = pyqtSignal()
 
@@ -171,10 +170,10 @@ class Engine(QObject):
 
         # Some conflict can be resolved automatically
         self.dao.newConflict.connect(self.conflict_resolver)
+
         # Try to resolve conflict on startup
         for conflict in self.dao.get_conflicts():
             self.conflict_resolver(conflict.id, emit=False)
-        self.dao.transferUpdated.connect(self.transferUpdated)
 
         # Scan in remote_watcher thread
         self._scanPair.connect(self._remote_watcher.scan_pair)
@@ -276,16 +275,6 @@ class Engine(QObject):
     def release_folder_lock(self) -> None:
         log.info("Local Folder unlocking")
         self._folder_lock = None
-
-    def get_last_files(
-        self, number: int, direction: str = "", duration: int = None
-    ) -> DocPairs:
-        """ Return the last files transferred (see EngineDAO). """
-        return self.dao.get_last_files(number, direction=direction, duration=duration)
-
-    def get_last_files_count(self, direction: str = "", duration: int = None) -> int:
-        """ Return the count of the last files transferred (see EngineDAO). """
-        return self.dao.get_last_files_count(direction=direction, duration=duration)
 
     def set_offline(self, value: bool = True) -> None:
         if value == self._offline_state:

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -281,11 +281,11 @@ class Engine(QObject):
         self, number: int, direction: str = "", duration: int = None
     ) -> DocPairs:
         """ Return the last files transferred (see EngineDAO). """
-        return self.dao.get_last_files(number, direction, duration)
+        return self.dao.get_last_files(number, direction=direction, duration=duration)
 
     def get_last_files_count(self, direction: str = "", duration: int = None) -> int:
         """ Return the count of the last files transferred (see EngineDAO). """
-        return self.dao.get_last_files_count(direction, duration)
+        return self.dao.get_last_files_count(direction=direction, duration=duration)
 
     def set_offline(self, value: bool = True) -> None:
         if value == self._offline_state:

--- a/nxdrive/gui/api.py
+++ b/nxdrive/gui/api.py
@@ -108,13 +108,15 @@ class QMLDriveApi(QObject):
         return engines.get(uid)
 
     def get_last_files(
-        self, uid: str, number: int, direction: str, duration: int = None
+        self, uid: str, number: int, direction: str = "", duration: int = None
     ) -> List[Dict[str, Any]]:
         """ Return the last files transferred (see EngineDAO). """
         engine = self._get_engine(uid)
         result = []
-        if engine is not None:
-            for state in engine.get_last_files(number, direction, duration):
+        if engine:
+            for state in engine.get_last_files(
+                number, direction=direction, duration=duration
+            ):
                 result.append(state.export())
         return result
 
@@ -124,7 +126,7 @@ class QMLDriveApi(QObject):
         count = 0
         engine = self._get_engine(uid)
         if engine:
-            count = engine.get_last_files_count(direction="", duration=60)
+            count = engine.get_last_files_count(duration=60)
         return count
 
     @pyqtSlot(result=str)

--- a/nxdrive/gui/api.py
+++ b/nxdrive/gui/api.py
@@ -114,7 +114,7 @@ class QMLDriveApi(QObject):
         engine = self._get_engine(uid)
         result = []
         if engine:
-            for state in engine.get_last_files(
+            for state in engine.dao.get_last_files(
                 number, direction=direction, duration=duration
             ):
                 result.append(state.export())
@@ -126,7 +126,7 @@ class QMLDriveApi(QObject):
         count = 0
         engine = self._get_engine(uid)
         if engine:
-            count = engine.get_last_files_count(duration=60)
+            count = engine.dao.get_last_files_count(duration=60)
         return count
 
     @pyqtSlot(result=str)
@@ -215,12 +215,11 @@ class QMLDriveApi(QObject):
     def get_transfers(self) -> List[Dict[str, Any]]:
         result: List[Dict[str, Any]] = []
 
-        engines = self._manager.get_engines().values()
-
-        for engine in engines:
-            for download in engine.dao.get_downloads():
+        for engine in self._manager.get_engines().values():
+            dao = engine.dao
+            for download in dao.get_downloads():
                 result.append(asdict(download))
-            for upload in engine.dao.get_uploads():
+            for upload in dao.get_uploads():
                 result.append(asdict(upload))
         return result
 

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -267,7 +267,7 @@ class Application(QApplication):
             self._window_root(self.systray_window).updateProgress
         )
 
-    @pyqtSlot(Action)
+    @pyqtSlot(object)
     def action_progressing(self, action: Action) -> None:
         self.transfer_model.set_progress(action.export())
 

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -1333,7 +1333,7 @@ class Application(QApplication):
 
     @pyqtSlot(str)
     def get_last_files(self, uid: str) -> None:
-        files = self.api.get_last_files(uid, 10, "")
+        files = self.api.get_last_files(uid, 10)
         if files != self.file_model.files:
             self.file_model.empty()
             self.file_model.addFiles(files)

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -761,7 +761,7 @@ class Application(QApplication):
         engine.noSpaceLeftOnDevice.connect(self._no_space_left)
         engine.newSyncStarted.connect(self.refresh_files)
         engine.newSyncEnded.connect(self.refresh_files)
-        engine.transferUpdated.connect(self.refresh_transfers)
+        engine.dao.transferUpdated.connect(self.refresh_transfers)
         self.change_systray_icon()
 
     def init_checks(self) -> None:
@@ -1324,8 +1324,8 @@ class Application(QApplication):
             self.transfer_model.set_transfers(transfers)
             self.transfer_model.fileChanged.emit()
 
-    @pyqtSlot()
-    def refresh_files(self) -> None:
+    @pyqtSlot(object)
+    def refresh_files(self, metrics: Dict[str, Any]) -> None:
         engine = self.sender()
         if not isinstance(engine, Engine):
             return

--- a/nxdrive/objects.py
+++ b/nxdrive/objects.py
@@ -2,7 +2,6 @@
 import hashlib
 import unicodedata
 from collections import namedtuple
-from contextlib import suppress
 from datetime import datetime
 from pathlib import Path
 from sqlite3 import Row
@@ -326,17 +325,16 @@ class DocPair(Row):
             f" local_state={self.local_state!r},"
             f" remote_state={self.remote_state!r},"
             f" pair_state={self.pair_state!r},"
-            f" filter_path={self.path!r}"
+            # f" filter_path={self.path!r}"
             ">"
         )
 
     def __getattr__(self, name: str) -> Optional[Union[str, Path]]:
-        with suppress(IndexError):
-            if name in {"local_path", "local_parent_path"}:
-                return Path((self[name] or "").lstrip("/"))
-            if name == "remote_ref":
-                return self[name] or ""
-            return self[name]
+        if name in ("local_path", "local_parent_path"):
+            return Path((self[name] or "").lstrip("/"))
+        if name == "remote_ref":
+            return self[name] or ""
+        return self[name]
 
     def export(self) -> Dict[str, Any]:
         result: Dict[str, Any] = {
@@ -396,10 +394,9 @@ class EngineDef(Row):
     name: str
 
     def __getattr__(self, name: str) -> Optional[Union[str, Path]]:
-        with suppress(IndexError):
-            if name == "local_folder":
-                return Path(self[name])
-            return self[name]
+        if name == "local_folder":
+            return Path(self[name])
+        return self[name]
 
 
 @dataclass

--- a/tests/unit/test_engine_dao.py
+++ b/tests/unit/test_engine_dao.py
@@ -269,13 +269,13 @@ def test_last_sync(engine_dao):
             assert files[i].id == ids[i]
 
         ids = [58, 62, 61, 60, 63]
-        files = dao.get_last_files(5, "remote")
+        files = dao.get_last_files(5, direction="remote")
         assert len(files) == 5
         for i in range(5):
             assert files[i].id == ids[i]
 
         ids = [8, 11, 5]
-        files = dao.get_last_files(5, "local")
+        files = dao.get_last_files(5, direction="local")
         assert len(files) == 3
         for i in range(3):
             assert files[i].id == ids[i]


### PR DESCRIPTION
It seems we cannot use `Action` as a PyQt slot type. Using `object` fixes the issue.

Also:

* Fix `Engine.refresh_files()` QtSlot: it was missing an argment
* Removed `Engine.transferUpdated`;
* Removed `Engine.get_last_files()` and `.get_last_files_count()`;
* Remove unsued `state_factory` arg from `EngineDAO.__init__()`;
* Do not alter `EngineDAO.row_factory` in `get_transfers()`;
* Remove non-signal class attributes in `activity.py`;
* NXDRIVE-1604: Set keyword only `get_last_file()` methods. Same for `get_last_files_count()`;
* Set up a timer to kick off the event loop every 100 ms.