### PR TITLE
NXDRIVE-1714: Start the upload only when the file is fully copied

### DIFF
--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -510,7 +510,7 @@ class Remote(Nuxeo):
         headers = {"Nuxeo-Transaction-Timeout": str(timeout)}
 
         log.debug(
-            f"Setting connection timeout to {timeout} seconds to handle the file creation on the server"
+            f"Setting connection timeout to {timeout:,} seconds to handle the file creation on the server"
         )
 
         # Terminate the upload action to be able to start the finalization one as we are allowing

--- a/nxdrive/constants.py
+++ b/nxdrive/constants.py
@@ -16,10 +16,14 @@ COMPANY = "Nuxeo"
 
 TIMEOUT = 20  # Seconds
 STARTUP_PAGE_CONNECTION_TIMEOUT = 30  # Seconds
-TX_TIMEOUT = 60 * 10  # 10 minutes
 FILE_BUFFER_SIZE = 1024 ** 2
 MAX_LOG_DISPLAYED = 50000  # Lines
 BATCH_SIZE = 100  # Scroll descendants batch size
+
+# Transaction timeout: it is used by the server when generating the whole file after all chunks
+# have been uploaded. Setting a high value to be able to handle very big files. Most of the
+# time, the server will finish way before thhat timeout.
+TX_TIMEOUT = 60 * 60 * 6  # 6 hours
 
 ROOT = Path()
 


### PR DESCRIPTION
As chunked uploads are based on the file size, and to have proper uploads with large files, we need to wait for the file to be fully copied on the hard drive before starting to upload it.

Also set the Nuxeo timeout to 6 hours. This is huge but only to handle big files. Testing are ongoing to knwo what value to set exactly.