### PR TITLE
NXDRIVE-1779: Ensure the tmp folder is on the same partition than the…

### DIFF
--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -43,6 +43,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1775](https://jira.nuxeo.com/browse/NXDRIVE-1775): Bypass `PermissionError` raised from `Path.resolve()`
 - [NXDRIVE-1776](https://jira.nuxeo.com/browse/NXDRIVE-1776): Handle incorrect chunked encoding in Direct Edit's upload queue
 - [NXDRIVE-1777](https://jira.nuxeo.com/browse/NXDRIVE-1777): Force re-download if a local file does not exist anymore but it is still referenced in the database
+- [NXDRIVE-1779](https://jira.nuxeo.com/browse/NXDRIVE-1779): Ensure the tmp folder is on the same partition than the sync folder
 - [NXDRIVE-1780](https://jira.nuxeo.com/browse/NXDRIVE-1780): Fix "Access online" context menu not opening the browser
 
 ## GUI
@@ -195,5 +196,6 @@ Release date: `2019-xx-xx`
 - Added utils.py::`compute_digest()`
 - Removed utils.py::`copy_to_clipboard()`
 - Added utils.py::`current_thread_id()`
+- Added utils.py::`find_suitable_tmp_dir()`
 - Added utils.py::`safe_rename()`
 - Added utils.py::`sizeof_fmt()`

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -37,6 +37,7 @@ from ..options import Options
 from ..utils import (
     current_thread_id,
     find_icon,
+    find_suitable_tmp_dir,
     if_frozen,
     safe_filename,
     set_path_readonly,
@@ -121,8 +122,6 @@ class Engine(QObject):
         self.local_folder = Path(definition.local_folder)
         self.folder = str(self.local_folder)
         self.local = self.local_cls(self.local_folder)
-        self.download_dir = self.manager.home / "tmp" / definition.uid
-        self.download_dir.mkdir(parents=True, exist_ok=True)
 
         self.uid = definition.uid
         self.name = definition.name
@@ -136,6 +135,11 @@ class Engine(QObject):
         if binder:
             self.bind(binder)
         self._load_configuration()
+
+        download_dir = find_suitable_tmp_dir(self.local_folder, self.manager.home)
+        self.download_dir = download_dir / ".tmp" / definition.uid
+        log.info(f"Using temporary download folder {self.download_dir!r}")
+        self.download_dir.mkdir(parents=True, exist_ok=True)
 
         if not binder:
             self._check_https()


### PR DESCRIPTION
… sync folder

Introduce `find_suitable_tmp_dir()` to guess a folder to use that is on the same partition as the local sync one.