### PR TITLE
NXDRIVE-1749: [GNU/Linux] Systray menu is not at the good location

### DIFF
--- a/docs/changes/4.2.0.md
+++ b/docs/changes/4.2.0.md
@@ -8,7 +8,7 @@ Release date: `2019-xx-xx`
 
 ## GUI
 
-- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
+- [NXDRIVE-1749](https://jira.nuxeo.com/browse/NXDRIVE-1749): [GNU/Linux] Systray menu is not at the good location
 
 ## Packaging / Build
 

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -10,8 +10,8 @@ from urllib.parse import unquote
 
 import requests
 from markdown import markdown
-from PyQt5.QtCore import Qt, QTimer, QUrl, pyqtSlot, QEvent
-from PyQt5.QtGui import QFont, QFontMetricsF, QIcon, QWindow
+from PyQt5.QtCore import Qt, QRect, QTimer, QUrl, pyqtSlot, QEvent
+from PyQt5.QtGui import QCursor, QFont, QFontMetricsF, QIcon, QWindow
 from PyQt5.QtNetwork import QLocalServer, QLocalSocket
 from PyQt5.QtQml import QQmlApplicationEngine, QQmlContext
 from PyQt5.QtQuick import QQuickView, QQuickWindow
@@ -609,19 +609,19 @@ class Application(QApplication):
         icon = self.tray_icon.geometry()
 
         if not icon or icon.isEmpty():
-            # On Ubuntu it's likely we can't retrieve the geometry.
-            # We're simply displaying the systray in the top right corner.
-            screen = self.desktop().screenGeometry()
-            pos_x = screen.right() - self.systray_window.width() - 20
-            pos_y = 30
-        else:
-            dpi_ratio = self.primaryScreen().devicePixelRatio() if WINDOWS else 1
-            pos_x = max(
-                0, (icon.x() + icon.width()) / dpi_ratio - self.systray_window.width()
-            )
-            pos_y = icon.y() / dpi_ratio - self.systray_window.height()
-            if pos_y < 0:
-                pos_y = (icon.y() + icon.height()) / dpi_ratio
+            # On some GNU/Linux flavor it's likely we can't retrieve the geometry.
+            # We're simply displaying the systray at the cursor position.
+            cur = QCursor.pos()
+            icon = QRect(cur.x(), cur.y(), 16, 16)
+
+        # Adjust the position
+        dpi_ratio = self.primaryScreen().devicePixelRatio() if WINDOWS else 1
+        pos_x = max(
+            0, (icon.x() + icon.width()) / dpi_ratio - self.systray_window.width()
+        )
+        pos_y = icon.y() / dpi_ratio - self.systray_window.height()
+        if pos_y < 0:
+            pos_y = (icon.y() + icon.height()) / dpi_ratio
 
         self.systray_window.setX(pos_x)
         self.systray_window.setY(pos_y)

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -1102,6 +1102,7 @@ class PidLockFile:
                 log.info(msg)
 
         self.locked = True
+        return None
 
     def lock(self) -> Optional[int]:
         pid = self.check_running()
@@ -1115,6 +1116,7 @@ class PidLockFile:
             raise RuntimeError(f"Invalid PID: {pid!r}")
 
         self.pid_filepath.write_text(str(pid), encoding="utf-8")
+        return None
 
 
 def compute_digest(path: Path, digest_func: str, callback: Callable = None) -> str:


### PR DESCRIPTION
Fallback on the cusor position to display the Systray menu when the notification tray is not reliable. This is true for some GNU/Linux flavors but the code will work for all OSes.