### PR TITLE
NXDRIVE-1816: Remove access to private methods

### DIFF
--- a/docs/changes/4.2.0.md
+++ b/docs/changes/4.2.0.md
@@ -13,6 +13,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1812](https://jira.nuxeo.com/browse/NXDRIVE-1812): Add a new option to quit the application after the sync is over
 - [NXDRIVE-1813](https://jira.nuxeo.com/browse/NXDRIVE-1813): Ignore engines that cannot be initalized
 - [NXDRIVE-1814](https://jira.nuxeo.com/browse/NXDRIVE-1814): Gracefully exit the application on CTRL+C
+- [NXDRIVE-1816](https://jira.nuxeo.com/browse/NXDRIVE-1816): Remove access to private methods
 
 ## GUI
 
@@ -62,12 +63,23 @@ Release date: `2019-xx-xx`
 
 ## Technical Changes
 
+- Added `AbstractOSIntegration.cleanup()`
+- Added `AbstractOSIntegration.init()`
 - Removed `AbstractOSIntegration.zoom_factor`
 - Removed `Action.get_last_file_action()`
 - Removed `Action.lastFileActions`
+- Added `Application.open_authentication_dialog()`
+- Removed `BaseUpdater.force_downgrade()`
 - Removed `BaseUpdater.force_status()`
+- Added `ConfigurationDAO.conn`
+- Added `ConfigurationDAO.lock`
+- Removed `ConfigurationDAO.get_db()`. Use `db` attribute instead.
+- Added `DarwinIntegration.cleanup()`
 - Added `DarwinIntegration.dark_mode_in_use()`
 - Added `DarwinIntegration.current_them()`
+- Added `DarwinIntegration.init()`
+- Removed `Engine.get_threads()`
+- Added `ExtensionListener.start_listening()`
 - Added `FileAction.chunk_size`
 - Added `FileAction.chunk_transfer_end_time_ns`
 - Added `FileAction.chunk_transfer_start_time_ns`
@@ -75,27 +87,43 @@ Release date: `2019-xx-xx`
 - Removed `FileAction.end_time`
 - Removed `FileAction.start_time`
 - Removed `FileAction.transfer_duration`
+- Removed `Manager.get_default_server_type()`. Use `DEFAULT_SERVER_TYPE` constant instead.
+- Added `Manager.get_server_login_type()`
+- Added `NotificationDelegator.manager`
 - Removed `Notification.get_replacements()`
 - Added `Options.sync_and_quit`
 - Added `PidLockFile.pid_filepath`
 - Removed `PidLockFile.folder`
 - Removed `process_name` keyword argument from `PidLockFile.check_running()`
+- Added `QMLDriveApi.callback_params`
 - Removed `QMLDriveApi.set_language()`
 - Removed `direction` keyword argument from `QMLDriveApi.get_last_files()`
 - Removed `duration` keyword argument from `QMLDriveApi.get_last_files()`
 - Removed `QMLDriveApi.get_actions()`
-- Removed `QMLDriveApi.get_errors_count()`
 - Removed `QMLDriveApi.get_conflicts_count()`
+- Removed `QMLDriveApi.get_errors_count()`
+- Removed `QMLDriveApi.get_threads()`
 - Removed `QMLDriveApi.get_update_progress()`
+- Added `Remote.base_folder_ref`
+- Added `Remote.check_ref()`
 - Added `Remote.transfer_end_callback()`
 - Added `Remote.transfer_start_callback()`
 - Changed return type of `Remote.upload_chunks()` from `Tuple[FileBlob, int]` to `FileBlob`
 - Removed `Remote.kwargs`
 - Removed `duration` argument from `Remote.link_blob_to_doc()`
+- Added `RemoteWatcher.scan_remote()`
 - Removed `Tracker.connect_engine()`
 - Removed `TransferStatus.CANCELLED`
+- Added `Translator.current_language`
+- Added `Translator.get_translation()`
+- Added `Translator.langs`
+- Added `Translator.set_language()`
+- Added `Translator.singleton`
 - Removed `Translator.translations()`
+- Added `WindowsIntegration.cleanup()`
+- Added `WindowsIntegration.init()`
 - Removed `WindowsIntegration.zoom_factor`
+- Added constants.py:`DEFAULT_SERVER_TYPE`
 - Added exceptions.py::`EngineInitError`
 - Added poll_worker.py::`SyncAndQuitWorker`
 - Added utils.py::`DEFAULTS_CERT_DETAILS`

--- a/nxdrive/__main__.py
+++ b/nxdrive/__main__.py
@@ -101,6 +101,7 @@ def main() -> int:
 
         with configure_scope() as scope:
             # Append OS and Python versions to all events
+            # pylint: disable=protected-access
             os_name, os_version = get_current_os()
             scope._contexts.update(
                 {

--- a/nxdrive/constants.py
+++ b/nxdrive/constants.py
@@ -31,6 +31,8 @@ UNACCESSIBLE_HASH = "TO_COMPUTE"
 
 TOKEN_PERMISSION = "ReadWrite"
 
+DEFAULT_SERVER_TYPE = "NXDRIVE"
+
 # Document's UID and token regexp
 DOC_UID_REG = "[0-f]{8}-[0-f]{4}-[0-f]{4}-[0-f]{4}-[0-f]{12}"
 

--- a/nxdrive/data/qml/GeneralTab.qml
+++ b/nxdrive/data/qml/GeneralTab.qml
@@ -70,7 +70,7 @@ Rectangle {
                     currentIndex = find(currentLanguage)
                 }
                 onActivated: {
-                    tl._set(languageModel.getTag(languageBox.currentIndex))
+                    tl.set_language(languageModel.getTag(languageBox.currentIndex))
                 }
             }
         }

--- a/nxdrive/direct_edit.py
+++ b/nxdrive/direct_edit.py
@@ -348,7 +348,7 @@ class DirectEdit(Worker):
 
         doc.update(
             {
-                "root": engine.remote._base_folder_ref,
+                "root": engine.remote.base_folder_ref,
                 "repository": engine.remote.client.repository,
             }
         )
@@ -693,7 +693,7 @@ class DirectEdit(Worker):
                 remote.upload(
                     os_path,
                     command=cmd,
-                    document=remote._check_ref(details.uid),
+                    document=remote.check_ref(details.uid),
                     engine_uid=engine.uid,
                     is_direct_edit=True,
                     **kwargs,

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -235,10 +235,7 @@ class Engine(QObject):
         }
 
     def _get_threads(self) -> List[Dict[str, Any]]:
-        result = []
-        for thread in self.get_threads():
-            result.append(thread.worker.export())
-        return result
+        return [thread.worker.export() for thread in self._threads]
 
     @pyqtSlot(object)
     def _check_sync_start(self, row_id: str = None) -> None:
@@ -360,7 +357,7 @@ class Engine(QObject):
             self.dao.remove_state_children(doc_pair)
         self.dao.force_remote_creation(doc_pair)
         if doc_pair.folderish:
-            self._remote_watcher._scan_remote(doc_pair)
+            self._remote_watcher.scan_remote(doc_pair)
 
     def get_metadata_url(self, remote_ref: str, edit: bool = False) -> str:
         """
@@ -725,9 +722,6 @@ class Engine(QObject):
             thread.start()
         self.syncStarted.emit(0)
         self._start.emit()
-
-    def get_threads(self) -> List[QThread]:
-        return self._threads
 
     def get_metrics(self) -> Metrics:
         return {

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -781,7 +781,7 @@ class Processor(EngineWorker):
                 remote_ref = fs_item_info.uid
                 self.dao.update_last_transfer(doc_pair.id, "upload")
 
-            with self.dao._lock:
+            with self.dao.lock:
                 remote_id_done = False
                 # NXDRIVE-599: set as soon as possible the remote_id as
                 # update_remote_state can crash with InterfaceError

--- a/nxdrive/engine/watcher/remote_watcher.py
+++ b/nxdrive/engine/watcher/remote_watcher.py
@@ -82,7 +82,7 @@ class RemoteWatcher(EngineWorker):
             raise
 
     @tooltip("Remote scanning")
-    def _scan_remote(self, from_state: DocPair = None):
+    def scan_remote(self, from_state: DocPair = None):
         """Recursively scan the bound remote folder looking for updates"""
         log.debug("Remote full scan")
         start = monotonic()
@@ -168,7 +168,7 @@ class RemoteWatcher(EngineWorker):
                 self._do_scan_remote(doc_pair, child_info)
         else:
             log.info(f"Remote scan_pair: {remote_path!r} is not available")
-            self._scan_remote()
+            self.scan_remote()
 
     @staticmethod
     def _check_modified(pair: DocPair, info: RemoteFileInfo) -> bool:
@@ -560,7 +560,7 @@ class RemoteWatcher(EngineWorker):
     def _partial_full_scan(self, path: str) -> None:
         log.info(f"Continue full scan of {path!r}")
         if path == "/":
-            self._scan_remote()
+            self.scan_remote()
         else:
             self._scan_pair(path)
         self.dao.delete_path_to_scan(path)
@@ -586,7 +586,7 @@ class RemoteWatcher(EngineWorker):
 
         try:
             if not self._last_remote_full_scan:
-                self._scan_remote()
+                self.scan_remote()
 
                 # Might need to handle the changes now
                 if first_pass:

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -303,7 +303,7 @@ class Application(QApplication):
         context.setContextProperty("update_check_delay", Options.update_check_delay)
         context.setContextProperty("isFrozen", Options.is_frozen)
         context.setContextProperty("WINDOWS", WINDOWS)
-        context.setContextProperty("tl", Translator._singleton)
+        context.setContextProperty("tl", Translator.singleton)
         context.setContextProperty(
             "nuxeoVersionText", f"{APP_NAME} {self.manager.version}"
         )
@@ -356,7 +356,7 @@ class Application(QApplication):
         Translator.on_change(self._handle_language_change)
         # Trigger it now
         self.osi.register_contextual_menu()
-        self.installTranslator(Translator._singleton)
+        self.installTranslator(Translator.singleton)
 
     @pyqtSlot(str, Path, str)
     def _direct_edit_conflict(self, filename: str, ref: Path, digest: str) -> None:
@@ -665,10 +665,10 @@ class Application(QApplication):
         self._show_window(self.settings_window)
 
     @pyqtSlot(str, object)
-    def _open_authentication_dialog(
+    def open_authentication_dialog(
         self, url: str, callback_params: Dict[str, str]
     ) -> None:
-        self.api._callback_params = callback_params
+        self.api.callback_params = callback_params
         if Options.is_frozen:
             """
             Authenticate through the browser.
@@ -885,7 +885,7 @@ class Application(QApplication):
         if not self._delegator:
             self._delegator = NotificationDelegator.alloc().init()
             if self._delegator:
-                self._delegator._manager = self.manager
+                self._delegator.manager = self.manager
         setup_delegator(self._delegator)
 
     @pyqtSlot(object)

--- a/nxdrive/logging_config.py
+++ b/nxdrive/logging_config.py
@@ -176,7 +176,7 @@ def check_level(level: str) -> str:
     """Handle bad logging level."""
     try:
         level = no_trace(level)
-        logging._nameToLevel[level]
+        logging._nameToLevel[level]  # pylint: disable=protected-access
     except (AttributeError, ValueError, KeyError):
         err = f"Unknown logging level {level!r}, need to be one of {LOG_LEVELS}."
         raise ValueError(err)

--- a/nxdrive/options.py
+++ b/nxdrive/options.py
@@ -419,7 +419,7 @@ class MetaOptions(type):
             items = items.items()
         elif not isinstance(items, list):
             # To handle CLI (type is argparse.Namespace)
-            items = items._get_kwargs()
+            items = items._get_kwargs()  # pylint: disable=protected-access
 
         for item, value in items:
             MetaOptions.set(

--- a/nxdrive/osi/__init__.py
+++ b/nxdrive/osi/__init__.py
@@ -106,10 +106,10 @@ class AbstractOSIntegration(QObject):
         """Copy some *text* into the clipboard."""
         pass
 
-    def _init(self) -> None:
+    def init(self) -> None:
         pass
 
-    def _cleanup(self) -> None:
+    def cleanup(self) -> None:
         pass
 
     @staticmethod

--- a/nxdrive/osi/darwin/darwin.py
+++ b/nxdrive/osi/darwin/darwin.py
@@ -65,7 +65,7 @@ class DarwinIntegration(AbstractOSIntegration):
     )
 
     @if_frozen
-    def _init(self) -> None:
+    def init(self) -> None:
         log.info("Telling plugInKit to use the FinderSync")
         try:
             subprocess.run(
@@ -79,7 +79,7 @@ class DarwinIntegration(AbstractOSIntegration):
             log.exception("Error while starting FinderSync")
 
     @if_frozen
-    def _cleanup(self) -> None:
+    def cleanup(self) -> None:
         log.info("Telling plugInKit to ignore the FinderSync")
         try:
             subprocess.run(

--- a/nxdrive/osi/darwin/pyNotificationCenter.py
+++ b/nxdrive/osi/darwin/pyNotificationCenter.py
@@ -20,7 +20,7 @@ __all__ = ("NotificationDelegator", "notify", "setup_delegator")
 
 class NotificationDelegator(NSObject):
 
-    _manager: "Manager"
+    manager: "Manager"
 
     def __init__(self) -> None:
         info_dict = NSBundle.mainBundle().infoDictionary()
@@ -33,13 +33,13 @@ class NotificationDelegator(NSObject):
         info = notification.userInfo()
         if info and "uuid" not in info:
             return
-        notifications = self._manager.notification_service.get_notifications()
+        notifications = self.manager.notification_service.get_notifications()
         if (
             info["uuid"] not in notifications
             or notifications[info["uuid"]].is_discard_on_trigger()
         ):
             center.removeDeliveredNotification_(notification)
-        self._manager.notification_service.trigger_notification(info["uuid"])
+        self.manager.notification_service.trigger_notification(info["uuid"])
 
     def userNotificationCenter_shouldPresentNotification_(
         self, center: object, notification: object

--- a/nxdrive/osi/extension.py
+++ b/nxdrive/osi/extension.py
@@ -78,7 +78,7 @@ class ExtensionListener(QTcpServer):
         """Compute the real address the server is listening on."""
         return f"{self.serverAddress().toString()}:{self.serverPort()}"
 
-    def _listen(self):
+    def start_listening(self):
         """
         Called once the Manager.started() is emitted.
 

--- a/nxdrive/osi/windows/windows.py
+++ b/nxdrive/osi/windows/windows.py
@@ -37,17 +37,17 @@ class WindowsIntegration(AbstractOSIntegration):
     nature = "Windows"
 
     @if_frozen
-    def _init(self) -> None:
+    def init(self) -> None:
         if self._manager:
             watched_folders = {
-                engine.local_folder for engine in self._manager._engine_definitions
+                engine.local_folder for engine in self._manager.engines.values()
             }
             if watched_folders:
                 set_filter_folders(watched_folders)
                 enable_overlay()
 
     @if_frozen
-    def _cleanup(self) -> None:
+    def cleanup(self) -> None:
         disable_overlay()
 
     @pyqtSlot(result=bool)

--- a/nxdrive/report.py
+++ b/nxdrive/report.py
@@ -74,16 +74,16 @@ class Report:
     @staticmethod
     def copy_db(myzip: ZipFile, dao: "EngineDAO") -> None:
         """
-        Copy a databse file to the ZIP report.
+        Copy a database file to the ZIP report.
         If it fails, we just try ignore the file.
         """
 
         # Lock to avoid inconsistence
-        with dao._lock:
+        with dao.lock:
             try:
-                myzip.write(dao._db, dao._db.name, compress_type=ZIP_DEFLATED)
+                myzip.write(dao.db, dao.db.name, compress_type=ZIP_DEFLATED)
             except Exception:
-                log.exception(f"Impossible to copy the database {dao._db.name!r}")
+                log.exception(f"Impossible to copy the database {dao.db.name!r}")
 
     def get_path(self) -> Path:
         return self._zipfile

--- a/nxdrive/updater/base.py
+++ b/nxdrive/updater/base.py
@@ -208,7 +208,7 @@ class BaseUpdater(PollWorker):
             login_type = Login.NONE
             for engine in list(self.manager.engines.values()):
                 url = engine.server_url
-                login_type |= self.manager._get_server_login_type(url, _raise=False)
+                login_type |= self.manager.get_server_login_type(url, _raise=False)
 
             channel = self.manager.get_update_channel()
             log.info(
@@ -228,7 +228,7 @@ class BaseUpdater(PollWorker):
             self.status = status
             self.version = ""
 
-    def _force_downgrade(self) -> None:
+    def force_downgrade(self) -> None:
         try:
             # Fetch all available versions
             self._fetch_versions()

--- a/nxdrive/updater/darwin.py
+++ b/nxdrive/updater/darwin.py
@@ -31,7 +31,7 @@ class Updater(BaseUpdater):
         On any error, the backup will be reverted.
         """
         # Unload the Finder Sync extension
-        self.manager.osi._cleanup()
+        self.manager.osi.cleanup()
 
         log.info(f"Mounting {filename!r}")
         mount_info = subprocess.check_output(["hdiutil", "mount", filename])

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -655,6 +655,7 @@ def get_certificate_details(hostname: str = "", cert_data: str = "") -> Dict[str
         cert_file.write_text(certificate, encoding="utf-8")
         try:
             # Taken from https://stackoverflow.com/a/50072461/1117028
+            # pylint: disable=protected-access
             details = ssl._ssl._test_decode_cert(cert_file)  # type: ignore
             defaults.update(details)
         finally:

--- a/tests/old_functional/__init__.py
+++ b/tests/old_functional/__init__.py
@@ -207,7 +207,7 @@ class RemoteBase(Remote):
         return self.execute(command="Document.GetChildren", input_obj=f"doc:{ref}")
 
     def get_children_info(self, ref: str, limit: int = 1000) -> List[NuxeoDocumentInfo]:
-        ref = self._escape(self._check_ref(ref))
+        ref = self._escape(self.check_ref(ref))
         types = {"File", "Note", "Workspace", "Folder", "Picture"}
 
         query = (
@@ -291,7 +291,7 @@ class RemoteBase(Remote):
         filtered = []
         for entry in entries:
             entry.update(
-                {"root": self._base_folder_ref, "repository": self.client.repository}
+                {"root": self.base_folder_ref, "repository": self.client.repository}
             )
             if parent_uid is None and fetch_parent_uid:
                 parent_uid = self.fetch(os.path.dirname(entry["path"]))["uid"]
@@ -426,7 +426,7 @@ class DocRemote(RemoteTest):
         # - Folder under Folder or Workspace
         # This configuration should be provided by a special operation on the
         # server.
-        parent = self._check_ref(parent)
+        parent = self.check_ref(parent)
         doc = self.create(parent, doc_type, name=name, properties={"dc:title": name})
         return doc["uid"]
 
@@ -437,7 +437,7 @@ class DocRemote(RemoteTest):
 
         Creates a temporary file from the content then streams it.
         """
-        parent = self._check_ref(parent)
+        parent = self.check_ref(parent)
         properties = {"dc:title": name}
         if doc_type == "Note" and content is not None:
             properties["note:note"] = content
@@ -495,7 +495,7 @@ class DocRemote(RemoteTest):
         """
 
         if not isinstance(ref, NuxeoDocumentInfo):
-            ref = self._check_ref(ref)
+            ref = self.check_ref(ref)
         return self.get_blob(ref)
 
     def update_content(
@@ -507,13 +507,13 @@ class DocRemote(RemoteTest):
         """
         if filename is None:
             filename = self.get_info(ref).name
-        self.attach_blob(self._check_ref(ref), content, filename)
+        self.attach_blob(self.check_ref(ref), content, filename)
 
     def move(self, ref: str, target: str, name: str = None):
         return self.execute(
             command="Document.Move",
-            input_obj=f"doc:{self._check_ref(ref)}",
-            target=self._check_ref(target),
+            input_obj=f"doc:{self.check_ref(ref)}",
+            target=self.check_ref(target),
             name=name,
         )
 
@@ -525,13 +525,13 @@ class DocRemote(RemoteTest):
     def copy(self, ref: str, target: str, name: str = None):
         return self.execute(
             command="Document.Copy",
-            input_obj=f"doc:{self._check_ref(ref)}",
-            target=self._check_ref(target),
+            input_obj=f"doc:{self.check_ref(ref)}",
+            target=self.check_ref(target),
             name=name,
         )
 
     def delete(self, ref: str, use_trash: bool = True):
-        input_obj = f"doc:{self._check_ref(ref)}"
+        input_obj = f"doc:{self.check_ref(ref)}"
         if use_trash:
             try:
                 if not self._has_new_trash_service:
@@ -548,7 +548,7 @@ class DocRemote(RemoteTest):
         return self.execute(command="Document.Delete", input_obj=input_obj)
 
     def delete_content(self, ref: str, xpath: str = None):
-        return self.delete_blob(self._check_ref(ref), xpath=xpath)
+        return self.delete_blob(self.check_ref(ref), xpath=xpath)
 
     def delete_blob(self, ref: str, xpath: str = None):
         return self.execute(command="Blob.Remove", input_obj=f"doc:{ref}", xpath=xpath)
@@ -561,7 +561,7 @@ class DocRemote(RemoteTest):
         headers = {"X-NXfetch.document": "versionLabel"}
         versions = self.execute(
             command="Document.GetVersions",
-            input_obj=f"doc:{self._check_ref(ref)}",
+            input_obj=f"doc:{self.check_ref(ref)}",
             headers=headers,
         )
         return [(v["uid"], v["versionLabel"]) for v in versions["entries"]]
@@ -569,7 +569,7 @@ class DocRemote(RemoteTest):
     def create_version(self, ref: str, increment: str = "None"):
         doc = self.execute(
             command="Document.CreateVersion",
-            input_obj=f"doc:{self._check_ref(ref)}",
+            input_obj=f"doc:{self._heck_ref(ref)}",
             increment=increment,
         )
         return doc["uid"]
@@ -577,12 +577,12 @@ class DocRemote(RemoteTest):
     def restore_version(self, version: str) -> str:
         doc = self.execute(
             command="Document.RestoreVersion",
-            input_obj=f"doc:{self._check_ref(version)}",
+            input_obj=f"doc:{self.check_ref(version)}",
         )
         return doc["uid"]
 
     def block_inheritance(self, ref: str, overwrite: bool = True):
-        input_obj = f"doc:{self._check_ref(ref)}"
+        input_obj = f"doc:{self.check_ref(ref)}"
 
         self.execute(
             command="Document.SetACE",

--- a/tests/old_functional/test_concurrent_synchronization.py
+++ b/tests/old_functional/test_concurrent_synchronization.py
@@ -286,7 +286,7 @@ class TestConcurrentSynchronization(TwoUsersTest):
         self.engine_1.suspend()
         local.delete("/Test folder")
         assert not local.exists("/Test folder")
-        test_folder_ref = remote._check_ref("/Test folder")
+        test_folder_ref = remote.check_ref("/Test folder")
         # Wait for 1 second to make sure the folder's last modification time
         # will be different from the pair state's last remote update time
         time.sleep(REMOTE_MODIFICATION_TIME_RESOLUTION)
@@ -331,7 +331,7 @@ class TestConcurrentSynchronization(TwoUsersTest):
         time.sleep(OS_STAT_MTIME_RESOLUTION)
         local.update_content("/test.odt", b"Updated content.")
         assert local.get_content("/test.odt") == b"Updated content."
-        test_file_ref = remote._check_ref("/test.odt")
+        test_file_ref = remote.check_ref("/test.odt")
         # Wait for 1 second to make sure the file's last modification time
         # will be different from the pair state's last remote update time
         time.sleep(REMOTE_MODIFICATION_TIME_RESOLUTION)

--- a/tests/old_functional/test_direct_edit.py
+++ b/tests/old_functional/test_direct_edit.py
@@ -97,7 +97,7 @@ class TestDirectEdit(OneUserTest, DirectEditSetup):
             file_path,
             command="Blob.AttachOnDocument",
             filename=attachment_filename,
-            document=self.remote._check_ref(doc_id),
+            document=self.remote.check_ref(doc_id),
             xpath="files:files",
         )
         scheme, host = self.nuxeo_url.split("://")

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -44,7 +44,7 @@ def test_load_file():
 
 
 def test_non_iniialized():
-    Translator._singleton = None
+    Translator.singleton = None
     with pytest.raises(RuntimeError):
         Translator.get("TEST")
 


### PR DESCRIPTION
A lot of changes, remaining issues will be tackled with NXPY-128 and NXDRIVE-1095.

```shell
$ python -m pylint --disable=all --enable=protected-access nxdrive          
************* Module nxdrive.engine.watcher.local_watcher
nxdrive/engine/watcher/local_watcher.py:841: [W0212(protected-access), LocalWatcher._handle_watchdog_event_on_known_pair] Access to a protected member _queue_pair_state of a client class
************* Module nxdrive.client.remote_client
nxdrive/client/remote_client.py:449: [W0212(protected-access), Remote.upload_chunks] Access to a protected member _upload_idx of a client class
nxdrive/client/remote_client.py:479: [W0212(protected-access), Remote.upload_chunks] Access to a protected member _upload_idx of a client class
```