### PR TITLE
NXDRIVE-1744: Always use the full exception string when increasing an…

### DIFF
--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -26,6 +26,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1727](https://jira.nuxeo.com/browse/NXDRIVE-1727): Check for local folder rights and fail gracefully on permission error
 - [NXDRIVE-1733](https://jira.nuxeo.com/browse/NXDRIVE-1733): Fix missing `select` argument in `open_local_file()`
 - [NXDRIVE-1736](https://jira.nuxeo.com/browse/NXDRIVE-1736): Filter out the `WinError` 123 (about long file names too long)
+- [NXDRIVE-1744](https://jira.nuxeo.com/browse/NXDRIVE-1744): Always use the full exception string when increasing an error
 
 ## GUI
 

--- a/nxdrive/engine/workers.py
+++ b/nxdrive/engine/workers.py
@@ -215,10 +215,7 @@ class EngineWorker(Worker):
     ) -> None:
         details = None
         if exception:
-            try:
-                details = getattr(exception, "message")
-            except AttributeError:
-                details = str(exception)
+            details = str(exception)
         log.info(f"Increasing error [{error}] ({details}) for {doc_pair!r}")
         self.dao.increase_error(doc_pair, error, details=details)
         self.engine.queue_manager.push_error(doc_pair, exception=exception)


### PR DESCRIPTION
… error