### PR TITLE
NXDRIVE-1801: Chunk upload is broken on macOS

### DIFF
--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -42,7 +42,6 @@ from ..utils import (
     compute_digest,
     get_device,
     lock_path,
-    safe_os_filename,
     sizeof_fmt,
     unlock_path,
     version_le,
@@ -352,10 +351,7 @@ class Remote(Nuxeo):
         """Upload a blob by chunks or in one go."""
 
         tick = time.monotonic()
-        path = (
-            file_path.with_name(safe_os_filename(filename)) if filename else file_path
-        )
-        action = UploadAction(path, tmppath=file_path, reporter=QApplication.instance())
+        action = UploadAction(file_path, reporter=QApplication.instance())
         blob = FileBlob(str(file_path))
         if filename:
             blob.name = filename

--- a/nxdrive/engine/activity.py
+++ b/nxdrive/engine/activity.py
@@ -207,16 +207,8 @@ class VerificationAction(FileAction):
 class UploadAction(FileAction):
     """Upload: step 1/2 - Upload the file."""
 
-    def __init__(
-        self, filepath: Path, tmppath: Path = None, reporter: Any = None
-    ) -> None:
-        super().__init__(
-            "Upload",
-            filepath,
-            tmppath=tmppath,
-            size=tmppath.stat().st_size if tmppath else filepath.stat().st_size,
-            reporter=reporter,
-        )
+    def __init__(self, filepath: Path, reporter: Any = None) -> None:
+        super().__init__("Upload", filepath, reporter=reporter)
 
 
 class LinkingAction(FileAction):

--- a/tests/old_functional/test_transfer.py
+++ b/tests/old_functional/test_transfer.py
@@ -3,14 +3,14 @@ Test pause/resume transfers in differents scenarii.
 """
 from unittest.mock import patch
 
-import pytest
 from nuxeo.exceptions import HTTPError
-from nxdrive.constants import FILE_BUFFER_SIZE, TransferStatus, WINDOWS
+from nxdrive.constants import FILE_BUFFER_SIZE, TransferStatus
 from nxdrive.options import Options
 from requests.exceptions import ConnectionError
 
 from .. import ensure_no_exception
 from .common import OneUserTest, SYNC_ROOT_FAC_ID
+from ..markers import not_windows
 
 
 class TestDownload(OneUserTest):
@@ -352,9 +352,8 @@ class TestUpload(OneUserTest):
         assert not dao.get_uploads()
         assert self.local_1.get_content("/test.bin") == b"locally changed"
 
-    @pytest.mark.skipif(
-        WINDOWS,
-        reason="Cannot test the behavior as the local deletion is blocked by the OS.",
+    @not_windows(
+        reason="Cannot test the behavior as the local deletion is blocked by the OS."
     )
     def test_deleting_paused_upload(self):
         """Deleting a paused upload should discard the current upload."""


### PR DESCRIPTION
The issue is only reproductible when there is a GUI.
The UploadAction, when displayed in the systray menu, was somehow blocking the file access that was being uploaded, thus making socket timeouts and the upload was never really started.