### PR TITLE
NXDRIVE-1706: Fix repr(FileAction)

### DIFF
--- a/nxdrive/engine/activity.py
+++ b/nxdrive/engine/activity.py
@@ -179,7 +179,7 @@ class FileAction(Action):
 
     def __repr__(self) -> str:
         if self.size < 0:
-            return f"{self.type}({self.filename.name!r})"
+            return f"{self.type}({self.filepath.name!r})"
         percent = self.get_percent()
         if percent > 0.0:
             return f"{self.type}({self.filepath.name!r}[{self.size}]-{percent})"

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -707,16 +707,17 @@ def decrypt(
     try:
         encobj = AES.new(secret, AES.MODE_CFB, iv)
         return encobj.decrypt(ciphertext)
-    except:
+    except Exception:
         return None
 
 
 def _lazysecret(secret: bytes, blocksize: int = 32, padding: bytes = b"}") -> bytes:
     """Pad secret if not legal AES block size (16, 24, 32)"""
-    if len(secret) > blocksize:
-        return secret[: -(len(secret) - blocksize)]
-    if not len(secret) in (16, 24, 32):
-        return secret + (blocksize - len(secret)) * padding
+    length = len(secret)
+    if length > blocksize:
+        return secret[: -(length - blocksize)]
+    if length not in (16, 24, 32):
+        return secret + (blocksize - length) * padding
     return secret
 
 


### PR DESCRIPTION
NXDRIVE-1706: Improve `encrypt()`/`decrypt()` when lazy is set to `True`.