### PR TITLE
NXDRIVE-1722: Correctly handle Unauthorized and Forbidden statuses

### DIFF
--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -21,6 +21,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1707](https://jira.nuxeo.com/browse/NXDRIVE-1707): Set the UTF-8 encoding while opening/reading/writing text files
 - [NXDRIVE-1717](https://jira.nuxeo.com/browse/NXDRIVE-1717): Use `sizeof_fmt()` to have proper speed metrics
 - [NXDRIVE-1721](https://jira.nuxeo.com/browse/NXDRIVE-1721): Fix `get_timestamp_from_date()` signature
+- [NXDRIVE-1722](https://jira.nuxeo.com/browse/NXDRIVE-1722): Correctly handle Unauthorized and Forbidden statuses
 - [NXDRIVE-1723](https://jira.nuxeo.com/browse/NXDRIVE-1723): When selecting a local folder on auth, another folder is selected
 - [NXDRIVE-1727](https://jira.nuxeo.com/browse/NXDRIVE-1727): Check for local folder rights and fail gracefully on permission error
 
@@ -54,7 +55,7 @@ Release date: `2019-xx-xx`
 - Packaging: Added `requests` 2.2.0
 - Packaging: Removed `dataclasses` 0.6
 - Packaging: Updated `markdown` from 3.1 to 3.1.1
-- Packaging: Updated `nuxeo` from 2.0.5 to 2.1.1
+- Packaging: Updated `nuxeo` from 2.0.5 to 2.2.1
 - Packaging: Updated `pre-commit` from 1.16.1 to 1.17.0
 - Packaging: Updated `pycryptodomex` from 3.8.1 to 3.8.2
 - Packaging: Updated `pytest` from 4.5.0 to 4.6.2
@@ -117,6 +118,7 @@ Release date: `2019-xx-xx`
 - Added exceptions.py::`DownloadPaused`
 - Added exceptions.py::`TransferPaused`
 - Added exceptions.py::`UploadPaused`
+- Removed exceptions.py::`Forbidden`. Use `nuxeo.exceptions.Forbidden` instead.
 - Added fatal_error.py
 - Renamed gui/view.py::`ActionModel` to `TransferModel`
 - Added objects.py::`Download`

--- a/nxdrive/direct_edit.py
+++ b/nxdrive/direct_edit.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional, Pattern, TYPE_CHECKING
 from urllib.parse import quote
 
 from PyQt5.QtWidgets import QApplication
-from nuxeo.exceptions import HTTPError
+from nuxeo.exceptions import Forbidden, HTTPError
 from nuxeo.utils import get_digest_algorithm
 from nuxeo.models import Blob
 from PyQt5.QtCore import pyqtSignal, pyqtSlot
@@ -35,13 +35,7 @@ from .engine.activity import tooltip, DownloadAction
 from .engine.blacklist_queue import BlacklistQueue
 from .engine.watcher.local_watcher import DriveFSEventHandler
 from .engine.workers import Worker
-from .exceptions import (
-    DocumentAlreadyLocked,
-    Forbidden,
-    NotFound,
-    ThreadInterrupt,
-    UnknownDigest,
-)
+from .exceptions import DocumentAlreadyLocked, NotFound, ThreadInterrupt, UnknownDigest
 from .objects import DirectEditDetails, Metrics, NuxeoDocumentInfo, Download
 from .utils import (
     current_milli_time,

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -10,7 +10,13 @@ from time import sleep
 from typing import Any, Callable, Dict, List, Optional, Tuple, TYPE_CHECKING
 
 from PyQt5.QtCore import pyqtSignal
-from nuxeo.exceptions import CorruptedFile, HTTPError, Unauthorized, UploadError
+from nuxeo.exceptions import (
+    CorruptedFile,
+    Forbidden,
+    HTTPError,
+    Unauthorized,
+    UploadError,
+)
 
 from .activity import Action
 from .workers import EngineWorker
@@ -295,6 +301,12 @@ class Processor(EngineWorker):
             except Unauthorized:
                 self.giveup_error(doc_pair, "INVALID_CREDENTIALS")
                 continue
+            except Forbidden:
+                msg = (
+                    f" Access to the document {doc_pair.remote_ref!r} on server {self.engine.hostname!r}"
+                    f" is forbidden for user {self.engine.remote_user!r}"
+                )
+                log.warning(msg)
             except (PairInterrupt, ParentNotSynced) as exc:
                 log.info(f"{type(exc).__name__} on {doc_pair!r}, wait 1s and requeue")
                 sleep(1)

--- a/nxdrive/engine/watcher/remote_watcher.py
+++ b/nxdrive/engine/watcher/remote_watcher.py
@@ -7,13 +7,13 @@ from time import monotonic, sleep
 from typing import Any, Dict, Optional, Set, Tuple, TYPE_CHECKING
 
 from PyQt5.QtCore import pyqtSignal, pyqtSlot
-from nuxeo.exceptions import BadQuery, HTTPError
+from nuxeo.exceptions import BadQuery, HTTPError, Unauthorized
 
 from ..activity import Action, tooltip
 from ..workers import EngineWorker
 from ...client.local_client import FileInfo
 from ...constants import BATCH_SIZE, CONNECTION_ERROR, ROOT, WINDOWS
-from ...exceptions import Forbidden, NotFound, ScrollDescendantsError, ThreadInterrupt
+from ...exceptions import NotFound, ScrollDescendantsError, ThreadInterrupt
 from ...objects import Metrics, RemoteFileInfo, DocPair, DocPairs
 from ...utils import safe_filename, get_date_from_sqlite
 
@@ -617,7 +617,7 @@ class RemoteWatcher(EngineWorker):
             log.warning(exc)
         except (*CONNECTION_ERROR, OSError) as exc:
             log.warning(f"Network error: {exc}")
-        except Forbidden:
+        except Unauthorized:
             self.engine.set_invalid_credentials()
             self.engine.set_offline()
         except HTTPError as exc:
@@ -891,9 +891,7 @@ class RemoteWatcher(EngineWorker):
                                 f"Trying to synchronize remote duplicate rename of {doc_pair}, "
                                 f"forcing new local path {info}"
                             )
-                            self.dao.update_local_state(
-                                doc_pair, info, versioned=False
-                            )
+                            self.dao.update_local_state(doc_pair, info, versioned=False)
 
                         if self.dao.update_remote_state(
                             doc_pair,

--- a/nxdrive/exceptions.py
+++ b/nxdrive/exceptions.py
@@ -48,12 +48,6 @@ class FolderAlreadyUsed(DriveError):
     pass
 
 
-class Forbidden(DriveError):
-    """ The access to a remote document is forbidden for the user. """
-
-    pass
-
-
 class InvalidDriveException(DriveError):
     """ The bound folder cannot be used on this file system. """
 

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -305,9 +305,10 @@ def increment_local_folder(basefolder: Path, name: str) -> Path:
     num = 2
     while "checking":
         if not folder.is_dir():
-            return folder
+            break
         folder = basefolder / f"{name} {num}"
         num += 1
+    return folder
 
 
 def is_hexastring(value: str) -> bool:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ distro==1.4.0; sys_platform == 'linux'
 https://github.com/GoodRx/universal-analytics-python/archive/77ce628c56de1ba51a9bf0774794fd687f785803.zip
 https://github.com/gorakhargosh/watchdog/archive/8b94506c3156a3b66faef7aac9a139f603772506.zip
 markdown==3.1.1
-nuxeo==2.1.1
+nuxeo==2.2.1
 psutil==5.6.2
 pyaml==19.4.1
 pycryptodomex==3.8.2

--- a/tests/old_functional/test_direct_edit.py
+++ b/tests/old_functional/test_direct_edit.py
@@ -6,14 +6,10 @@ from typing import Any, Dict
 from urllib.error import URLError
 
 import pytest
+from nuxeo.exceptions import Forbidden
 from unittest.mock import patch
 
-from nxdrive.exceptions import (
-    DocumentAlreadyLocked,
-    Forbidden,
-    NotFound,
-    ThreadInterrupt,
-)
+from nxdrive.exceptions import DocumentAlreadyLocked, NotFound, ThreadInterrupt
 from nxdrive.objects import NuxeoDocumentInfo
 from nxdrive.utils import safe_os_filename
 from . import LocalTest, make_tmp_file

--- a/tests/old_functional/test_permission_hierarchy.py
+++ b/tests/old_functional/test_permission_hierarchy.py
@@ -4,9 +4,9 @@ from contextlib import suppress
 from pathlib import Path
 
 import pytest
+from nuxeo.exceptions import Forbidden
 
 from nxdrive.constants import WINDOWS
-from nxdrive.exceptions import Forbidden
 from . import LocalTest
 from .common import OneUserTest, TwoUsersTest
 from ..markers import windows_only

--- a/tests/old_functional/test_readonly.py
+++ b/tests/old_functional/test_readonly.py
@@ -4,9 +4,9 @@ from logging import getLogger
 from pathlib import Path
 
 import pytest
+from nuxeo.exceptions import Forbidden
 
 from nxdrive.constants import WINDOWS
-from nxdrive.exceptions import Forbidden
 from .common import FS_ITEM_ID_PREFIX, SYNC_ROOT_FAC_ID, OneUserTest, TwoUsersTest
 from ..markers import windows_only
 

--- a/tests/old_functional/test_synchronization.py
+++ b/tests/old_functional/test_synchronization.py
@@ -4,10 +4,9 @@ from pathlib import Path
 from unittest.mock import patch
 
 from requests import ConnectionError
-from nuxeo.exceptions import HTTPError
+from nuxeo.exceptions import HTTPError, Unauthorized
 
 from nxdrive.constants import ROOT, WINDOWS
-from nxdrive.exceptions import Forbidden
 from . import LocalTest
 from .common import OS_STAT_MTIME_RESOLUTION, OneUserTest, TwoUsersTest
 from .. import ensure_no_exception
@@ -142,7 +141,7 @@ class TestSynchronization(OneUserTest):
         # Simulate bad responses
         with patch.object(self.engine_1, "remote", new=self.get_bad_remote()):
             self.engine_1.remote.request_token()
-            self.engine_1.remote.make_server_call_raise(Forbidden())
+            self.engine_1.remote.make_server_call_raise(Unauthorized())
             self.wait_sync(wait_for_async=True, fail_if_timeout=False)
             assert self.engine_1.is_offline()
 


### PR DESCRIPTION
* Packaging: Updated nuxeo from 2.1.1 to 2.2.1;
* NXDRIVE-1731: Fix `UnboundLocalError`: local variable 'handler_name' referenced before assignment in `Processor`.