### PR TITLE
NXDRIVE-1783: Handle account addition with already used local folder

### DIFF
--- a/docs/changes/4.2.0.md
+++ b/docs/changes/4.2.0.md
@@ -4,6 +4,7 @@ Release date: `2019-xx-xx`
 
 ## Core
 
+- [NXDRIVE-1783](https://jira.nuxeo.com/browse/NXDRIVE-1783): Handle account addition with already used local folder
 - [NXDRIVE-1784](https://jira.nuxeo.com/browse/NXDRIVE-1784): Remove unused objects and add CI/QA checks
 
 ## GUI

--- a/tests/functional/test_behavior.py
+++ b/tests/functional/test_behavior.py
@@ -38,8 +38,8 @@ AttributeError: 'Engine' object has no attribute '_local_watcher'
 
 
 @not_windows(reason="PermissionError when trying to delete the file.")
-def test_mananger_engine_removal(manager_factory):
-    """NXDIVE-1618: Remove inexistant engines from the Manager engines list."""
+def test_manager_engine_removal(manager_factory):
+    """NXDRIVE-1618: Remove inexistant engines from the Manager engines list."""
 
     manager, engine = manager_factory()
 


### PR DESCRIPTION
This happens in that scenario:
 - Add a new account using the local folder `/home/USER/drive`.
 - Delete the Engine database.
 - Add a new account using the local folder `/home/USER/drive`.

`FolderAlreadyUsed` is raised instead of deleting the old database entry because it is convenient to be able to restore the DB file later for whatever reason.
And there is no popup to ask the user for its deletion for the same purpose.

Note that the use case is rare enough to be handled that way. In fact, in years, that happened only while testing the application a lot.