### PR TITLE
NXDRIVE-1699: Bump version to 4.2.0

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -11,7 +11,8 @@
 - [4.1.1](changes/4.1.1.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-4.1.0...release-4.1.1))
 - [4.1.2](changes/4.1.2.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-4.1.1...release-4.1.2))
 - [4.1.3](changes/4.1.3.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-4.1.2...release-4.1.3))
-- [4.1.4](changes/4.1.4.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-4.1.3...master))
+- [4.1.4](changes/4.1.4.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-4.1.3...release-4.1.4))
+- [4.2.0](changes/4.2.0.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-4.1.4...master))
 
 ## 3.x
 

--- a/docs/changes/4.2.0.md
+++ b/docs/changes/4.2.0.md
@@ -1,0 +1,31 @@
+# 4.2.0
+
+Release date: `2019-xx-xx`
+
+## Core
+
+- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
+
+## GUI
+
+- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
+
+## Packaging / Build
+
+- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
+
+## Tests
+
+- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
+
+## Doc
+
+- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
+
+## Minor Changes
+
+-
+
+## Technical Changes
+
+-

--- a/nxdrive/__init__.py
+++ b/nxdrive/__init__.py
@@ -26,7 +26,7 @@ To declare a beta, use this schema:
 """
 
 __author__ = "Nuxeo"
-__version__ = "4.1.4"
+__version__ = "4.2.0"
 __copyright__ = """
     Copyright Nuxeo (https://www.nuxeo.com) and others.
 


### PR DESCRIPTION
The major version update is because we will implement this new feature: NXDRIVE-1803 (Add a new update option: Centralized).