### PR TITLE
NXDRIVE-1727: Check for local folder rights and fail gracefully on permission error

### DIFF
--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -21,6 +21,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1707](https://jira.nuxeo.com/browse/NXDRIVE-1707): Set the UTF-8 encoding while opening/reading/writing text files
 - [NXDRIVE-1717](https://jira.nuxeo.com/browse/NXDRIVE-1717): Use `sizeof_fmt()` to have proper speed metrics
 - [NXDRIVE-1721](https://jira.nuxeo.com/browse/NXDRIVE-1721): Fix `get_timestamp_from_date()` signature
+- [NXDRIVE-1727](https://jira.nuxeo.com/browse/NXDRIVE-1727): Check for local folder rights and fail gracefully on permission error
 
 ## GUI
 

--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -21,6 +21,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1707](https://jira.nuxeo.com/browse/NXDRIVE-1707): Set the UTF-8 encoding while opening/reading/writing text files
 - [NXDRIVE-1717](https://jira.nuxeo.com/browse/NXDRIVE-1717): Use `sizeof_fmt()` to have proper speed metrics
 - [NXDRIVE-1721](https://jira.nuxeo.com/browse/NXDRIVE-1721): Fix `get_timestamp_from_date()` signature
+- [NXDRIVE-1723](https://jira.nuxeo.com/browse/NXDRIVE-1723): When selecting a local folder on auth, another folder is selected
 - [NXDRIVE-1727](https://jira.nuxeo.com/browse/NXDRIVE-1727): Check for local folder rights and fail gracefully on permission error
 
 ## GUI

--- a/nxdrive/data/i18n/i18n.json
+++ b/nxdrive/data/i18n/i18n.json
@@ -123,6 +123,7 @@
     "FILTERS_WINDOW_TITLE": "Nuxeo Drive - Filters",
     "FILTERS_DISABLED": "You must wait for current synchronisation actions to be done before filtering some folders.",
     "FOLDER_DOES_NOT_EXISTS": "This folder does not exist",
+    "FOLDER_PERMISSION_ERROR": "No enough rights to use the local folder",
     "FOLDER_USED": "Folder already used by another Nuxeo Drive account",
     "HELP": "Help",
     "HOST": "Host",

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -486,10 +486,12 @@ class Engine(QObject):
 
         self.dispose_db()
         try:
-            os.remove(self._get_db_file())
-        except OSError as exc:
-            if exc.errno != 2:  # File not found, already removed
-                log.exception("Database removal error")
+            self._get_db_file().unlink()
+        except FileNotFoundError:
+            # File already removed
+            pass
+        except OSError:
+            log.exception("Database removal error")
 
     def check_fs_marker(self) -> bool:
         tag, tag_value = "drive-fs-test", b"NXDRIVE_VERIFICATION"

--- a/nxdrive/gui/api.py
+++ b/nxdrive/gui/api.py
@@ -566,6 +566,8 @@ class QMLDriveApi(QObject):
             error = "UNAUTHORIZED"
         except FolderAlreadyUsed:
             error = "FOLDER_USED"
+        except PermissionError:
+            error = "FOLDER_PERMISSION_ERROR"
         except HTTPError:
             error = "CONNECTION_ERROR"
         except CONNECTION_ERROR as e:

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -302,13 +302,12 @@ def increment_local_folder(basefolder: Path, name: str) -> Path:
     Example: "Nuxeo Drive" > "Nuxeo Drive 2" > "Nuxeo Drive 3"
     """
     folder = basefolder / name
-    for num in range(2, 42):
+    num = 2
+    while "checking":
         if not folder.is_dir():
-            break
+            return folder
         folder = basefolder / f"{name} {num}"
-    else:
-        folder = Path()
-    return folder
+        num += 1
 
 
 def is_hexastring(value: str) -> bool:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -269,7 +269,7 @@ def test_get_timestamp_from_date():
     assert nxdrive.utils.get_timestamp_from_date(None) == 0
 
     dtime = datetime(2019, 6, 20)
-    assert nxdrive.utils.get_timestamp_from_date(dtime) == 1560988800
+    assert nxdrive.utils.get_timestamp_from_date(dtime) == 1_560_988_800
 
 
 @pytest.mark.parametrize("hostname", BAD_HOSTNAMES)
@@ -370,6 +370,29 @@ def test_guess_server_url(url, result):
             pytest.skip(f"Intranet not stable ({exc})")
     else:
         assert func(url) == result
+
+
+def test_increment_local_folder(tmp):
+    func = nxdrive.utils.increment_local_folder
+    basefolder = tmp()
+    name = "folder"
+
+    # There is no existing folder
+    assert func(basefolder, name) == basefolder / "folder"
+
+    # Create the folder, and check the next call returns an incremented folder name
+    (basefolder / "folder").mkdir(parents=True)
+    assert func(basefolder, name) == basefolder / "folder 2"
+
+    # Loop on folder creation for 100 iterations to check we always get an incremented folder name.
+    # Before NXDRIVE-1723, after 41 iterations it was returning ".", the current folder (bad).
+    for n in range(2, 101):
+        assert func(basefolder, name) == basefolder / f"folder {n}"
+        (basefolder / f"folder {n}").mkdir()
+
+    # Remove 1 folder in the middle of all and check we get it back when calling the function
+    (basefolder / "folder 69").rmdir()
+    assert func(basefolder, name) == basefolder / "folder 69"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
* Also improved Engine.unbind() when the database file is already deleted;
* NXDRIVE-1723: When selecting a local folder on auth, another folder is selected.