### PR TITLE
NXDRIVE-1782: Provide information on transfer speed

### DIFF
--- a/docs/changes/4.2.0.md
+++ b/docs/changes/4.2.0.md
@@ -10,6 +10,7 @@ Release date: `2019-xx-xx`
 ## GUI
 
 - [NXDRIVE-1749](https://jira.nuxeo.com/browse/NXDRIVE-1749): [GNU/Linux] Systray menu is not at the good location
+- [NXDRIVE-1782](https://jira.nuxeo.com/browse/NXDRIVE-1782): Provide information on transfer speed
 - [NXDRIVE-1806](https://jira.nuxeo.com/browse/NXDRIVE-1806): Fix transfered files list refreshing in the systray
 
 ## Packaging / Build
@@ -32,6 +33,10 @@ Release date: `2019-xx-xx`
 
 - Removed `AbstractOSIntegration.zoom_factor`
 - Removed `BaseUpdater.force_status()`
+- Added `FileAction.chunk_size`
+- Added `FileAction.chunk_transfer_end_time_ns`
+- Added `FileAction.chunk_transfer_start_time_ns`
+- Added `FileAction.last_chunk_transfer_speed`
 - Removed `FileAction.transfer_duration`
 - Removed `Notification.get_replacements()`
 - Added `PidLockFile.pid_filepath`
@@ -44,7 +49,11 @@ Release date: `2019-xx-xx`
 - Removed `QMLDriveApi.get_errors_count()`
 - Removed `QMLDriveApi.get_conflicts_count()`
 - Removed `QMLDriveApi.get_update_progress()`
+- Added `Remote.transfer_end_callback()`
+- Added `Remote.transfer_start_callback()`
+- Changed return type of `Remote.upload_chunks()` from `Tuple[FileBlob, int]` to `FileBlob`
 - Removed `Remote.kwargs`
+- Removed `duration` argument from `Remote.link_blob_to_doc()`
 - Removed `TransferStatus.CANCELLED`
 - Removed `Translator.translations()`
 - Removed `WindowsIntegration.zoom_factor`

--- a/docs/changes/4.2.0.md
+++ b/docs/changes/4.2.0.md
@@ -32,11 +32,15 @@ Release date: `2019-xx-xx`
 ## Technical Changes
 
 - Removed `AbstractOSIntegration.zoom_factor`
+- Removed `Action.get_last_file_action()`
+- Removed `Action.lastFileActions`
 - Removed `BaseUpdater.force_status()`
 - Added `FileAction.chunk_size`
 - Added `FileAction.chunk_transfer_end_time_ns`
 - Added `FileAction.chunk_transfer_start_time_ns`
 - Added `FileAction.last_chunk_transfer_speed`
+- Removed `FileAction.end_time`
+- Removed `FileAction.start_time`
 - Removed `FileAction.transfer_duration`
 - Removed `Notification.get_replacements()`
 - Added `PidLockFile.pid_filepath`
@@ -54,6 +58,7 @@ Release date: `2019-xx-xx`
 - Changed return type of `Remote.upload_chunks()` from `Tuple[FileBlob, int]` to `FileBlob`
 - Removed `Remote.kwargs`
 - Removed `duration` argument from `Remote.link_blob_to_doc()`
+- Removed `Tracker.connect_engine()`
 - Removed `TransferStatus.CANCELLED`
 - Removed `Translator.translations()`
 - Removed `WindowsIntegration.zoom_factor`

--- a/docs/changes/4.2.0.md
+++ b/docs/changes/4.2.0.md
@@ -40,6 +40,7 @@ Release date: `2019-xx-xx`
 - Removed `QMLDriveApi.set_language()`
 - Removed `direction` keyword argument from `QMLDriveApi.get_last_files()`
 - Removed `duration` keyword argument from `QMLDriveApi.get_last_files()`
+- Removed `QMLDriveApi.get_actions()`
 - Removed `QMLDriveApi.get_errors_count()`
 - Removed `QMLDriveApi.get_conflicts_count()`
 - Removed `QMLDriveApi.get_update_progress()`

--- a/nxdrive/engine/activity.py
+++ b/nxdrive/engine/activity.py
@@ -124,6 +124,14 @@ class FileAction(Action):
             self.empty = True
         self.size = size
 
+        # Used to compute the transfer speed, updated by the Remote client
+        self.chunk_size = 0
+        # Used to compute the transfer speed, updated by the Remote client at each (down|up)loaded chunk
+        self.chunk_transfer_start_time_ns = 0.0  # nanoseconds
+        self.chunk_transfer_end_time_ns = 0.0  # nanoseconds
+        # The transfer speed of the latest (down|up)loaded chunk
+        self.last_chunk_transfer_speed = 0.0
+
         self.start_time = monotonic()
         self.end_time = 0.0
 
@@ -174,6 +182,7 @@ class FileAction(Action):
             "tmppath": str(self.tmppath),
             "empty": self.empty,
             "uploaded": self.uploaded,
+            "speed": self.last_chunk_transfer_speed,
         }
 
     def __repr__(self) -> str:

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -485,7 +485,7 @@ class Processor(EngineWorker):
         if duration <= 0:
             return
 
-        log.debug(f"Transfer speed: {sizeof_fmt(action.size / duration)}/s")
+        log.debug(f"Overall transfer speed was {sizeof_fmt(action.size / duration)}/s")
         self._current_metrics["speed"] = action.size / duration / 1024  # KiB/s
 
     def _synchronize_if_not_remotely_dirty(

--- a/nxdrive/engine/tracker.py
+++ b/nxdrive/engine/tracker.py
@@ -2,7 +2,7 @@
 import os
 import sys
 from logging import getLogger
-from typing import Any, Dict, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 from PyQt5.QtCore import QTimer, pyqtSlot
 from UniversalAnalytics import Tracker as UATracker
@@ -48,17 +48,10 @@ class Tracker(Worker):
         self._stat_timer = QTimer()
         self._stat_timer.timeout.connect(self._send_stats)
 
-        # Connect engines
-        for engine in self._manager.engines.values():
-            self.connect_engine(engine)
-        self._manager.newEngine.connect(self.connect_engine)
-        if self._manager.direct_edit is not None:
+        # Connect Direct Edit metrics
+        if self._manager.direct_edit:
             self._manager.direct_edit.openDocument.connect(self._send_directedit_open)
             self._manager.direct_edit.editDocument.connect(self._send_directedit_edit)
-
-    @pyqtSlot(object)
-    def connect_engine(self, engine: "Engine") -> None:
-        engine.newSyncEnded.connect(self._send_sync_event)
 
     @property
     def current_locale(self) -> str:
@@ -153,27 +146,6 @@ class Tracker(Worker):
             label=extension.lower(),
             value=self._manager.direct_edit.get_metrics()["last_action_timing"],
         )
-
-    @pyqtSlot(object)
-    def _send_sync_event(self, metrics: Dict[str, Any]) -> None:
-        timing = metrics.get("end_time", 0) - metrics["start_time"]
-        speed = metrics.get("speed", None)  # KiB/s
-
-        if timing > 0:
-            self.send_event(
-                category="TransferOperation",
-                action=metrics["handler"],
-                label="OverallTime",
-                value=timing,
-            )
-
-        if speed:
-            self.send_event(
-                category="TransferOperation",
-                action=metrics["handler"],
-                label="Speed",
-                value=speed,
-            )
 
     @pyqtSlot()
     def _send_stats(self) -> None:

--- a/nxdrive/gui/api.py
+++ b/nxdrive/gui/api.py
@@ -14,7 +14,6 @@ from PyQt5.QtWidgets import QMessageBox
 
 from ..client.proxy import get_proxy
 from ..constants import APP_NAME, CONNECTION_ERROR, TOKEN_PERMISSION
-from ..engine.activity import Action, FileAction
 from ..exceptions import (
     FolderAlreadyUsed,
     InvalidDriveException,
@@ -176,18 +175,6 @@ class QMLDriveApi(QObject):
     def app_update(self, version: str) -> None:
         """ Start the udpate to the specified version. """
         self._manager.updater.update(version)
-
-    @pyqtSlot(result=list)
-    def get_actions(self) -> List[Dict[str, Any]]:
-        result: List[Dict[str, Any]] = []
-
-        if not self._manager.engines:
-            return result
-
-        for action in Action.get_actions().values():
-            if isinstance(action, FileAction):
-                result.append(action.export())
-        return result
 
     @pyqtSlot(result=list)
     def get_transfers(self) -> List[Dict[str, Any]]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ distro==1.4.0; sys_platform == 'linux'
 https://github.com/GoodRx/universal-analytics-python/archive/77ce628c56de1ba51a9bf0774794fd687f785803.zip
 https://github.com/gorakhargosh/watchdog/archive/8b94506c3156a3b66faef7aac9a139f603772506.zip
 # nuxeo==2.2.2
-https://github.com/nuxeo/nuxeo-python-client/archive/beb5e4c3e8b07f44236569eda8416d0a4aa97bf9.zip
+https://github.com/nuxeo/nuxeo-python-client/archive/b6d5dbc7dd69c576a9cadeb122b8587308597643.zip
 markdown==3.1.1
 psutil==5.6.3
 pyaml==19.4.1

--- a/tests/functional/test_tracker.py
+++ b/tests/functional/test_tracker.py
@@ -19,18 +19,10 @@ def test_tracker_send_methods(manager_factory, monkeypatch):
     # We need an engine to test custom dimensions (here it is unused and so we use "_")
     manager, _ = manager_factory()
 
-    metrics = {
-        "start_time": 0,
-        "end_time": 42,
-        "speed": 42,
-        "handler": "test_tracker_send_methods",
-    }
-
     with manager:
         tracker = Tracker(manager, uid="")
         monkeypatch.setattr(tracker._tracker, "send", send)
 
         tracker._send_directedit_open("Jean-Michel Jarre - Oxygen")
         tracker._send_directedit_edit("Jean-Michel Jarre - Oxygen.ogg")
-        tracker._send_sync_event(metrics)
         tracker._send_stats()

--- a/tests/old_functional/test_transfer.py
+++ b/tests/old_functional/test_transfer.py
@@ -59,7 +59,8 @@ class TestDownload(OneUserTest):
 
             # Call the original function to make the paused download
             # effective at the 2nd iteration
-            callback_orig()
+            for cb in callback_orig:
+                cb()
 
         engine = self.engine_1
         dao = self.engine_1.dao
@@ -104,7 +105,8 @@ class TestDownload(OneUserTest):
             self.manager_1.suspend()
 
             # Call the original function to make the suspended download effective
-            callback_orig()
+            for cb in callback_orig:
+                cb()
 
         engine = self.engine_1
         dao = self.engine_1.dao
@@ -152,7 +154,8 @@ class TestDownload(OneUserTest):
                 remote.update_content(file.uid, b"remotely changed")
 
             # Call the original function to make the paused download effective
-            callback_orig()
+            for cb in callback_orig:
+                cb()
 
         count = 0
         remote = self.remote_1
@@ -197,7 +200,8 @@ class TestDownload(OneUserTest):
             remote.delete(file.uid)
 
             # Call the original function to make the paused download effective
-            callback_orig()
+            for cb in callback_orig:
+                cb()
 
         remote = self.remote_1
         engine = self.engine_1

--- a/tests/unit/test_action.py
+++ b/tests/unit/test_action.py
@@ -77,7 +77,6 @@ def test_file_action(tmp):
     assert details["name"] == filepath.name
     assert details["filepath"] == str(filepath)
 
-    assert Action.get_last_file_action() is None
     assert Action.get_current_action() is action
 
     # Test repr() when .get_percent() > 0
@@ -87,8 +86,6 @@ def test_file_action(tmp):
 
     Action.finish_action()
     assert action.finished
-
-    assert Action.get_last_file_action() is action
 
 
 def test_file_action_empty_file(tmp):


### PR DESCRIPTION
Reworked `Engine.suspend_client()` and little refactoring to use 3 transfer callbacks instead of a big method.
Timers are using nanoseconds to have the most accurate metrics possible, and so the variation
between 2 chunk metrics can be high depending on the server time to respond and the network
bandwith.

I also removed the useless and inaccurate `Processor` speed metric, completely.

Also:
- NXDRIVE-1784: Remove unused `QMLDriveApi.get_actions()`.