### PR TITLE
NXDRIVE-1734: Ignore decoding issues when retrieving the path stored in xattrs

### DIFF
--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -25,6 +25,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1723](https://jira.nuxeo.com/browse/NXDRIVE-1723): When selecting a local folder on auth, another folder is selected
 - [NXDRIVE-1727](https://jira.nuxeo.com/browse/NXDRIVE-1727): Check for local folder rights and fail gracefully on permission error
 - [NXDRIVE-1733](https://jira.nuxeo.com/browse/NXDRIVE-1733): Fix missing `select` argument in `open_local_file()`
+- [NXDRIVE-1734](https://jira.nuxeo.com/browse/NXDRIVE-1734): Ignore decoding issues when retrieving the path stored in xattrs
 - [NXDRIVE-1736](https://jira.nuxeo.com/browse/NXDRIVE-1736): Filter out the `WinError` 123 (about long file names too long)
 - [NXDRIVE-1744](https://jira.nuxeo.com/browse/NXDRIVE-1744): Always use the full exception string when increasing an error
 - [NXDRIVE-1746](https://jira.nuxeo.com/browse/NXDRIVE-1746): Fix the `--ssl-no-verify` option from the CLI that is always set to False
@@ -107,6 +108,7 @@ Release date: `2019-xx-xx`
 - Removed `state_factory` keyworkd argument from `EngineDAO.__init__()`
 - Changed `EngineDAO.update_remote_state()` return type from `None` to `bool`
 - Added `FileModel.ID` role
+- Added `LocalClient.set_path_remote_id()`
 - Renamed `check_suspended` keyword argument of `LocalClient.__init__()` to `digest_callback`
 - Added `Manager.directEdit` signal
 - Added `purge` argument to `Manager.unbind_engine()`

--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -24,6 +24,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1722](https://jira.nuxeo.com/browse/NXDRIVE-1722): Correctly handle Unauthorized and Forbidden statuses
 - [NXDRIVE-1723](https://jira.nuxeo.com/browse/NXDRIVE-1723): When selecting a local folder on auth, another folder is selected
 - [NXDRIVE-1727](https://jira.nuxeo.com/browse/NXDRIVE-1727): Check for local folder rights and fail gracefully on permission error
+- [NXDRIVE-1728](https://jira.nuxeo.com/browse/NXDRIVE-1728): Lower logging level of "Cannot find parent pair of postponed remote descendant, ..."
 - [NXDRIVE-1729](https://jira.nuxeo.com/browse/NXDRIVE-1729): [macOS] Use EAFP to catch `FileNotFoundError` in `send_content_sync_status()`
 - [NXDRIVE-1733](https://jira.nuxeo.com/browse/NXDRIVE-1733): Fix missing `select` argument in `open_local_file()`
 - [NXDRIVE-1734](https://jira.nuxeo.com/browse/NXDRIVE-1734): Ignore decoding issues when retrieving the path stored in xattrs

--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -24,6 +24,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1722](https://jira.nuxeo.com/browse/NXDRIVE-1722): Correctly handle Unauthorized and Forbidden statuses
 - [NXDRIVE-1723](https://jira.nuxeo.com/browse/NXDRIVE-1723): When selecting a local folder on auth, another folder is selected
 - [NXDRIVE-1727](https://jira.nuxeo.com/browse/NXDRIVE-1727): Check for local folder rights and fail gracefully on permission error
+- [NXDRIVE-1729](https://jira.nuxeo.com/browse/NXDRIVE-1729): [macOS] Use EAFP to catch `FileNotFoundError` in `send_content_sync_status()`
 - [NXDRIVE-1733](https://jira.nuxeo.com/browse/NXDRIVE-1733): Fix missing `select` argument in `open_local_file()`
 - [NXDRIVE-1734](https://jira.nuxeo.com/browse/NXDRIVE-1734): Ignore decoding issues when retrieving the path stored in xattrs
 - [NXDRIVE-1736](https://jira.nuxeo.com/browse/NXDRIVE-1736): Filter out the `WinError` 123 (about long file names too long)

--- a/nxdrive/engine/watcher/remote_watcher.py
+++ b/nxdrive/engine/watcher/remote_watcher.py
@@ -317,7 +317,7 @@ class RemoteWatcher(EngineWorker):
                     descendant_info.parent_uid
                 )
                 if not parent_pair:
-                    log.error(
+                    log.warning(
                         "Cannot find parent pair of postponed remote descendant, "
                         f"ignoring {descendant_info}"
                     )

--- a/nxdrive/osi/darwin/darwin.py
+++ b/nxdrive/osi/darwin/darwin.py
@@ -211,16 +211,14 @@ class DarwinIntegration(AbstractOSIntegration):
         :param state: current local state of the file
         :param path: full path of the file
         """
+        name = f"{BUNDLE_IDENTIFIER}.syncStatus"
         try:
-            if not path.exists():
-                return
-
-            name = f"{BUNDLE_IDENTIFIER}.syncStatus"
             status = get_formatted_status(state, path)
-
             log.debug(f"Sending status to FinderSync for {path!r}: {status}")
             self._send_notification(name, {"statuses": [status]})
-        except:
+        except FileNotFoundError:
+            pass
+        except Exception:
             log.exception("Error while trying to send status to FinderSync")
 
     @if_frozen
@@ -231,12 +229,8 @@ class DarwinIntegration(AbstractOSIntegration):
         :param states: current local states of the children of the folder
         :param path: full path of the folder
         """
+        name = f"{BUNDLE_IDENTIFIER}.syncStatus"
         try:
-            if not path.exists():
-                return
-
-            name = f"{BUNDLE_IDENTIFIER}.syncStatus"
-
             # We send the statuses of the children by batch in case
             # the notification center doesn't allow notifications
             # with a heavy payload.
@@ -255,7 +249,9 @@ class DarwinIntegration(AbstractOSIntegration):
                 )
                 log.debug(statuses)
                 self._send_notification(name, {"statuses": statuses})
-        except:
+        except FileNotFoundError:
+            pass
+        except Exception:
             log.exception("Error while trying to send status to FinderSync")
 
     @if_frozen

--- a/tests/functional/test_local_client.py
+++ b/tests/functional/test_local_client.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+from nxdrive.client.local_client import LocalClient
+
+
+def test_set_get_xattr_file_not_found(tmp):
+    """If file is not found, there is no value to retrieve."""
+    file = Path("file-no-found.txt")
+
+    # This call should not fail
+    LocalClient.set_path_remote_id(file, "something")
+
+    # And this one should return an empty string
+    assert LocalClient.get_path_remote_id(file) == ""
+
+
+def test_set_get_xattr_invalid_start_byte(tmp):
+    """
+    Ensure this will never happen again:
+        UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 8: invalid start byte
+    """
+    folder = tmp()
+    folder.mkdir()
+
+    file = folder / "test-xattr.txt"
+    file.write_text("bla" * 3)
+
+    raw_value, result_needed = b"fdrpMACS\x80", "fdrpMACS"
+    LocalClient.set_path_remote_id(file, raw_value)
+    assert LocalClient.get_path_remote_id(file) == result_needed


### PR DESCRIPTION
Introduced the `LocalClient.set_path_remote_id()` static method to be able to test the feature without needing an account.

While testing, I saw that on Windows, when a file is not found and we want to set the remote ID, an exception would be rasied. But not on other OSes. So I aligned the behavior.

* NXDRIVE-1729: [macOS] Use EAFP to catch `FileNotFoundError` in `send_content_sync_status()`

* NXDRIVE-1728: Lower logging level of "Cannot find parent pair of post…poned remote descendant, ..."