### PR TITLE
NXDRIVE-445: [GNU/Linux] Add support for the custom URL protocol

### DIFF
--- a/docs/changes/4.2.0.md
+++ b/docs/changes/4.2.0.md
@@ -4,6 +4,7 @@ Release date: `2019-xx-xx`
 
 ## Core
 
+- [NXDRIVE-445](https://jira.nuxeo.com/browse/NXDRIVE-445): [GNU/Linux] Add support for the custom URL protocol
 - [NXDRIVE-1473](https://jira.nuxeo.com/browse/NXDRIVE-1473): Add GNU/Linux support to the auto-updater
 - [NXDRIVE-1491](https://jira.nuxeo.com/browse/NXDRIVE-1491): Do not use bare exceptions
 - [NXDRIVE-1783](https://jira.nuxeo.com/browse/NXDRIVE-1783): Handle account addition with already used local folder
@@ -91,6 +92,7 @@ Release date: `2019-xx-xx`
 - Removed `FileAction.end_time`
 - Removed `FileAction.start_time`
 - Removed `FileAction.transfer_duration`
+- Added `LinuxIntegration.register_protocol_handlers()`
 - Removed `Manager.get_default_server_type()`. Use `DEFAULT_SERVER_TYPE` constant instead.
 - Added `Manager.get_server_login_type()`
 - Added `NotificationDelegator.manager`
@@ -128,6 +130,7 @@ Release date: `2019-xx-xx`
 - Added `WindowsIntegration.init()`
 - Removed `WindowsIntegration.zoom_factor`
 - Added constants.py:`DEFAULT_SERVER_TYPE`
+- Added constants.py:`NXDRIVE_SCHEME`
 - Added exceptions.py::`EngineInitError`
 - Added poll_worker.py::`SyncAndQuitWorker`
 - Added utils.py::`DEFAULTS_CERT_DETAILS`

--- a/nxdrive/constants.py
+++ b/nxdrive/constants.py
@@ -10,6 +10,9 @@ LINUX = platform == "linux"
 MAC = platform == "darwin"
 WINDOWS = platform == "win32"
 
+# Custom protocol URL (nxdrive://...)
+NXDRIVE_SCHEME = "nxdrive"
+
 BUNDLE_IDENTIFIER = "org.nuxeo.drive"
 APP_NAME = "Nuxeo Drive"
 COMPANY = "Nuxeo"

--- a/nxdrive/osi/darwin/darwin.py
+++ b/nxdrive/osi/darwin/darwin.py
@@ -27,7 +27,7 @@ from nuxeo.compat import quote
 from .extension import DarwinExtensionListener
 from .. import AbstractOSIntegration
 from ..extension import get_formatted_status
-from ...constants import APP_NAME, BUNDLE_IDENTIFIER
+from ...constants import APP_NAME, BUNDLE_IDENTIFIER, NXDRIVE_SCHEME
 from ...objects import DocPair
 from ...options import Options
 from ...translator import Translator
@@ -43,7 +43,6 @@ class DarwinIntegration(AbstractOSIntegration):
 
     nature = "macOS"
 
-    NXDRIVE_SCHEME = "nxdrive"
     NDRIVE_AGENT_TEMPLATE = (
         '<?xml version="1.0" encoding="UTF-8"?>'
         '<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"'
@@ -172,10 +171,8 @@ class DarwinIntegration(AbstractOSIntegration):
                 " was launched from the Python OSX app bundle"
             )
             return
-        LSSetDefaultHandlerForURLScheme(self.NXDRIVE_SCHEME, bundle_id)
-        log.info(
-            f"Registered bundle {bundle_id!r} for URL scheme {self.NXDRIVE_SCHEME!r}"
-        )
+        LSSetDefaultHandlerForURLScheme(NXDRIVE_SCHEME, bundle_id)
+        log.info(f"Registered bundle {bundle_id!r} for URL scheme {NXDRIVE_SCHEME!r}")
 
     @staticmethod
     def is_partition_supported(folder: Path) -> bool:

--- a/nxdrive/updater/README.md
+++ b/nxdrive/updater/README.md
@@ -144,7 +144,7 @@ Then, actions taken are OS-specific.
 
 The process is quite simple:
 
-1. Copy the `nuxeo-drive-x.y.z-x86_64.AppImage` into the `$HOME` folder;
+1. Move the new `nuxeo-drive-x.y.z-x86_64.AppImage` file next to the current running AppImage file;
 2. Restart Drive using the new executable.
 
 #### macOS

--- a/tools/linux/deploy_jenkins_slave.sh
+++ b/tools/linux/deploy_jenkins_slave.sh
@@ -33,17 +33,17 @@ create_package() {
     local app_version="$(python tools/changelog.py --drive-version)"
     local app_dir="dist/AppRun"
 
-    echo ">>> [AppImage] Adjusting file names to fit in the AppImage"
+    echo ">>> [AppImage ${app_version}] Adjusting file names to fit in the AppImage"
     # Taken from https://gitlab.com/scottywz/ezpyi/blob/master/ezpyi
     [ -d "${app_dir}" ] && rm -rfv "${app_dir}"
     mv -v "dist/ndrive" "${app_dir}"
     mv -v "${app_dir}/ndrive" "${app_dir}/AppRun"
 
-    echo ">>> [AppImage] Copying icons"
+    echo ">>> [AppImage ${app_version}] Copying icons"
     cp -v "tools/linux/app_icon.svg" "${app_dir}/.DirIcon.svg"
     cp -v "tools/linux/app_icon.svg" "${app_dir}/.icon.svg"
 
-    echo ">>> [AppImage] Copying metadata files"
+    echo ">>> [AppImage ${app_version}] Copying metadata files"
     mkdir -pv "${app_dir}/usr/share/metainfo"
     cp -v "tools/linux/${app_id}.appdata.xml" "${app_dir}/usr/share/metainfo"
     mkdir -pv "${app_dir}/usr/share/applications"
@@ -57,7 +57,7 @@ create_package() {
     chmod -v a+x "appimagetool-x86_64.AppImage"
     ./appimagetool-x86_64.AppImage --appimage-extract
 
-    echo ">>> [AppImage] Creating the AppImage file"
+    echo ">>> [AppImage ${app_version}] Creating the AppImage file"
     # --no-appstream because appstreamcli is not easily installable on CentOS
     ./squashfs-root/AppRun --no-appstream "${app_dir}" "dist/${app_name}-${app_version}-x86_64.AppImage"
 
@@ -67,7 +67,7 @@ create_package() {
     wget "https://github.com/AppImage/pkg2appimage/raw/master/excludelist"
     wget "https://github.com/AppImage/pkg2appimage/raw/master/appdir-lint.sh"
 
-    echo ">>> [AppImage] Checking the AppImage conformity"
+    echo ">>> [AppImage ${app_version}] Checking the AppImage conformity"
     bash appdir-lint.sh "${app_dir}"
     appstream-util validate-relax "${app_dir}/usr/share/metainfo/${app_id}.appdata.xml"
     echo "!!! Further checks needed, not usable on CentOS, keep it as example and regularly do it manually"


### PR DESCRIPTION
Also a small improvement regarding the previous commit (GNU/Linux support for the auto-updater):
-  NXDRIVE-1743: Move the new file next to the running AppImage instead of the `$HOME` folder