### PR TITLE
NXDRIVE-1751: Localize the "B" abbreviation for "byte" in sizeof_fmt()

### DIFF
--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -58,6 +58,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1698](https://jira.nuxeo.com/browse/NXDRIVE-1698): Display the progress bar when resuming an upload
 - [NXDRIVE-1705](https://jira.nuxeo.com/browse/NXDRIVE-1705): Add an option to remove local files when removing an account
 - [NXDRIVE-1726](https://jira.nuxeo.com/browse/NXDRIVE-1726): Show Account setting at statup if there is no account
+- [NXDRIVE-1751](https://jira.nuxeo.com/browse/NXDRIVE-1751): Localize the "B" abbreviation for "byte" in `sizeof_fmt()`
 - [NXDRIVE-1762](https://jira.nuxeo.com/browse/NXDRIVE-1762): Display a progress bar when attaching the blob to a document
 - [NXDRIVE-1781](https://jira.nuxeo.com/browse/NXDRIVE-1781): Display size details on progress of a download/upload
 
@@ -141,6 +142,7 @@ Release date: `2019-xx-xx`
 - Changed `EngineDAO.update_remote_state()` return type from `None` to `bool`
 - Renamed `filename` keyword argument of `FileAction.__init__()` to `tmppath`
 - Added `FileModel.ID` role
+- Added `FileModel.tr()`
 - Added `LocalClient.set_path_remote_id()`
 - Renamed `check_suspended` keyword argument of `LocalClient.__init__()` to `digest_callback`
 - Changed `filename` argument type from `str` to `Path` for `LocalClient.is_temp_file()`
@@ -169,6 +171,7 @@ Release date: `2019-xx-xx`
 - Changed `file_out` keyword argument of `Remote.__init__()` to positional argument
 - Added `TransferModel.PROGRESS_METRICS`
 - Added `TransferModel.get_progress()`
+- Added `TransferModel.tr()`
 - Renamed `TransferModel.VERIFYING` to `FINALIZING`
 - Renamed `filename` keyword argument of `UploadAction.__init__()` to `tmppath`
 - Removed `filename` keyword argument from `VerificationAction.__init__()`

--- a/nxdrive/data/i18n/i18n.json
+++ b/nxdrive/data/i18n/i18n.json
@@ -17,6 +17,7 @@
     "AUTOUPDATE_UPGRADE": "A new version %1 is available.",
     "BROWSE_DIALOG_CAPTION": "Select Nuxeo Drive folder location",
     "BUG_REPORT": "Report a bug",
+    "BYTE_ABBREV": "B",
     "CANCEL": "Cancel",
     "CHANNEL": "Channel",
     "CHANNEL_CHANGE_SETTINGS": "Change channel update settings",

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -486,7 +486,7 @@ class Processor(EngineWorker):
             return
 
         log.debug(f"Transfer speed: {sizeof_fmt(action.size / duration)}/s")
-        self._current_metrics["speed"] = action.size / duration / 1024  # Kib/s
+        self._current_metrics["speed"] = action.size / duration / 1024  # KiB/s
 
     def _synchronize_if_not_remotely_dirty(
         self, doc_pair: DocPair, remote_info: RemoteFileInfo = None

--- a/nxdrive/engine/tracker.py
+++ b/nxdrive/engine/tracker.py
@@ -157,7 +157,7 @@ class Tracker(Worker):
     @pyqtSlot(object)
     def _send_sync_event(self, metrics: Dict[str, Any]) -> None:
         timing = metrics.get("end_time", 0) - metrics["start_time"]
-        speed = metrics.get("speed", None)  # Kib/s
+        speed = metrics.get("speed", None)  # KiB/s
 
         if timing > 0:
             self.send_event(

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -184,12 +184,12 @@ class Application(QApplication):
     def init_gui(self) -> None:
 
         self.api = QMLDriveApi(self)
-        self.conflicts_model = FileModel()
-        self.errors_model = FileModel()
+        self.conflicts_model = FileModel(self.translate)
+        self.errors_model = FileModel(self.translate)
         self.engine_model = EngineModel(self)
-        self.transfer_model = TransferModel()
-        self.file_model = FileModel()
-        self.ignoreds_model = FileModel()
+        self.transfer_model = TransferModel(self.translate)
+        self.file_model = FileModel(self.translate)
+        self.ignoreds_model = FileModel(self.translate)
         self.language_model = LanguageModel()
 
         self.add_engines(list(self.manager.engines.values()))

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -979,7 +979,7 @@ def lock_path(path: Path, locker: int) -> None:
         set_path_readonly(path.parent)
 
 
-def sizeof_fmt(num: Union[float, int], suffix: str = "o") -> str:
+def sizeof_fmt(num: Union[float, int], suffix: str = "B") -> str:
     """
     Human readable version of file size.
     Supports:
@@ -991,9 +991,9 @@ def sizeof_fmt(num: Union[float, int], suffix: str = "o") -> str:
     Examples:
 
         >>> sizeof_fmt(168963795964)
-        "157.4 Gio"
-        >>> sizeof_fmt(168963795964, suffix="B")
         "157.4 GiB"
+        >>> sizeof_fmt(168963795964, suffix="o")
+        "157.4 Gio"
 
     Source: https://stackoverflow.com/a/1094933/1117028
     """

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -457,21 +457,21 @@ def test_safe_rename(tmp):
 @pytest.mark.parametrize(
     "size, result",
     [
-        (0, "0.0 o"),
-        (1, "1.0 o"),
-        (-1024, "-1.0 Kio"),
-        (1024, "1.0 Kio"),
-        (1024 * 1024, "1.0 Mio"),
-        (pow(1024, 2), "1.0 Mio"),
-        (pow(1024, 3), "1.0 Gio"),
-        (pow(1024, 4), "1.0 Tio"),
-        (pow(1024, 5), "1.0 Pio"),
-        (pow(1024, 6), "1.0 Eio"),
-        (pow(1024, 7), "1.0 Zio"),
-        (pow(1024, 8), "1.0 Yio"),
-        (pow(1024, 9), "1,024.0 Yio"),
-        (pow(1024, 10), "1,048,576.0 Yio"),
-        (168_963_795_964, "157.4 Gio"),
+        (0, "0.0 B"),
+        (1, "1.0 B"),
+        (-1024, "-1.0 KiB"),
+        (1024, "1.0 KiB"),
+        (1024 * 1024, "1.0 MiB"),
+        (pow(1024, 2), "1.0 MiB"),
+        (pow(1024, 3), "1.0 GiB"),
+        (pow(1024, 4), "1.0 TiB"),
+        (pow(1024, 5), "1.0 PiB"),
+        (pow(1024, 6), "1.0 EiB"),
+        (pow(1024, 7), "1.0 ZiB"),
+        (pow(1024, 8), "1.0 YiB"),
+        (pow(1024, 9), "1,024.0 YiB"),
+        (pow(1024, 10), "1,048,576.0 YiB"),
+        (168_963_795_964, "157.4 GiB"),
     ],
 )
 def test_sizeof_fmt(size, result):
@@ -479,7 +479,7 @@ def test_sizeof_fmt(size, result):
 
 
 def test_sizeof_fmt_arg():
-    assert nxdrive.utils.sizeof_fmt(168_963_795_964, suffix="B") == "157.4 GiB"
+    assert nxdrive.utils.sizeof_fmt(168_963_795_964, suffix="o") == "157.4 Gio"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The suffix is translated only in the systray menu. In the logs, as sentences are in english, no need
to do the translation.