### PR TITLE
NXDRIVE-1714: Skip digest computation for big files

### DIFF
--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -147,6 +147,7 @@ Release date: `2019-xx-xx`
 - Added `purge` argument to `Manager.unbind_engine()`
 - Removed `Manager.get_dao()`. Use `dao` attribute instead.
 - Removed `Manager.get_engines()`. Use `engines` attribute instead.
+- Added `Options.big_file`
 - Added `Options.tmp_file_limit`
 - Renamed `Processor.pairSync` signal to `Processor.pairSyncEnded`
 - Removed `Processor.tmp_file`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,6 +38,7 @@ Parameter values are taken as is, except for booleans. In that case, you can spe
 
 | Parameter | Default Value | Type | Version Added | Description
 |---|---|---|---|---
+| `big-file` | 300 | int | 4.1.4 | File size in MiB. Files bigger than this limit are considered "big". This implies few tweaks in the synchronization engine like bypassing most of the expensive and time consuming digest computations. It is a tradeoff to handle large files as best effort.
 | `ca-bundle` | None | str | 4.0.2 | File or directory with certificates of trusted CAs. If set, `ssl-no-verify` has no effect. See the `requests` [documentation](http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification) for more details.
 | `channel` | release | str | 4.0.2 | Update channel. Can be release, beta or alpha.
 | `chunk_limit` | 20 | int | 4.1.2 | Size in MiB above which files will be uploaded in chunks (if `chunk_upload` is `True`). Has to be above 0.

--- a/nxdrive/client/local_client.py
+++ b/nxdrive/client/local_client.py
@@ -16,10 +16,9 @@ from pathlib import Path
 from time import mktime, strptime
 from typing import Any, List, Optional, Tuple, Union
 
+from nuxeo.utils import get_digest_algorithm
 from send2trash import send2trash
 from send2trash.exceptions import TrashPermissionError
-
-from nuxeo.utils import get_digest_algorithm
 
 from ..constants import LINUX, MAC, ROOT, WINDOWS
 from ..exceptions import DuplicationDisabledError, NotFound, UnknownDigest

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -121,7 +121,9 @@ class Engine(QObject):
 
         self.local_folder = Path(definition.local_folder)
         self.folder = str(self.local_folder)
-        self.local = self.local_cls(self.local_folder)
+        self.local = self.local_cls(
+            self.local_folder, digest_callback=self.suspend_client
+        )
 
         self.uid = definition.uid
         self.name = definition.name
@@ -1036,6 +1038,9 @@ class Engine(QObject):
             raise PairInterrupt()
 
         if not action:
+            return
+
+        if not isinstance(action, FileAction):
             return
 
         # Get the current download and check if it is still ongoing

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -786,14 +786,15 @@ class Processor(EngineWorker):
                     return
 
                 if doc_pair.local_digest == UNACCESSIBLE_HASH:
-                    doc_pair.local_digest = local_info.get_digest()
                     log.debug(f"Creation of postponed local file: {doc_pair!r}")
+                    doc_pair.local_digest = local_info.get_digest()
                     self.dao.update_local_state(
                         doc_pair, local_info, versioned=False, queue=False
                     )
                     if doc_pair.local_digest == UNACCESSIBLE_HASH:
                         self._postpone_pair(doc_pair, "Unaccessible hash")
                         return
+
                 fs_item_info = self.remote.stream_file(
                     parent_ref,
                     self.local.abspath(doc_pair.local_path),

--- a/nxdrive/engine/watcher/local_watcher.py
+++ b/nxdrive/engine/watcher/local_watcher.py
@@ -882,7 +882,14 @@ class LocalWatcher(EngineWorker):
             dao.update_local_modification_time(doc_pair, local_info)
             return
 
-        if doc_pair.local_state == "synchronized":
+        # We can't allow this branch to be taken for big files
+        # because computing their digest will explode everything.
+        # This code is taken _a lot_ when copying big files, so it
+        # makes sens to bypass this check.
+        if (
+            local_info.size < Options.big_file * 1024 * 1024
+            and doc_pair.local_state == "synchronized"
+        ):
             digest = local_info.get_digest()
             # Unchanged digest, can be the case if only the last
             # modification time or file permissions have been updated

--- a/nxdrive/engine/watcher/local_watcher.py
+++ b/nxdrive/engine/watcher/local_watcher.py
@@ -469,6 +469,8 @@ class LocalWatcher(EngineWorker):
                                 self._protected_files[doc_pair.remote_ref] = True
                     if child_info.folderish:
                         to_scan_new.append(child_info)
+                except ThreadInterrupt:
+                    raise
                 except Exception:
                     log.exception(
                         f"Error during recursive scan of {child_info.path!r}, "

--- a/nxdrive/engine/watcher/local_watcher.py
+++ b/nxdrive/engine/watcher/local_watcher.py
@@ -828,7 +828,7 @@ class LocalWatcher(EngineWorker):
 
             # TODO: This piece of code is only useful on Windows when creating a file inside a read-only folder.
             # TODO: Remove everything with NXDRIVE-1095.
-            if acquired_pair:
+            if WINDOWS and acquired_pair:
                 refreshed_pair = dao.get_state_from_id(acquired_pair.id)
                 if refreshed_pair and refreshed_pair.pair_state not in (
                     "synchronized",

--- a/nxdrive/options.py
+++ b/nxdrive/options.py
@@ -188,6 +188,7 @@ class MetaOptions(type):
 
     # Default options
     options: Dict[str, Tuple[Any, str]] = {
+        "big_file": (300, "default"),
         "browser_startup_page": ("drive_browser_login.jsp", "default"),
         "ca_bundle": (None, "default"),
         "channel": ("release", "default"),

--- a/tests/old_functional/test_local_client.py
+++ b/tests/old_functional/test_local_client.py
@@ -69,7 +69,6 @@ class StubLocalClient:
         folder_1_info = local.get_info(folder_1)
         assert folder_1_info.name == "A new folder"
         assert folder_1_info.path == folder_1
-        assert not folder_1_info.get_digest()
         assert folder_1_info.folderish
 
         doc_3 = local.make_file(folder_1, "Document 3.txt", content=SOME_TEXT_CONTENT)

--- a/tests/old_functional/test_local_move_and_rename.py
+++ b/tests/old_functional/test_local_move_and_rename.py
@@ -706,7 +706,7 @@ are well taken into account.
                 local1.move(child.path, dst)
 
         # Checks
-        self.wait_sync(wait_for_async=True, wait_for_engine_2=True, timeout=120)
+        self.wait_sync(wait_for_async=True, wait_for_engine_2=True, timeout=180)
 
         for local in {local1, local2}:
             assert len(local.get_children_info("/")) == 1

--- a/tests/old_functional/test_nxdrive_903.py
+++ b/tests/old_functional/test_nxdrive_903.py
@@ -103,7 +103,7 @@ class Test(TwoUsersTest):
 
         # Steps 19 -> 21
         engine_2.resume()
-        self.wait_sync(wait_for_async=True, wait_for_engine_2=True, timeout=60)
+        self.wait_sync(wait_for_async=True, wait_for_engine_2=True, timeout=120)
 
         # Ensure there is no postponed nor documents in error
         assert not engine_2.dao.get_error_count(threshold=0)


### PR DESCRIPTION
Introduced `Options.big_file` to be able to set a custom value for the file size limit (300 MiB by
default). This is a tradoff to handle large files as best effort.

* Stop the checksum computation on pause or exit.

* Repush the acquired doc pair only on Windows
As this portion of code is only needed on Windows whhen creating a file inside a read-only folder,
we can skip it on Unix.