### PR TITLE
NXDRIVE-1753: Improve uploads robustness

### DIFF
--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -34,6 +34,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1744](https://jira.nuxeo.com/browse/NXDRIVE-1744): Always use the full exception string when increasing an error
 - [NXDRIVE-1746](https://jira.nuxeo.com/browse/NXDRIVE-1746): Fix the `--ssl-no-verify` option from the CLI that is always set to False
 - [NXDRIVE-1752](https://jira.nuxeo.com/browse/NXDRIVE-1752): Fix account removal when the server is not responding
+- [NXDRIVE-1753](https://jira.nuxeo.com/browse/NXDRIVE-1753): Improve uploads robustness
 
 ## GUI
 
@@ -128,7 +129,9 @@ Release date: `2019-xx-xx`
 - Added `QMLDriveApi.resume_transfer()`
 - Added `purge` argument to `QMLDriveApi.unbind_server()`
 - Added `Remote.check_integrity()`
+- Added `Remote.link_blob_to_doc()`
 - Added `Remote.upload_callback()`
+- Added `Remote.upload_chunks()`
 - Renamed `check_suspended` keyword argument of `Remote.__init__()` to `download_callback`
 - Moved \_\_main__.py::`check_executable_path` to fatal_error.py
 - Moved \_\_main__.py::`show_critical_error` to fatal_error.py

--- a/nxdrive/engine/dao/sqlite.py
+++ b/nxdrive/engine/dao/sqlite.py
@@ -1716,13 +1716,13 @@ class EngineDAO(ConfigurationDAO):
         # Check if it really needs an update
         if (
             row.remote_ref == info.uid
-            and info.parent_uid == row.remote_parent_ref
-            and remote_parent_path == row.remote_parent_path
-            and info.name == row.remote_name
-            and info.can_rename == row.remote_can_rename
-            and info.can_delete == row.remote_can_delete
-            and info.can_update == row.remote_can_update
-            and info.can_create_child == row.remote_can_create_child
+            and row.remote_parent_ref == info.parent_uid
+            and row.remote_parent_path == remote_parent_path
+            and row.remote_name == info.name
+            and row.remote_can_rename == info.can_rename
+            and row.remote_can_delete == info.can_delete
+            and row.remote_can_update == info.can_update
+            and row.remote_can_create_child == info.can_create_child
         ):
             bname = os.path.basename(row.local_path)
             if bname == info.name or (WINDOWS and bname.strip() == info.name.strip()):

--- a/nxdrive/engine/watcher/remote_watcher.py
+++ b/nxdrive/engine/watcher/remote_watcher.py
@@ -615,11 +615,11 @@ class RemoteWatcher(EngineWorker):
             raise
         except ScrollDescendantsError as exc:
             log.warning(exc)
-        except (*CONNECTION_ERROR, OSError) as exc:
-            log.warning(f"Network error: {exc}")
         except Unauthorized:
             self.engine.set_invalid_credentials()
             self.engine.set_offline()
+        except (*CONNECTION_ERROR, OSError) as exc:
+            log.warning(f"Network error: {exc}")
         except HTTPError as exc:
             status = exc.status
             err = f"HTTP error {status} while trying to handle remote changes"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,9 @@ appdirs==1.4.3
 distro==1.4.0; sys_platform == 'linux'
 https://github.com/GoodRx/universal-analytics-python/archive/77ce628c56de1ba51a9bf0774794fd687f785803.zip
 https://github.com/gorakhargosh/watchdog/archive/8b94506c3156a3b66faef7aac9a139f603772506.zip
+# nuxeo==2.2.2
+https://github.com/nuxeo/nuxeo-python-client/archive/3ec0744e0c14a629c95f128c3815fd69e53fb30b.zip
 markdown==3.1.1
-nuxeo==2.2.1
 psutil==5.6.2
 pyaml==19.4.1
 pycryptodomex==3.8.2

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -112,6 +112,10 @@ def ensure_no_exception():
 
     def error(type_, value, traceback) -> None:
         """ Install an exception hook to catch any error. """
+        # Mock'ed errors should not entrave the check
+        if "mock" in str(value).lower():
+            return
+
         nonlocal received
         received = True
         print(type_)

--- a/tests/old_functional/common.py
+++ b/tests/old_functional/common.py
@@ -121,7 +121,7 @@ class StubQApplication(QCoreApplication):
 
     @pyqtSlot(int)
     def unbind_engine(self, number):
-        self._test.unbind_engine(number)
+        self._test.unbind_engine(number, purge=False)
 
 
 class TwoUsersTest(TestCase):
@@ -414,14 +414,12 @@ class TwoUsersTest(TestCase):
 
         return engine
 
-    def unbind_engine(self, number: int) -> None:
+    def unbind_engine(self, number: int, purge: bool = True) -> None:
         number_str = str(number)
         engine = getattr(self, f"engine_{number_str}")
         manager = getattr(self, f"manager_{number_str}")
-        local_folder = engine.local_folder
-        manager.unbind_engine(engine.uid, purge=True)
+        manager.unbind_engine(engine.uid, purge=purge)
         delattr(self, f"engine_{number_str}")
-        assert not local_folder.exists()
 
     def send_bind_engine(self, number: int, start_engine: bool = True) -> None:
         self.app.bindEngine.emit(number, start_engine)

--- a/tests/old_functional/common.py
+++ b/tests/old_functional/common.py
@@ -13,7 +13,7 @@ from unittest import TestCase
 from uuid import uuid4
 
 from faker import Faker
-from PyQt5.QtCore import QCoreApplication, pyqtSignal, pyqtSlot
+from PyQt5.QtCore import QCoreApplication, QTimer, pyqtSignal, pyqtSlot
 from nuxeo.models import Document, User
 
 from sentry_sdk import configure_scope
@@ -220,6 +220,17 @@ class TwoUsersTest(TestCase):
 
             with suppress(Exception):
                 self.app.quit()
+
+        # Ensure to kill the app if it is taking too long.
+        # We need to do that because sometimes a thread get blocked and so the test suite.
+        # Here, we set the timeout to 00:02:00, let's see if a higher value is needed.
+        timeout = 2 * 60
+
+        def kill_test():
+            log.error(f"Killing {self.id()} after {timeout} seconds")
+            self.app.quit()
+
+        QTimer.singleShot(timeout * 1000, kill_test)
 
         # Start the app and let signals transit between threads!
         sync_thread = Thread(target=launch_test)

--- a/tests/old_functional/test_direct_edit.py
+++ b/tests/old_functional/test_direct_edit.py
@@ -223,7 +223,7 @@ class TestDirectEdit(OneUserTest, DirectEditSetup):
         self.direct_edit.directEditForbidden.connect(forbidden_signal)
 
         bad_remote = self.get_bad_remote()
-        bad_remote.make_server_call_raise(Forbidden())
+        bad_remote.make_server_call_raise(Forbidden(message="Mock"))
 
         with patch.object(
             self.manager_1, "open_local_file", new=open_local_file
@@ -246,7 +246,7 @@ class TestDirectEdit(OneUserTest, DirectEditSetup):
 
             # Simulate server error
             bad_remote = self.get_bad_remote()
-            bad_remote.make_upload_raise(Forbidden())
+            bad_remote.make_upload_raise(Forbidden(message="Mock"))
 
             with patch.object(self.engine_1, "remote", new=bad_remote):
                 # Update file content

--- a/tests/old_functional/test_local_creations.py
+++ b/tests/old_functional/test_local_creations.py
@@ -21,7 +21,7 @@ class TestLocalCreations(OneUserTest):
         self.wait_sync(wait_for_async=True)
 
         bad_remote = self.get_bad_remote()
-        error = Unauthorized(status=401, message="Mock")
+        error = Unauthorized(message="Mock")
         bad_remote.make_upload_raise(error)
 
         file = "Performance Reports - error n°401.txt"

--- a/tests/old_functional/test_multiple_files.py
+++ b/tests/old_functional/test_multiple_files.py
@@ -12,7 +12,7 @@ from ..markers import not_linux
 class TestMultipleFiles(OneUserTest):
 
     NUMBER_OF_LOCAL_FILES = 10
-    SYNC_TIMEOUT = 5  # in seconds
+    SYNC_TIMEOUT = 10  # in seconds
 
     def setUp(self):
         """
@@ -92,7 +92,7 @@ class TestMultipleFiles(OneUserTest):
         num = self.NUMBER_OF_LOCAL_FILES
         names = set(["local%04d.txt" % n for n in range(1, num + 1)])
 
-        for path in {new_path, copy_path}:
+        for path in (new_path, copy_path):
             # Local
             assert local.abspath(path).exists()
             children = [f.name for f in local.abspath(path).iterdir()]

--- a/tests/old_functional/test_multiple_files.py
+++ b/tests/old_functional/test_multiple_files.py
@@ -92,7 +92,7 @@ class TestMultipleFiles(OneUserTest):
         num = self.NUMBER_OF_LOCAL_FILES
         names = set(["local%04d.txt" % n for n in range(1, num + 1)])
 
-        for path in (new_path, copy_path):
+        for path in {new_path, copy_path}:
             # Local
             assert local.abspath(path).exists()
             children = [f.name for f in local.abspath(path).iterdir()]

--- a/tests/old_functional/test_reinit_database.py
+++ b/tests/old_functional/test_reinit_database.py
@@ -24,8 +24,8 @@ class TestReinitDatabase(OneUserTest):
         assert self.local.exists("/Test folder")
         assert self.local.exists("/Test folder/Test.txt")
 
-        # Destroy database
-        self.unbind_engine(1)
+        # Destroy database but keep synced files as we just need to test the database
+        self.unbind_engine(1, purge=False)
         self.bind_engine(1, start_engine=False)
 
     def _check_states(self):

--- a/tests/old_functional/test_synchronization.py
+++ b/tests/old_functional/test_synchronization.py
@@ -141,7 +141,7 @@ class TestSynchronization(OneUserTest):
         # Simulate bad responses
         with patch.object(self.engine_1, "remote", new=self.get_bad_remote()):
             self.engine_1.remote.request_token()
-            self.engine_1.remote.make_server_call_raise(Unauthorized())
+            self.engine_1.remote.make_server_call_raise(Unauthorized(message="Mock"))
             self.wait_sync(wait_for_async=True, fail_if_timeout=False)
             assert self.engine_1.is_offline()
 


### PR DESCRIPTION
The commit splits out `Remote.upload()` in 2 parts:

- `Remote.upload_chunks()` to effectively upload a given blob (either in chunk or normal mode).
- `Remote.link_blob_to_doc()` that calls the `NuxeoDrive.CreateDocument` operation.

I reworked the code to be more robust against temporary failures while uploading chunks and after, at the operation call. This should help with big file uploads.

Also:

* This reverts commit 853cb52 as it seems we still need the timer to prevent infinite tests.
* NXDRIVE-1705: Fix tests requiring local data to be present after unbinding.