### PR TITLE
NXDRIVE-1815: [Windows] Add CLI sub-commands tests: context menu entries

### DIFF
--- a/docs/changes/4.2.0.md
+++ b/docs/changes/4.2.0.md
@@ -26,6 +26,7 @@ Release date: `2019-xx-xx`
 
 - [NXDRIVE-1706](https://jira.nuxeo.com/browse/NXDRIVE-1706): Expand `utils.py` tests coverage
 - [NXDRIVE-1741](https://jira.nuxeo.com/browse/NXDRIVE-1741): [Windows] Add CLI sub-commands tests: `bind-root` and `unbind-root`
+- [NXDRIVE-1815](https://jira.nuxeo.com/browse/NXDRIVE-1815): [Windows] Add CLI sub-commands tests: context menu entries
 
 ## Doc
 

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -8,4 +8,5 @@ pytest-cov==2.7.1
 pytest-timeout==1.3.3
 pytest-xdist==1.29.0
 pywinauto==0.6.6; sys_platform == 'win32'
+selenium==3.141.0; sys_platform == 'win32'
 vulture==1.0

--- a/tests/integration/windows/utils.py
+++ b/tests/integration/windows/utils.py
@@ -2,11 +2,23 @@ from logging import getLogger
 from time import sleep
 
 from nxdrive.constants import APP_NAME
-from nxdrive.osi import AbstractOSIntegration
-
+from selenium import webdriver
 
 log = getLogger(__name__)
-osi = AbstractOSIntegration(None)
+
+
+def cb_get() -> str:
+    """Get the text data from the clipboard.
+    Emulate: CTRL + V
+
+    Copied from WindowsAbstration class, else it does not work.
+    """
+    import win32clipboard
+
+    win32clipboard.OpenClipboard()
+    text = win32clipboard.GetClipboardData(win32clipboard.CF_UNICODETEXT)
+    win32clipboard.CloseClipboard()
+    return text
 
 
 def fatal_error_dlg(app, with_details: bool = True) -> bool:
@@ -19,7 +31,7 @@ def fatal_error_dlg(app, with_details: bool = True) -> bool:
             sleep(1)
             dlg.child_window(title="Copy details").wait("visible").click()
             sleep(1)
-            log.warning(f"Fatal error screen detected! Details:\n{osi.cb_get()}")
+            log.warning(f"Fatal error screen detected! Details:\n{cb_get()}")
         else:
             log.warning(f"Fatal error screen detected!")
 
@@ -41,3 +53,19 @@ def share_metrics_dlg(app) -> bool:
         dlg.close()
         return True
     return False
+
+
+def get_opened_url() -> str:
+    """Return the current opened URL and quit the browser."""
+    # For the drive location
+    # https://pypi.org/project/selenium/, Drivers section
+    # Let's say the binary is at the root of the repository:
+    import os
+
+    os.environ["PATH"] = os.environ["PATH"] + ":" + os.getcwd()
+
+    browser = webdriver.Firefox()
+    try:
+        return browser.current_url
+    finally:
+        browser.quit()


### PR DESCRIPTION
`access-online` and `edit-metadata` are not well tested because we need to have control over the browser to guess the current opened URL.

So there is only a check that Drive works as expected, and the browser check should be done later in a specific ticket.