### PR TITLE
NXDRIVE-1733: Fix missing "select" argument in open_local_file()

### DIFF
--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -25,6 +25,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1723](https://jira.nuxeo.com/browse/NXDRIVE-1723): When selecting a local folder on auth, another folder is selected
 - [NXDRIVE-1727](https://jira.nuxeo.com/browse/NXDRIVE-1727): Check for local folder rights and fail gracefully on permission error
 - [NXDRIVE-1733](https://jira.nuxeo.com/browse/NXDRIVE-1733): Fix missing `select` argument in `open_local_file()`
+- [NXDRIVE-1736](https://jira.nuxeo.com/browse/NXDRIVE-1736): Filter out the `WinError` 123 (about long file names too long)
 
 ## GUI
 
@@ -112,6 +113,7 @@ Release date: `2019-xx-xx`
 - Moved \_\_main__.py::`check_executable_path` to fatal_error.py
 - Moved \_\_main__.py::`show_critical_error` to fatal_error.py
 - Removed \_\_main__.py::`section`
+- Added constants.py::`LONG_FILE_ERRORS`
 - Added constants.py::`TransferStatus`
 - Added engine/activity.py::`DownloadAction`
 - Added engine/activity.py::`UploadAction`

--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -24,6 +24,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1722](https://jira.nuxeo.com/browse/NXDRIVE-1722): Correctly handle Unauthorized and Forbidden statuses
 - [NXDRIVE-1723](https://jira.nuxeo.com/browse/NXDRIVE-1723): When selecting a local folder on auth, another folder is selected
 - [NXDRIVE-1727](https://jira.nuxeo.com/browse/NXDRIVE-1727): Check for local folder rights and fail gracefully on permission error
+- [NXDRIVE-1733](https://jira.nuxeo.com/browse/NXDRIVE-1733): Fix missing `select` argument in `open_local_file()`
 
 ## GUI
 

--- a/nxdrive/constants.py
+++ b/nxdrive/constants.py
@@ -49,6 +49,36 @@ NO_SPACE_ERRORS = {
     errno.ERANGE,  # Result too large
 }
 
+# OSError indicating the incapacity to do anything because of too long file name or deep tree.
+#
+# OSError: [Errno 36] Filename too long
+# Cause: on GNU/Linux, filename is restricted to 255 chars or even worse: 143 if using encryptFS.
+#
+# WindowsError: [Error 111] ??? (seems related to deep tree)
+# Cause: short paths are disabled on Windows
+#
+# WindowsError: [Error 121] The source or destination path exceeded or would exceed MAX_PATH.
+# Cause: short paths are disabled on Windows
+#
+# OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect.
+#
+# WindowsError: [Error 124] The path in the source or destination or both was invalid.
+# Cause: dealing with different drives, ie when the sync folder is not on the same drive as Nuxeo Drive one.
+#
+# WindowsError: [Error 206] The filename or extension is too long.
+# Cause: even the full short path is too long
+#
+# OSError: Couldn't perform operation. Error code: 1223 (seems related to long paths)
+LONG_FILE_ERRORS = {
+    errno.ENAMETOOLONG,  # Filename too long
+    111,
+    121,
+    123,
+    124,
+    206,
+    1223,
+}
+
 CONNECTION_ERROR = (ChunkedEncodingError, ConnectionError, Timeout)
 
 

--- a/nxdrive/manager.py
+++ b/nxdrive/manager.py
@@ -383,7 +383,7 @@ class Manager(QObject):
         file_path = force_decode(file_path)
         log.info(f"Launching editor on {file_path!r}")
         try:
-            self.osi.open_local_file(file_path)
+            self.osi.open_local_file(file_path, select=select)
         except OSError as exc:
             if exc.errno in NO_SPACE_ERRORS:
                 log.warning("Cannot open local file, disk space needed", exc_info=True)

--- a/tests/old_functional/common.py
+++ b/tests/old_functional/common.py
@@ -13,7 +13,7 @@ from unittest import TestCase
 from uuid import uuid4
 
 from faker import Faker
-from PyQt5.QtCore import QCoreApplication, QTimer, pyqtSignal, pyqtSlot
+from PyQt5.QtCore import QCoreApplication, pyqtSignal, pyqtSlot
 from nuxeo.models import Document, User
 
 from sentry_sdk import configure_scope
@@ -220,17 +220,6 @@ class TwoUsersTest(TestCase):
 
             with suppress(Exception):
                 self.app.quit()
-
-        # Ensure to kill the app if it is taking too long.
-        # We need to do that because sometimes a thread get blocked and so the test suite.
-        # Here, we set the timeout to 00:02:00, let's see if a higher value is needed.
-        timeout = 2 * 60
-
-        def kill_test():
-            log.error(f"Killing {self.id()} after {timeout} seconds")
-            self.app.quit()
-
-        QTimer.singleShot(timeout * 1000, kill_test)
 
         # Start the app and let signals transit between threads!
         sync_thread = Thread(target=launch_test)

--- a/tests/old_functional/test_multiple_files.py
+++ b/tests/old_functional/test_multiple_files.py
@@ -92,7 +92,7 @@ class TestMultipleFiles(OneUserTest):
         num = self.NUMBER_OF_LOCAL_FILES
         names = set(["local%04d.txt" % n for n in range(1, num + 1)])
 
-        for path in {new_path, copy_path}:
+        for path in (new_path, copy_path):
             # Local
             assert local.abspath(path).exists()
             children = [f.name for f in local.abspath(path).iterdir()]


### PR DESCRIPTION
* NXDRIVE-1736: Filter out the `WinError 123` (about long file names too long);
* Remove the `QTimer` to kill a test. It is no more useful since 7b317b4.