### PR TITLE
NXDRIVE-1775: Bypass PermissionError raised from Path.resolve()

### DIFF
--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -38,6 +38,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1765](https://jira.nuxeo.com/browse/NXDRIVE-1765): Skip inexistant files in DirectEdit's lock queue
 - [NXDRIVE-1773](https://jira.nuxeo.com/browse/NXDRIVE-1773): Check the parent exists before trying to retrieve its details
 - [NXDRIVE-1774](https://jira.nuxeo.com/browse/NXDRIVE-1774): Filter out `urllib3` logging about "Certificate did not match..."
+- [NXDRIVE-1775](https://jira.nuxeo.com/browse/NXDRIVE-1775): Bypass `PermissionError` raised from `Path.resolve()`
 
 ## GUI
 

--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -39,6 +39,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1773](https://jira.nuxeo.com/browse/NXDRIVE-1773): Check the parent exists before trying to retrieve its details
 - [NXDRIVE-1774](https://jira.nuxeo.com/browse/NXDRIVE-1774): Filter out `urllib3` logging about "Certificate did not match..."
 - [NXDRIVE-1775](https://jira.nuxeo.com/browse/NXDRIVE-1775): Bypass `PermissionError` raised from `Path.resolve()`
+- [NXDRIVE-1776](https://jira.nuxeo.com/browse/NXDRIVE-1776): Handle incorrect chunked encoding in Direct Edit's upload queue
 
 ## GUI
 

--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -40,6 +40,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1774](https://jira.nuxeo.com/browse/NXDRIVE-1774): Filter out `urllib3` logging about "Certificate did not match..."
 - [NXDRIVE-1775](https://jira.nuxeo.com/browse/NXDRIVE-1775): Bypass `PermissionError` raised from `Path.resolve()`
 - [NXDRIVE-1776](https://jira.nuxeo.com/browse/NXDRIVE-1776): Handle incorrect chunked encoding in Direct Edit's upload queue
+- [NXDRIVE-1777](https://jira.nuxeo.com/browse/NXDRIVE-1777): Force re-download if a local file does not exist anymore but it is still referenced in the database
 
 ## GUI
 

--- a/nxdrive/client/local_client.py
+++ b/nxdrive/client/local_client.py
@@ -387,7 +387,7 @@ FolderType=Generic
             path_alt = f"{path}:{name}"
             try:
                 with open(path_alt, "rb") as f:
-                    return f.read().decode("utf-8")
+                    return f.read().decode("utf-8", errors="ignore")
             except OSError:
                 return ""
 

--- a/nxdrive/client/local_client.py
+++ b/nxdrive/client/local_client.py
@@ -743,7 +743,12 @@ FolderType=Generic
         # - target.name == "ABCDE.txt"
         # - "abcde.txt" exists on the filesystem
         # -> target.resolve() will set target.name as "abcde.txt"
-        target = target.resolve().with_name(target.name)
+        try:
+            target = target.resolve().with_name(target.name)
+        except PermissionError:
+            # On Windows, we can get a PermissionError when the file is being
+            # opened in another software, fallback on .absolute() then.
+            target = target.absolute().with_name(target.name)
 
         try:
             return target.relative_to(self.base_folder)

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -994,9 +994,13 @@ class Processor(EngineWorker):
             locker = unlock_path(file_out)
             try:
                 shutil.copy(self.local.abspath(pair.local_path), file_out)
+            except FileNotFoundError:
+                # Let's re-download the file
+                pass
+            else:
+                return file_out
             finally:
                 lock_path(file_out, locker)
-            return file_out
 
         tmp_file = self.remote.stream_content(
             doc_pair.remote_ref,

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -410,7 +410,11 @@ class Processor(EngineWorker):
             # check if the document is present on the server to bypass
             # (infinite|useless) retries.
             # Note: this is ugly as there are hardcoded values, maybe need to review that.
-            path = f"/default-domain/workspaces/{doc_pair.local_path}"
+            local_path = str(doc_pair.local_path)
+            if WINDOWS:
+                local_path = local_path.replace("\\", "/")
+            path = f"/default-domain/workspaces/{local_path}"
+            print("path =", path)
             try:
                 fs_item = self.remote.fetch(path)
             except Exception:

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -467,7 +467,13 @@ def normalized_path(path: Union[bytes, str, Path]) -> Path:
     """ Return absolute, normalized file path. """
     if not isinstance(path, Path):
         path = force_decode(path)
-    return Path(path).expanduser().resolve()
+    expanded = Path(path).expanduser()
+    try:
+        return expanded.resolve()
+    except PermissionError:
+        # On Windows, we can get a PermissionError when the file is being
+        # opened in another software, fallback on .absolute() then.
+        return expanded.absolute()
 
 
 def normalize_and_expand_path(path: str) -> Path:

--- a/tests/functional/test_local_client.py
+++ b/tests/functional/test_local_client.py
@@ -1,9 +1,37 @@
 from pathlib import Path
+from unittest.mock import Mock
 
 from nxdrive.client.local_client import LocalClient
+from nxdrive.constants import ROOT
 
 
-def test_set_get_xattr_file_not_found(tmp):
+def test_get_path(tmp):
+    folder = tmp()
+    folder.mkdir()
+    local = LocalClient(folder)
+    path = folder / "foo.txt"
+    path_upper = folder / "FOO.TXT"
+
+    # The path does not exist, it returns ROOT
+    assert local.get_path(Path("bar.doc")) == ROOT
+
+    # The path exists, it returns
+    assert local.get_path(path) == Path("foo.txt")
+    assert local.get_path(path_upper) == Path("FOO.TXT")
+
+    # Path.resolve() raises a PermissionError, it should fallback on .absolute()
+    Path.resolve = Mock(side_effect=PermissionError())
+    Path.absolute = Mock()
+    path_abs = local.get_path(path)
+    assert Path.absolute.called
+
+    # Restore the original ehavior and check that .resolved() and .absolute()
+    # return the same value.
+    Path.resolve.reset_mock()
+    assert local.get_path(path) == path_abs
+
+
+def test_set_get_xattr_file_not_found():
     """If file is not found, there is no value to retrieve."""
     file = Path("file-no-found.txt")
 

--- a/tests/unit/test_action.py
+++ b/tests/unit/test_action.py
@@ -65,6 +65,7 @@ def test_file_action(tmp):
 
     action = FileAction("Mocking", filepath)
     assert action.type == "Mocking"
+    assert not action.empty
 
     # Will test .get_percent()
     details = action.export()
@@ -78,10 +79,6 @@ def test_file_action(tmp):
     assert Action.get_last_file_action() is None
     assert Action.get_current_action() is action
 
-    # Test repr() when size is None
-    action.size = None
-    assert repr(action) == "Mocking('test.txt')"
-
     # Test repr() when .get_percent() > 0
     action.size = 42
     action.progress = 4.2
@@ -91,6 +88,52 @@ def test_file_action(tmp):
     assert action.finished
 
     assert Action.get_last_file_action() is action
+
+
+def test_file_action_empty_file(tmp):
+    parent = tmp()
+    parent.mkdir()
+    filepath = parent / "test.txt"
+    filepath.touch()
+
+    action = FileAction("Mocking", filepath)
+
+    assert action.empty
+    assert not action.uploaded
+    details = action.export()
+    assert details["action_type"] == "Mocking"
+    assert details["progress"] == 0.0
+    assert isinstance(details["uid"], str)
+    assert details["size"] == 0
+    assert details["name"] == filepath.name
+    assert details["filepath"] == str(filepath)
+
+    # Trigger a progression update telling that the file has been uploaded
+    action.progress += 0
+    assert action.export()["progress"] == 100.0
+    assert action.uploaded
+
+    Action.finish_action()
+
+
+def test_file_action_inexistant_file(tmp):
+    parent = tmp()
+    parent.mkdir()
+    filepath = parent / "test.txt"
+
+    action = FileAction("Mocking", filepath)
+    assert not action.empty
+    assert not action.uploaded
+
+    details = action.export()
+    assert details["action_type"] == "Mocking"
+    assert details["progress"] == 0.0
+    assert isinstance(details["uid"], str)
+    assert details["size"] == -1.0
+    assert details["name"] == filepath.name
+    assert details["filepath"] == str(filepath)
+
+    Action.finish_action()
 
 
 def test_file_action_with_values():
@@ -116,6 +159,7 @@ def test_file_action_with_values():
     action.progress = 222.0
     details = action.export()
     assert details["progress"] == 100.0
+    assert details["uploaded"]
 
 
 def test_file_action_signals():


### PR DESCRIPTION
Also a couple of other fixes to reduce Sentry events:
* NXDRIVE-1777: Force re-download if a local file does not exist anymore but it is still referenced in the database
* NXDRIVE-1776: Handle incorrect chunked encoding in Direct Edit's upload queue
* NXDRIVE-1734: [Windows] Ignore decoding issues when retrieving the path stored in xattrs

And fixes related to uploads:
* NXDRIVE-1753: Handle correctly empty file uploads
* NXDRIVE-1753: [Windows] Fix path separator when calling `Remote.fetch()`
