### PR TITLE
NXDRIVE-1766: Fix extensions local server to listen on localhost

### DIFF
--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -38,6 +38,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1753](https://jira.nuxeo.com/browse/NXDRIVE-1753): Improve uploads robustness
 - [NXDRIVE-1754](https://jira.nuxeo.com/browse/NXDRIVE-1754): [macOS] `locale.getdefaultlocale()` fails with default language set to English
 - [NXDRIVE-1765](https://jira.nuxeo.com/browse/NXDRIVE-1765): Skip inexistant files in DirectEdit's lock queue
+- [NXDRIVE-1766](https://jira.nuxeo.com/browse/NXDRIVE-1766): Fix extensions local server to listen on localhost
 - [NXDRIVE-1773](https://jira.nuxeo.com/browse/NXDRIVE-1773): Check the parent exists before trying to retrieve its details
 - [NXDRIVE-1774](https://jira.nuxeo.com/browse/NXDRIVE-1774): Filter out `urllib3` logging about "Certificate did not match..."
 - [NXDRIVE-1775](https://jira.nuxeo.com/browse/NXDRIVE-1775): Bypass `PermissionError` raised from `Path.resolve()`
@@ -141,6 +142,8 @@ Release date: `2019-xx-xx`
 - Removed `state_factory` keyworkd argument from `EngineDAO.__init__()`
 - Added `progress` argument to `EngineDAO.pause_transfer()`
 - Changed `EngineDAO.update_remote_state()` return type from `None` to `bool`
+- Added `ExtensionListener.address`
+- Added `ExtensionListener.host_to_addr()`
 - Renamed `filename` keyword argument of `FileAction.__init__()` to `tmppath`
 - Added `FileModel.ID` role
 - Added `FileModel.tr()`

--- a/tests/unit/test_extension_listener.py
+++ b/tests/unit/test_extension_listener.py
@@ -1,0 +1,15 @@
+from PyQt5.QtNetwork import QAbstractSocket, QHostAddress
+
+from nxdrive.osi.extension import ExtensionListener
+
+
+def test_host_to_addr():
+    # Bad hostname
+    assert not ExtensionListener.host_to_addr("")
+    assert not ExtensionListener.host_to_addr("blablabla")
+
+    # Good hostname
+    address = ExtensionListener.host_to_addr("localhost")
+    assert isinstance(address, QHostAddress)
+    assert address.protocol() == QAbstractSocket.IPv4Protocol
+    assert address.toString() == "127.0.0.1"


### PR DESCRIPTION
The issue came from `QHostAdress()` that does no DNS lookup and so returning an empty string.
Qt used then the default `0.0.0.0` IP.