### PR TITLE
NXDRIVE-1732: Better handling of the Direct Edit protocol

### DIFF
--- a/docs/changes/4.1.4.md
+++ b/docs/changes/4.1.4.md
@@ -27,6 +27,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1727](https://jira.nuxeo.com/browse/NXDRIVE-1727): Check for local folder rights and fail gracefully on permission error
 - [NXDRIVE-1728](https://jira.nuxeo.com/browse/NXDRIVE-1728): Lower logging level of "Cannot find parent pair of postponed remote descendant, ..."
 - [NXDRIVE-1729](https://jira.nuxeo.com/browse/NXDRIVE-1729): [macOS] Use EAFP to catch `FileNotFoundError` in `send_content_sync_status()`
+- [NXDRIVE-1732](https://jira.nuxeo.com/browse/NXDRIVE-1732): Better handling of the Direct Edit protocol
 - [NXDRIVE-1733](https://jira.nuxeo.com/browse/NXDRIVE-1733): Fix missing `select` argument in `open_local_file()`
 - [NXDRIVE-1734](https://jira.nuxeo.com/browse/NXDRIVE-1734): Ignore decoding issues when retrieving the path stored in xattrs
 - [NXDRIVE-1735](https://jira.nuxeo.com/browse/NXDRIVE-1735): Make Manager's engines public

--- a/nxdrive/direct_edit.py
+++ b/nxdrive/direct_edit.py
@@ -138,7 +138,7 @@ class DirectEdit(Worker):
 
         info = parse_protocol_url(url)
 
-        if not info:
+        if not isinstance(info, dict) or info.get("command", "") != "download_edit":
             return
 
         self.edit(

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -863,8 +863,8 @@ def parse_protocol_url(url_string: str) -> Optional[Dict[str, str]]:
         (
             r"nxdrive://(?P<cmd>edit)/(?P<scheme>\w*)/(?P<server>.*)/"
             r"user/(?P<username>.*)/repo/(?P<repo>.*)/"
-            r"nxdocid/(?P<docid>(\d|[a-f]|-)*)/filename/(?P<filename>[^/]*)"
-            r"(/downloadUrl/(?P<download>.*)|)"
+            r"nxdocid/(?P<docid>[0-9a-fA-F\-]*)/filename/(?P<filename>[^/]*)"
+            r"/downloadUrl/(?P<download>.*)"
         ),
         # Events from context menu:
         #     - Access online

--- a/tests/functional/test_direct_edit.py
+++ b/tests/functional/test_direct_edit.py
@@ -128,20 +128,6 @@ def test_handle_url_malformed(direct_edit):
     assert not direct_edit.handle_url("https://example.org")
 
 
-def test_handle_url_missing_username(direct_edit):
-    """ The username must be in the URL. """
-    url = (
-        "nxdrive://edit/https/server.cloud.nuxeo.com/nuxeo"
-        "/repo/default"
-        "/nxdocid/xxxxxxxx-xxxx-xxxx-xxxx"
-        "/filename/lebron-james-beats-by-dre-powerb.psd"
-        "/downloadUrl/nxfile/default/xxxxxxxx-xxxx-xxxx-xxxx"
-        "/file:content/lebron-james-beats-by-dre-powerb.psd"
-    )
-    with pytest.raises(ValueError):
-        direct_edit.handle_url(url)
-
-
 def test_invalid_credentials(manager_factory):
     """Opening a document without being authenticated is not allowed."""
 


### PR DESCRIPTION
The regexp to parse the DirectEdit URL is now stricter: the download URL must be part of it. It is a requirement since a while, but the regexp was not updated.

Also, the same regexp has been improved to skip an anonymous group around the document's UID.

Tests have been added for `parse_protocol_url()`.