### PR TITLE
NXDRIVE-1780: Fix "Access online" context menu not opening the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ There is currently no universal package to download. In the meantime you can ins
 
 The easiest and safest way to build Drive is to follow the same steps as we do on [Jenkins](#jenkins).
 
+Note that the `xclip` tool is needed for the clipboard copy/paste to work.
+
 #### xattr
 
 First note that Nuxeo Drive uses [Extended file attributes](https://en.wikipedia.org/wiki/Extended_file_attributes) through the [xattr](https://pypi.python.org/pypi/xattr/) Python wrapper.

--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -42,6 +42,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1775](https://jira.nuxeo.com/browse/NXDRIVE-1775): Bypass `PermissionError` raised from `Path.resolve()`
 - [NXDRIVE-1776](https://jira.nuxeo.com/browse/NXDRIVE-1776): Handle incorrect chunked encoding in Direct Edit's upload queue
 - [NXDRIVE-1777](https://jira.nuxeo.com/browse/NXDRIVE-1777): Force re-download if a local file does not exist anymore but it is still referenced in the database
+- [NXDRIVE-1780](https://jira.nuxeo.com/browse/NXDRIVE-1780): Fix "Access online" context menu not opening the browser
 
 ## GUI
 
@@ -89,6 +90,8 @@ Release date: `2019-xx-xx`
 
 ## Technical Changes
 
+- Added `AbstractOSIntegration.cb_get()` and implementations for all flavors
+- Added `AbstractOSIntegration.cb_set()` and implementations for all flavors
 - Removed `thread_id` keyword argument of `Action.__init__()`
 - Renamed `Application.action_model` to `transfer_model`
 - Renamed `Application.refresh_actions()` to `refresh_transfers()`
@@ -184,6 +187,7 @@ Release date: `2019-xx-xx`
 - Added objects.py::`Upload`
 - Added options.py::`validate_tmp_file_limit()`
 - Added utils.py::`compute_digest()`
+- Removed utils.py::`copy_to_clipboard()`
 - Added utils.py::`current_thread_id()`
 - Added utils.py::`safe_rename()`
 - Added utils.py::`sizeof_fmt()`

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -356,7 +356,6 @@ class Engine(QObject):
         :param edit: Show the metadata edit page instead of the document.
         :return: The complete URL.
         """
-
         _, repo, uid = remote_ref.split("#", 2)
         page = ("view_documents", "view_drive_metadata")[edit]
         token = self.get_remote_token()

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -295,6 +295,7 @@ class Processor(EngineWorker):
                 log.warning(
                     f"The document or its parent does not exist anymore: {doc_pair!r}"
                 )
+                self.remove_void_transfers(doc_pair)
             except Unauthorized:
                 self.giveup_error(doc_pair, "INVALID_CREDENTIALS")
             except Forbidden:

--- a/nxdrive/fatal_error.py
+++ b/nxdrive/fatal_error.py
@@ -144,13 +144,14 @@ def fatal_error_qt(exc_formatted: str) -> None:
 
     def copy() -> None:
         """Copy details to the clipboard and change the text of the button. """
-        copy_to_clipboard("\n".join(details))
+        osi.cb_set("\n".join(details))
         copy_paste.setText(tr("FATAL_ERROR_DETAILS_COPIED"))
 
     # "Copy details" button
     with suppress(Exception):
-        from nxdrive.utils import copy_to_clipboard
+        from nxdrive.osi import AbstractOSIntegration
 
+        osi = AbstractOSIntegration.get(None)
         copy_paste = buttons.addButton(
             tr("FATAL_ERROR_DETAILS_COPY"), QDialogButtonBox.ActionRole
         )

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -114,10 +114,6 @@ class Application(QApplication):
         # kicking off our event loop every few milliseconds.
         #
         # https://machinekoder.com/how-to-not-shoot-yourself-in-the-foot-using-python-qt/
-        #
-        # ---
-        # This is usefull while testing too, as sometimes the test is cancelled due
-        # to a timeout set before running it (wanted behavior).
         self.timer = QTimer()
         self.timer.timeout.connect(lambda: None)
         self.timer.start(100)

--- a/nxdrive/osi/__init__.py
+++ b/nxdrive/osi/__init__.py
@@ -101,6 +101,16 @@ class AbstractOSIntegration(QObject):
     def get_system_configuration(self) -> Dict[str, Any]:
         return dict()
 
+    @staticmethod
+    def cb_get() -> str:
+        """Get the text data from the clipboard."""
+        return ""
+
+    @staticmethod
+    def cb_set(text: str) -> None:
+        """Copy some *text* into the clipboard."""
+        pass
+
     def _init(self) -> None:
         pass
 

--- a/nxdrive/osi/darwin/darwin.py
+++ b/nxdrive/osi/darwin/darwin.py
@@ -31,7 +31,7 @@ from ...constants import APP_NAME, BUNDLE_IDENTIFIER
 from ...objects import DocPair
 from ...options import Options
 from ...translator import Translator
-from ...utils import if_frozen
+from ...utils import force_decode, if_frozen
 
 
 __all__ = ("DarwinIntegration",)
@@ -90,6 +90,21 @@ class DarwinIntegration(AbstractOSIntegration):
 
     def _get_agent_file(self) -> Path:
         return Path(f"~/Library/LaunchAgents/{BUNDLE_IDENTIFIER}.plist").expanduser()
+
+    @staticmethod
+    def cb_get() -> str:
+        """Get the text data from the clipboard."""
+        data = subprocess.check_output(["pbpaste"])
+        # data = '"blablabla"\n' -> remove useless characters
+        data = data.rstrip()[1:-1]
+        return force_decode(data)
+
+    @staticmethod
+    def cb_set(text: str) -> None:
+        """Copy some *text* into the clipboard."""
+        with subprocess.Popen(["echo", f'"{text}"'], stdout=subprocess.PIPE) as ps:
+            subprocess.check_call(["pbcopy"], stdin=ps.stdout)
+            ps.wait()
 
     def open_local_file(self, file_path: str, select: bool = False) -> None:
         """Note that this function must _not_ block the execution."""

--- a/nxdrive/osi/linux/linux.py
+++ b/nxdrive/osi/linux/linux.py
@@ -3,6 +3,7 @@ import subprocess
 from logging import getLogger
 
 from .. import AbstractOSIntegration
+from ...utils import force_decode
 
 __all__ = ("LinuxIntegration",)
 
@@ -12,6 +13,21 @@ log = getLogger(__name__)
 class LinuxIntegration(AbstractOSIntegration):
 
     nature = "GNU/Linux"
+
+    @staticmethod
+    def cb_get() -> str:
+        """Get the text data from the clipboard. The xclip tool needs to be installed."""
+        data = subprocess.check_output("xclip -selection clipboard -o".split())
+        # data = '"blablabla"\n' -> remove useless characters
+        data = data.rstrip()[1:-1]
+        return force_decode(data)
+
+    @staticmethod
+    def cb_set(text: str) -> None:
+        """Copy some *text* into the clipboard. The xclip tool needs to be installed."""
+        with subprocess.Popen(["echo", f'"{text}"'], stdout=subprocess.PIPE) as ps:
+            subprocess.check_call(["xclip", "-selection", "c"], stdin=ps.stdout)
+            ps.wait()
 
     def open_local_file(self, file_path: str, select: bool = False) -> None:
         """Note that this function must _not_ block the execution."""

--- a/nxdrive/osi/windows/windows.py
+++ b/nxdrive/osi/windows/windows.py
@@ -78,6 +78,26 @@ class WindowsIntegration(AbstractOSIntegration):
             return True
         return False
 
+    @staticmethod
+    def cb_get() -> str:
+        """Get the text data from the clipboard."""
+        import win32clipboard
+
+        win32clipboard.OpenClipboard()
+        text = win32clipboard.GetClipboardData(win32clipboard.CF_UNICODETEXT)
+        win32clipboard.CloseClipboard()
+        return text
+
+    @staticmethod
+    def cb_set(text: str) -> None:
+        """Copy some *text* into the clipboard."""
+        import win32clipboard
+
+        win32clipboard.OpenClipboard()
+        win32clipboard.EmptyClipboard()
+        win32clipboard.SetClipboardText(text, win32clipboard.CF_UNICODETEXT)
+        win32clipboard.CloseClipboard()
+
     @pyqtSlot(result=bool)
     def install_addons(self, setup: str = "nuxeo-drive-addons.exe") -> bool:
         """Install addons using the installer shipped within the main installer."""

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -45,7 +45,6 @@ __all__ = (
     "compute_digest",
     "compute_fake_pid_from_path",
     "compute_urls",
-    "copy_to_clipboard",
     "current_milli_time",
     "current_thread_id",
     "decrypt",
@@ -127,24 +126,6 @@ def compute_fake_pid_from_path(path: str) -> int:
         path_b = path.encode(getdefaultencoding() or "utf-8", errors="ignore")
 
     return crc32(path_b)
-
-
-def copy_to_clipboard(text: str) -> None:
-    """ Copy the given text to the clipboard. """
-
-    if WINDOWS:
-        import win32clipboard
-
-        win32clipboard.OpenClipboard()
-        win32clipboard.EmptyClipboard()
-        win32clipboard.SetClipboardText(text, win32clipboard.CF_UNICODETEXT)
-        win32clipboard.CloseClipboard()
-    else:
-        from PyQt5.QtWidgets import QApplication
-
-        cb = QApplication.clipboard()
-        cb.clear(mode=cb.Clipboard)
-        cb.setText(text, mode=cb.Clipboard)
 
 
 def current_thread_id() -> int:

--- a/tests/integration/windows/utils.py
+++ b/tests/integration/windows/utils.py
@@ -2,21 +2,11 @@ from logging import getLogger
 from time import sleep
 
 from nxdrive.constants import APP_NAME
+from nxdrive.osi import AbstractOSIntegration
 
 
 log = getLogger(__name__)
-
-
-def copy_clipboard() -> str:
-    """Get content of the clip board."""
-    # Use the import there to prevent pytest --last-failed to crash
-    # when running on non Windows platforms
-    import win32clipboard
-
-    win32clipboard.OpenClipboard()
-    details = win32clipboard.GetClipboardData(win32clipboard.CF_UNICODETEXT)
-    win32clipboard.CloseClipboard()
-    return details
+osi = AbstractOSIntegration(None)
 
 
 def fatal_error_dlg(app, with_details: bool = True) -> bool:
@@ -29,7 +19,7 @@ def fatal_error_dlg(app, with_details: bool = True) -> bool:
             sleep(1)
             dlg.child_window(title="Copy details").wait("visible").click()
             sleep(1)
-            log.warning(f"Fatal error screen detected! Details:\n{copy_clipboard()}")
+            log.warning(f"Fatal error screen detected! Details:\n{osi.cb_get()}")
         else:
             log.warning(f"Fatal error screen detected!")
 

--- a/tests/old_functional/test_context_menu.py
+++ b/tests/old_functional/test_context_menu.py
@@ -1,0 +1,55 @@
+from os.path import isfile
+
+import pytest
+
+from .common import OneUserTest
+
+
+class TestContextMenu(OneUserTest):
+    def setUp(self):
+        self.engine_1.start()
+        self.wait_sync(wait_for_async=True)
+
+    def test_copy_share_link(self):
+        """It will test the copy/paste clipboard stuff."""
+        manager = self.manager_1
+        local = self.local_1
+
+        # Document does not inexist
+        with pytest.raises(ValueError):
+            manager.ctx_copy_share_link("/a folder/a file.bin")
+
+        # Document exists
+        local.make_folder("/", "a folder")
+        file = local.make_file("/a folder", "a file.bin", content=b"something")
+        self.wait_sync()
+        path = local.abspath(file)
+        assert isfile(path)
+        url = manager.ctx_copy_share_link(path)
+        assert url.startswith("http")
+        assert manager.osi.cb_get() == url
+
+    def test_get_metadata_infos(self):
+        """This will test "Access online" and "Edit metadata" entries."""
+        manager = self.manager_1
+        local = self.local_1
+
+        # Document does not inexist
+        with pytest.raises(ValueError):
+            manager.get_metadata_infos("/a folder/a file.bin")
+
+        # Document exists
+        local.make_folder("/", "a folder")
+        file = local.make_file("/a folder", "a file.bin", content=b"something")
+        self.wait_sync()
+        path = local.abspath(file)
+        assert isfile(path)
+
+        # "Access online" entry
+        url = manager.get_metadata_infos(path)
+        assert url.startswith("http")
+
+        # "Edit metadata" entry
+        url_edit = manager.get_metadata_infos(path, edit=True)
+        assert url.startswith("http")
+        assert url_edit != url


### PR DESCRIPTION
I needed to change how we deal with the clipboard.
It now uses OS tools:
- `pbcopy`/`pbpaste` on macOS
- `xclip` on GNU/Linux (manual installation needed)

The `QApplication.clipboard()` is broken and not really safe to use (segfault on Unix, no clipboard available for some reason, ... ).

Also remove void transfers on document not found.