### PR TITLE
NXDRIVE-1812: Add a new option to quit the application after the sync…

### DIFF
--- a/docs/changes/4.2.0.md
+++ b/docs/changes/4.2.0.md
@@ -7,6 +7,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1491](https://jira.nuxeo.com/browse/NXDRIVE-1491): Do not use bare exceptions
 - [NXDRIVE-1783](https://jira.nuxeo.com/browse/NXDRIVE-1783): Handle account addition with already used local folder
 - [NXDRIVE-1784](https://jira.nuxeo.com/browse/NXDRIVE-1784): Remove unused objects and add CI/QA checks
+- [NXDRIVE-1812](https://jira.nuxeo.com/browse/NXDRIVE-1812): Add a new option to quit the application after the sync is over
 
 ## GUI
 
@@ -47,6 +48,7 @@ Release date: `2019-xx-xx`
 - Removed `FileAction.start_time`
 - Removed `FileAction.transfer_duration`
 - Removed `Notification.get_replacements()`
+- Added `Options.sync_and_quit`
 - Added `PidLockFile.pid_filepath`
 - Removed `PidLockFile.folder`
 - Removed `process_name` keyword argument from `PidLockFile.check_running()`
@@ -66,6 +68,7 @@ Release date: `2019-xx-xx`
 - Removed `TransferStatus.CANCELLED`
 - Removed `Translator.translations()`
 - Removed `WindowsIntegration.zoom_factor`
+- Added poll_worker.py::`SyncAndQuitWorker`
 - Added utils.py::`DEFAULTS_CERT_DETAILS`
 - Added `cls` keyword argument to utils.py::`normalized_path()`
 - Removed utils.py::`WIN32_PATCHED_MIME_TYPES`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,6 +58,7 @@ Parameter values are taken as is, except for booleans. In that case, you can spe
 | `nofscheck` | False | bool | 2.0.911 | Disable the standard check for binding, to allow installation on network filesystem.
 | `proxy-server` | None | str | 2 | Define the address of the proxy server (e.g. `http://proxy.example.com:3128`). This can also be set up by the user from the Settings window.
 | `ssl-no-verify` | False | bool | 4.0.1 | Define if SSL errors should be ignored. Highly unadvised to enable this option.
+| `sync-and-quit` | False | bool | 4.2.0 | Launch the synchronization and then exit the application.
 | `tmp_file_limit` | 10.0 | float | 4.1.4 | File size in MiB. Files smaller than this limit will be written at once to the file rather than chunk by chunk.
 | `timeout` | 30 | int | 2 | Define the socket timeout.
 | `update-check-delay` | 3600 | int | 2 | Define the auto-update check delay. 0 means disabled.

--- a/nxdrive/commandline.py
+++ b/nxdrive/commandline.py
@@ -144,6 +144,13 @@ class CliHandler:
         )
 
         common_parser.add_argument(
+            "--sync-and-quit",
+            default=Options.sync_and_quit,
+            action="store_true",
+            help="Launch the synchronization and then exit the application.",
+        )
+
+        common_parser.add_argument(
             "--debug-pydev",
             default=Options.debug_pydev,
             action="store_true",

--- a/nxdrive/console.py
+++ b/nxdrive/console.py
@@ -2,8 +2,9 @@
 """ Console mode application. """
 
 from logging import getLogger
+from typing import Any
 
-from PyQt5.QtCore import QCoreApplication
+from PyQt5.QtCore import QCoreApplication, QTimer
 
 __all__ = ("ConsoleApplication",)
 
@@ -13,9 +14,18 @@ log = getLogger(__name__)
 class ConsoleApplication(QCoreApplication):
     """Console mode Nuxeo Drive application"""
 
-    def __init__(self, manager, argv=()):
-        super().__init__(list(argv))
+    def __init__(self, manager, *args: Any):
+        super().__init__(list(*args))
+
+        # Little trick here! See Application.__init__() for details.
+        self.timer = QTimer()
+        self.timer.timeout.connect(lambda: None)
+        self.timer.start(100)
+
         self.manager = manager
+
+        # Used by SyncAndQuitWorker
+        self.manager.application = self
 
         # Make sure manager is stopped before quitting
         self.aboutToQuit.connect(self.manager.stop)

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -92,6 +92,9 @@ class Application(QApplication):
         super().__init__(list(*args))
         self.manager = manager
 
+        # Used by SyncAndQuitWorker
+        self.manager.application = self
+
         # Little trick here!
         #
         # Qt strongly builds on a concept called event loop.

--- a/nxdrive/options.py
+++ b/nxdrive/options.py
@@ -220,6 +220,7 @@ class MetaOptions(type):
         "res_dir": (_get_resources_dir(), "default"),
         "ssl_no_verify": (False, "default"),
         "startup_page": ("drive_login.jsp", "default"),
+        "sync_and_quit": (False, "default"),
         "system_wide": (_is_system_wide(), "default"),
         "theme": ("ui5", "default"),
         "timeout": (30, "default"),

--- a/nxdrive/poll_workers.py
+++ b/nxdrive/poll_workers.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import logging
+from typing import TYPE_CHECKING
 
 from PyQt5.QtCore import pyqtSlot
 
@@ -7,13 +8,17 @@ from .engine.workers import PollWorker
 from .options import Options
 from .utils import normalize_and_expand_path
 
+if TYPE_CHECKING:
+    from .manager import Manager  # noqa
+
+
 log = logging.getLogger(__name__)
 
 
 class DatabaseBackupWorker(PollWorker):
     """ Class for making backups of the manager and engine databases. """
 
-    def __init__(self, manager):
+    def __init__(self, manager: "Manager"):
         # Backup every hour
         super().__init__(60 * 60)
         self.manager = manager
@@ -38,7 +43,7 @@ class DatabaseBackupWorker(PollWorker):
 class ServerOptionsUpdater(PollWorker):
     """ Class for checking the server's config.json updates. """
 
-    def __init__(self, manager):
+    def __init__(self, manager: "Manager"):
         super().__init__(Options.update_check_delay)
         self.manager = manager
 
@@ -71,5 +76,39 @@ class ServerOptionsUpdater(PollWorker):
                 # be outdated and still have obsolete options.
                 Options.update(conf, setter="server", fail_on_error=False)
                 break
+
+        return True
+
+
+class SyncAndQuitWorker(PollWorker):
+    """Class for checking if the application needs to be exited."""
+
+    def __init__(self, manager: "Manager"):
+        """Check every 10 seconds.
+        """
+        super().__init__(10)
+        self.manager = manager
+
+        # Skip the first check to let engines having time to start
+        self._first_check = True
+
+    @pyqtSlot(result=bool)
+    def _poll(self) -> bool:
+        """Check for the synchronization state."""
+
+        if self._first_check:
+            self._first_check = False
+            return True
+
+        if (
+            Options.sync_and_quit
+            and self.manager.is_started()
+            and not self.manager.is_syncing()
+            and hasattr(self.manager, "application")
+        ):
+            log.info(
+                "The 'sync_and_quit' option is True and the synchronization is over."
+            )
+            self.manager.application.quit()
 
         return True


### PR DESCRIPTION
… is over

The new option `sync_and_quit` is False by default.
A new worker has been created to check if the application must be exited. The interval delay is set to 10 seconds and the 1st check is skipped to let time for all engines to start.