### PR TITLE
NXDRIVE-1803: Add a new update channel: Centralized

### DIFF
--- a/docs/changes/4.2.0.md
+++ b/docs/changes/4.2.0.md
@@ -12,6 +12,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1784](https://jira.nuxeo.com/browse/NXDRIVE-1784): Remove unused objects and add CI/QA checks
 - [NXDRIVE-1787](https://jira.nuxeo.com/browse/NXDRIVE-1787): Ensure `Engine.newError` is passed an Engine
 - [NXDRIVE-1788](https://jira.nuxeo.com/browse/NXDRIVE-1788): Ensure `Application.action_progressing()` is passing an Action
+- [NXDRIVE-1803](https://jira.nuxeo.com/browse/NXDRIVE-1803): Add a new update channel: `Centralized`
 - [NXDRIVE-1807](https://jira.nuxeo.com/browse/NXDRIVE-1807): Improve startup SSL check wording
 - [NXDRIVE-1812](https://jira.nuxeo.com/browse/NXDRIVE-1812): Add a new option to quit the application after the sync is over
 - [NXDRIVE-1813](https://jira.nuxeo.com/browse/NXDRIVE-1813): Ignore engines that cannot be initalized
@@ -104,6 +105,8 @@ Release date: `2019-xx-xx`
 - Added `Manager.get_server_login_type()`
 - Added `NotificationDelegator.manager`
 - Removed `Notification.get_replacements()`
+- Changed default value of `Options.channel` from `release` to `centralized`
+- Added `Options.client_version`
 - Added `Options.sync_and_quit`
 - Added `PidLockFile.pid_filepath`
 - Removed `PidLockFile.folder`
@@ -136,9 +139,11 @@ Release date: `2019-xx-xx`
 - Added `WindowsIntegration.cleanup()`
 - Added `WindowsIntegration.init()`
 - Removed `WindowsIntegration.zoom_factor`
+- Added constants.py:`DEFAULT_CHANNEL`
 - Added constants.py:`DEFAULT_SERVER_TYPE`
 - Added constants.py:`NXDRIVE_SCHEME`
 - Added exceptions.py::`EngineInitError`
+- Added options.py::`validate_client_version()`
 - Added poll_worker.py::`SyncAndQuitWorker`
 - Added utils.py::`DEFAULTS_CERT_DETAILS`
 - Added `cls` keyword argument to utils.py::`normalized_path()`

--- a/docs/dep/2019-01 Generate a unique test environment during the setup.md
+++ b/docs/dep/2019-01 Generate a unique test environment during the setup.md
@@ -4,7 +4,7 @@
 - Last-Modified: 2019-05-17
 - Author: Mickaël Schoentgen <mschoentgen@nuxeo.com>,
           Léa Klein <lklein@nuxeo.com>
-- Status: ongoing implementation
+- Status: implemented
 - Related-Ticket: [NXDRIVE-1436](https://jira.nuxeo.com/browse/NXDRIVE-1436)
                   [NXDRIVE-1542](https://jira.nuxeo.com/browse/NXDRIVE-1542)
 

--- a/docs/dep/2019-09 New update channel - Centralized.md
+++ b/docs/dep/2019-09 New update channel - Centralized.md
@@ -1,0 +1,84 @@
+# Add a new update channel: Centralized
+
+- Created: 2019-09-02
+- Last-Modified: 2019-09-10
+- Author: Mickaël Schoentgen <mschoentgen@nuxeo.com>,
+          Patrick Abgrall <pabgrall@nuxeo.com>
+- Status: implemented
+- Related-Ticket: [NXDRIVE-1803](https://jira.nuxeo.com/browse/NXDRIVE-1803)
+
+## Abstract
+
+Add a new update channel to let the administrators manage all Nuxeo Drive versions.
+
+## Rationale
+
+Current [documented procedure](https://doc.nuxeo.com/client-apps/nuxeo-drive-update-site/) to manage the Nuxeo Drive client upgrade strategy assumes the customer will replicate the Nuxeo Drive upgrade site and update the upgrade URL on the client-side. Or the clients must be told not to upgrade automatically.
+
+This puts effectively Nuxeo in charge of managing the software landscape of customer productions.
+In case of incompatibility or problems introduced by a later version, the default strategy is "next version".
+To implement "last working version and no automatic upgrade", the administrator must put in place the process documented above or act on the client-side to disable automated upgrade of clients...
+
+### Idea
+
+What is requested is that the Administrator can force from a central place a given version of Nuxeo Drive on the client-side via configuration only.
+This would put the software landscape in production administrators hands in a simple and direct way.
+
+## Specifications
+
+### Server Side
+
+We will leverage de [global configuration capabilities](https://doc.nuxeo.com/client-apps/how-to-configure-nuxeo-drive-globally/) to define a new option named `client_version`.
+
+It will be a string representing a Nuxeo Drive version, e.g.: `4.2.0`.
+
+### Client Side
+
+A new update channel will be added, `Centralized`, that will be the default choice at installation.
+
+To resume, the update priority will be:
+
+1. Centralized
+2. Release
+3. Beta
+4. Alpha
+
+When the `Centralized` channel is used, the version that will be installed is the one set by the Administrator in the `client_version` option.
+
+Notes:
+
+* If the current update channel is `Centralized` and no `client_version` set, the `Release` channel will be used.
+* The current update channel will not be changed for users doing an update.
+
+## Downsides
+
+Those are questions or preocupations that are kept for historical reasons only. None of those are actual issues.
+
+### Cyclic Updates on Nuxeo Drive 4.x
+
+The new update option `client_version` will be implemented in the next Nuxeo Drive version (4.2.0).
+
+So if the Administrator sets the client version to an older version, that version will be installed.
+
+* If the desired version is less than `4.0.0`, see [Impossible to Start Nuxeo Drive 3.x](#impossible-to-start-nuxeo-drive-3.x).
+* If the desired version is greater or equal to `4.0.0` and less than `4.2.0`, that old Nuxeo Drive version does not understand the new update channel.
+* It will use the `Release` channel by default and thus updating to the newest Nuxeo Drive version, creating cyclic updates.
+
+This is known but we also need to move forward.
+So the good answer will be to document that behavior and add a protection in Nuxeo Drive itself by setting a minimal version allowed to be installed via this option.
+
+### Impossible to Start Nuxeo Drive 3.x
+
+This will not work for Nuxeo Drive 3.x. But those versions are obsolete and unsupported for a while.
+Setting the new option `client_version` will just break Nuxeo Drive as options are checked, and if it is not a known one, Nuxeo Drive raises a fatal error.
+
+To be more clear, users using Nuxeo Drive 2.x or 3.x will have issues if administrators are using the new `client_version` option.
+
+### Broken Updates
+
+The only implemented check will be to ensure the `client_version` is greater or equal to `4.2.0`.
+
+There will be no other checks so that administrators can use alpha, beta and release versions.
+
+This might lead to unusable or instable versions of the application.
+This is known and now that administrators are handling that, it is their responsability to ensure they do not deploy a problematic version of Nuxeo Drive.

--- a/nxdrive/commandline.py
+++ b/nxdrive/commandline.py
@@ -12,7 +12,7 @@ from logging import getLogger
 from typing import List, TYPE_CHECKING, Union
 
 from . import __version__
-from .constants import APP_NAME, BUNDLE_IDENTIFIER
+from .constants import APP_NAME, BUNDLE_IDENTIFIER, DEFAULT_CHANNEL
 from .logging_config import configure
 from .options import Options
 from .osi import AbstractOSIntegration
@@ -115,8 +115,8 @@ class CliHandler:
 
         common_parser.add_argument(
             "--channel",
-            default="release",
-            choices=("alpha", "beta", "release"),
+            default=DEFAULT_CHANNEL,
+            choices=("alpha", "beta", "release", "centralized"),
             help="Update channel",
         )
 

--- a/nxdrive/constants.py
+++ b/nxdrive/constants.py
@@ -28,6 +28,9 @@ BATCH_SIZE = 100  # Scroll descendants batch size
 # time, the server will finish way before thhat timeout.
 TX_TIMEOUT = 60 * 60 * 6  # 6 hours
 
+# Default update channel
+DEFAULT_CHANNEL = "centralized"
+
 ROOT = Path()
 
 UNACCESSIBLE_HASH = "TO_COMPUTE"

--- a/nxdrive/data/qml/ChannelPopup.qml
+++ b/nxdrive/data/qml/ChannelPopup.qml
@@ -15,14 +15,17 @@ NuxeoPopup {
     onOpened: {
         var channel = api.get_update_channel()
         switch(channel) {
-            case "release":
+            case "centralized":
                 channelType.currentIndex = 0
                 break
-            case "beta":
+            case "release":
                 channelType.currentIndex = 1
                 break
-            case "alpha":
+            case "beta":
                 channelType.currentIndex = 2
+                break
+            case "alpha":
+                channelType.currentIndex = 3
                 break
         }
     }
@@ -39,6 +42,7 @@ NuxeoPopup {
             textRole: "type"
             displayText: qsTr(currentText) + tl.tr
             model: ListModel {
+                ListElement { type: "Centralized"; value: "centralized" }
                 ListElement { type: "Release"; value: "release" }
                 ListElement { type: "Beta"; value: "beta" }
                 ListElement { type: "Alpha"; value: "alpha" }

--- a/nxdrive/manager.py
+++ b/nxdrive/manager.py
@@ -19,6 +19,7 @@ from .client.local_client import LocalClient
 from .client.proxy import get_proxy, load_proxy, save_proxy, validate_proxy
 from .constants import (
     APP_NAME,
+    DEFAULT_CHANNEL,
     DEFAULT_SERVER_TYPE,
     NO_SPACE_ERRORS,
     STARTUP_PAGE_CONNECTION_TIMEOUT,
@@ -135,7 +136,7 @@ class Manager(QObject):
                 if beta:
                     Options.set("channel", "beta", setter="local")
                 else:
-                    Options.set("channel", "release", setter="local")
+                    Options.set("channel", DEFAULT_CHANNEL, setter="local")
                 self.dao.delete_config("beta_channel")
 
             Options.set("channel", self.get_update_channel(), setter="local")
@@ -434,6 +435,7 @@ class Manager(QObject):
 
     @pyqtSlot(bool)
     def set_direct_edit_auto_lock(self, value: bool) -> None:
+        log.debug(f"Changed parameter 'direct_edit_auto_lock' to {value}")
         self.dao.store_bool("direct_edit_auto_lock", value)
 
     @pyqtSlot(result=bool)
@@ -445,6 +447,7 @@ class Manager(QObject):
 
     @pyqtSlot(bool)
     def set_auto_update(self, value: bool) -> None:
+        log.debug(f"Changed parameter 'auto_update' to {value}")
         self.dao.store_bool("auto_update", value)
 
     @pyqtSlot(result=bool)
@@ -461,6 +464,7 @@ class Manager(QObject):
 
     @pyqtSlot(bool, result=bool)
     def set_auto_start(self, value: bool) -> bool:
+        log.debug(f"Changed parameter 'auto_start' to {value}")
         self.dao.store_bool("auto_start", value)
 
         if value:
@@ -480,7 +484,9 @@ class Manager(QObject):
 
     @pyqtSlot(result=str)
     def get_update_channel(self) -> str:
-        return self.dao.get_config("channel", default=Options.channel or "release")
+        return self.dao.get_config(
+            "channel", default=Options.channel or DEFAULT_CHANNEL
+        )
 
     @pyqtSlot(str)
     def set_update_channel(self, value: str) -> None:
@@ -513,6 +519,7 @@ class Manager(QObject):
         return self._tracker.uid if self._tracker else ""
 
     def set_proxy(self, proxy: "Proxy") -> str:
+        log.debug(f"Changed proxy to {proxy}")
         for engine in self.engines.values():
             if not validate_proxy(proxy, engine.server_url):
                 return "PROXY_INVALID"

--- a/nxdrive/options.py
+++ b/nxdrive/options.py
@@ -192,10 +192,11 @@ class MetaOptions(type):
         "big_file": (300, "default"),
         "browser_startup_page": ("drive_browser_login.jsp", "default"),
         "ca_bundle": (None, "default"),
-        "channel": ("release", "default"),
+        "channel": ("centralized", "default"),
         "chunk_limit": (20, "default"),
         "chunk_size": (20, "default"),
         "chunk_upload": (True, "default"),
+        "client_version": (None, "default"),
         "debug": (False, "default"),
         "debug_pydev": (False, "default"),
         "delay": (30, "default"),
@@ -489,6 +490,19 @@ def validate_chunk_size(value: int) -> int:
     raise ValueError("Chunk size must be between 1 and 20 (MiB)")
 
 
+def validate_client_version(value: str) -> str:
+    """The minimum version which implements the Centralized channel is 4.2.0,
+    downgrades below this version are not allowed.
+    """
+    from .utils import version_lt
+
+    if not version_lt(value, "4.2.0"):
+        return value
+    raise ValueError(
+        f"Downgrade to version {value!r} is not possible. It must be >= '4.2.0'."
+    )
+
+
 def validate_tmp_file_limit(value: Union[int, float]) -> float:
     if value > 0:
         return float(value)
@@ -497,4 +511,5 @@ def validate_tmp_file_limit(value: Union[int, float]) -> float:
 
 Options.checkers["chunk_limit"] = validate_chunk_limit
 Options.checkers["chunk_size"] = validate_chunk_size
+Options.checkers["client_version"] = validate_client_version
 Options.checkers["tmp_file_limit"] = validate_tmp_file_limit

--- a/nxdrive/updater/base.py
+++ b/nxdrive/updater/base.py
@@ -105,7 +105,7 @@ class BaseUpdater(PollWorker):
     def refresh_status(self) -> None:
         """
         Check for an update.
-        Used when changing the beta channel option or when binding a new engine.
+        Used when changing the channel option or when binding a new engine.
         """
         self._poll()
 
@@ -213,7 +213,8 @@ class BaseUpdater(PollWorker):
             channel = self.manager.get_update_channel()
             log.info(
                 f"Getting update status for version {self.manager.version}"
-                f" (channel={channel}) on server {self.server_ver}"
+                f" (channel={channel}, desired client_version={Options.client_version})"
+                f" on server {self.server_ver}"
             )
             status, version = get_update_status(
                 self.manager.version,

--- a/tests/unit/test_updater.py
+++ b/tests/unit/test_updater.py
@@ -5,8 +5,10 @@ from nxdrive.updater.constants import (
     UPDATE_STATUS_INCOMPATIBLE_SERVER,
     UPDATE_STATUS_UPDATE_AVAILABLE,
     UPDATE_STATUS_UP_TO_DATE,
+    UPDATE_STATUS_WRONG_CHANNEL,
     Login,
 )
+from nxdrive.options import Options
 from nxdrive.updater.utils import get_update_status
 
 
@@ -39,16 +41,19 @@ VERSIONS = {
     "4.0.3.1": {"type": "alpha", "min": "10.10"},
     "4.0.3.6": {"type": "alpha", "min": "10.11"},
     "4.0.3.12": {"type": "alpha", "min": "10.11"},
+    "4.2.0": {"type": "release", "min": "10.12"},
+    "4.2.1": {"type": "release", "min": "10.13"},
+    "4.3.4": {"type": "beta", "min": "10.12"},
 }
 
 
 @pytest.mark.parametrize(
-    "current, server, nature, action_required, new",
+    "current, server, channel, action_required, new",
     [
         # No version
         ("3.1.2", "", "release", "", ""),
         ("3.1.2", None, "release", "", ""),
-        # Unexisting nature
+        # Unexisting channel, fallback on the release one
         ("3.1.2", "10.10", "bar", UPDATE_STATUS_UPDATE_AVAILABLE, "3.1.3"),
         # Unexisting version
         ("3.1.2", "0.0.0", "release", "", ""),
@@ -74,6 +79,8 @@ VERSIONS = {
         # Unknown version from versions.yml
         ("42.2.2", "10.3-SNAPSHOT", "release", "", ""),
         ("42.2.2", "5.6", "release", "", ""),
+        # Wrong channel
+        ("4.0.2.13", "10.1", "release", UPDATE_STATUS_WRONG_CHANNEL, "3.1.3"),
         # Beta
         ("2.4.2b1", "9.2", "beta", UPDATE_STATUS_UPDATE_AVAILABLE, "3.1.3"),
         ("2.5.0b1", "9.2", "beta", UPDATE_STATUS_UPDATE_AVAILABLE, "3.1.3"),
@@ -84,17 +91,80 @@ VERSIONS = {
         ("4.0.3.1", "10.11", "alpha", UPDATE_STATUS_UPDATE_AVAILABLE, "4.0.3.12"),
     ],
 )
-def test_get_update_status(current, server, nature, action_required, new):
+def test_get_update_status(current, server, channel, action_required, new):
     """get_update_status calls get_latest_version and get_compatible_versions, 2 tests in one!"""
-    action, version = get_update_status(current, VERSIONS, nature, server, Login.NEW)
+    action, version = get_update_status(current, VERSIONS, channel, server, Login.NEW)
     assert action == action_required
     assert version == new
+
+
+@Options.mock()
+@pytest.mark.parametrize(
+    "current, desired, action_required, new",
+    [
+        # Centralized
+        ("4.3.4", "4.2.0", UPDATE_STATUS_UPDATE_AVAILABLE, "4.2.0"),
+        ("4.3.4", "4.2.2", UPDATE_STATUS_UPDATE_AVAILABLE, "4.2.2"),
+        ("4.3.4", "4.3.4", UPDATE_STATUS_UP_TO_DATE, ""),
+    ],
+)
+def test_get_update_status_centralized_channel(current, desired, action_required, new):
+    """Test the Centralized channel."""
+    Options.client_version = desired
+    assert Options.client_version == desired
+    action, version = get_update_status(
+        current, VERSIONS, "centralized", "10.12", Login.NEW
+    )
+    assert action == action_required
+    assert version == new
+
+
+@Options.mock()
+def test_get_update_status_centralized_channel_wrong_client_version():
+    """Test the Centralized channel with a client_version too low."""
+    Options.client_version = "4.0.3.12"
+
+    # The options is not updated, protected by the option's callback
+    assert Options.client_version is None
+
+    action, version = get_update_status(
+        "4.3.4", VERSIONS, "centralized", "10.12", Login.NEW
+    )
+    # As the client_version is not set, it falls back to the release channel
+    assert action == UPDATE_STATUS_UPDATE_AVAILABLE
+    # And so the latest release is 4.2.0 (4.3.4 is beta, so a downgrade is asked)
+    assert version == "4.2.0"
+
+
+@Options.mock()
+def test_get_update_status_centralized_channel_without_client_version():
+    """Test the Centralized channel when no client_version is set,
+    it should fall back on the release channel.
+    """
+    assert Options.client_version is None
+    action, version = get_update_status(
+        "4.0.1", VERSIONS, "centralized", "10.15", Login.NEW
+    )
+    assert action == UPDATE_STATUS_UPDATE_AVAILABLE
+    assert version == "4.2.1"
+
+
+@Options.mock()
+def test_get_update_status_centralized_channel_wrong_server():
+    """Test the Centralized channel when the desired version is not compatible with the server."""
+    Options.client_version = "4.2.1"
+    assert Options.client_version == "4.2.1"
+    action, version = get_update_status(
+        "4.3.4", VERSIONS, "centralized", "10.11", Login.NEW
+    )
+    assert action == UPDATE_STATUS_INCOMPATIBLE_SERVER
+    assert version == "4.2.1"
 
 
 def test_get_update_status_versions_is_none():
     """BaseUpdater.versions may be set to None, before NXDRIVE-1682."""
     # No version
-    current, server, nature, action_required, new = "3.1.2", "", "release", "", ""
-    action, version = get_update_status(current, None, nature, server, Login.NONE)
+    current, server, channel, action_required, new = "3.1.2", "", "release", "", ""
+    action, version = get_update_status(current, None, channel, server, Login.NONE)
     assert action == action_required
     assert version == new


### PR DESCRIPTION
Step 1: DEP review.
You can see the DEP at this [link](https://github.com/nuxeo/nuxeo-drive/blob/wip-NXDRIVE-1803-new-centralized-auto-update-option/docs/dep/2019-09%20New%20update%20channel%20-%20Centralized.md).