### PR TITLE
NXDRIVE-1747: Fix the SSL support on GNU/Linux

### DIFF
--- a/docs/changes/4.2.0.md
+++ b/docs/changes/4.2.0.md
@@ -8,6 +8,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1473](https://jira.nuxeo.com/browse/NXDRIVE-1473): Add GNU/Linux support to the auto-updater
 - [NXDRIVE-1491](https://jira.nuxeo.com/browse/NXDRIVE-1491): Do not use bare exceptions
 - [NXDRIVE-1783](https://jira.nuxeo.com/browse/NXDRIVE-1783): Handle account addition with already used local folder
+- [NXDRIVE-1747](https://jira.nuxeo.com/browse/NXDRIVE-1747): Fix the SSL support on GNU/Linux
 - [NXDRIVE-1784](https://jira.nuxeo.com/browse/NXDRIVE-1784): Remove unused objects and add CI/QA checks
 - [NXDRIVE-1787](https://jira.nuxeo.com/browse/NXDRIVE-1787): Ensure `Engine.newError` is passed an Engine
 - [NXDRIVE-1788](https://jira.nuxeo.com/browse/NXDRIVE-1788): Ensure `Application.action_progressing()` is passing an Action
@@ -61,6 +62,7 @@ Release date: `2019-xx-xx`
 - Packaging: Added `pywin32` 224
 - Packaging: Added `six` 1.12.0
 - Packaging: Added `tld` 0.9.3
+- Packaging: Updated `pyqt5` from 5.11.2 to 5.13.0 on GNU/Linux and Windows
 - Packaging: Removed `appdirs`
 - Packaging: Removed `pypiwin32`
 - Packaging: Updated `nuxeo` to 2.2.2

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -89,6 +89,20 @@ class Application(QApplication):
     tray_icon: DriveSystrayIcon
 
     def __init__(self, manager: "Manager", *args: Any) -> None:
+        # This 1st line is needed to fix:
+        #   QML Settings: Failed to initialize QSettings instance. Status code is: 1
+        #   QML Settings: The following application identifiers have not been set:
+        #       QVector("organizationName", "organizationDomain")
+        #
+        # This affects the locations where Qt WebEngine stores persistent and cached data
+        # (even if we do not use it though).
+        #
+        # See https://bugreports.qt.io/browse/QTBUG-71669
+        # and https://codereview.qt-project.org/c/qt/qtwebengine/+/244966
+        #
+        # The bug happened with PyQt 5.13.0 on Windows.
+        QApplication.setOrganizationName(COMPANY)
+
         super().__init__(list(*args))
         self.manager = manager
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -131,7 +131,7 @@ pycryptodomex==3.8.2 \
     --hash=sha256:fc951613c5deb7f9c9b42a8d147e7094a2ff4f9be8128511e30f551975ada870 \
     --hash=sha256:fcfb2d6ad91021bc1e4196eb293f8eca958161d5b8a0953fbbec3328a0966f74 \
     --hash=sha256:feeebb7ee5c5b2be1f3498da517226668e775d1260d52480c59d39c16dea03fa
-# Ignore pyobjc updates until NXDRIVE-1396 is done
+# [macOS] Ignore pyobjc updates until NXDRIVE-1396 is done
 pyobjc-core==4.2.2 ; sys_platform == "darwin" \
     --hash=sha256:19b98162bb42de01b05bb6c3c32e2c533085ce98799c6451177550416430188a \
     # pyup: ignore
@@ -155,7 +155,8 @@ pyobjc-framework-SystemConfiguration==4.2.2 ; sys_platform == "darwin" \
     # via pypac
 pypac==0.12.0 \
     --hash=sha256:ccba48d38f611002005ef1e92b23aeaeebe98241c03533960027e8a39c5920aa
-pyqt5-sip==4.19.13 \
+# [macOS] Ignore SIP updates until NXDRIVE-1719 is done
+pyqt5-sip==4.19.13 ; sys_platform == "darwin" \
     --hash=sha256:125f77c087572c9272219cda030a63c2f996b8507592b2a54d7ef9b75f9f054d \
     --hash=sha256:14c37b06e3fb7c2234cb208fa461ec4e62b4ba6d8b32ca3753c0b2cfd61b00e3 \
     --hash=sha256:1cb2cf52979f9085fc0eab7e0b2438eb4430d4aea8edec89762527e17317175b \
@@ -167,14 +168,25 @@ pyqt5-sip==4.19.13 \
     --hash=sha256:a4ee6026216f1fbe25c8847f9e0fbce907df5b908f84816e21af16ec7666e6fe \
     --hash=sha256:a91a308a5e0cc99de1e97afd8f09f46dd7ca20cfaa5890ef254113eebaa1adff \
     --hash=sha256:b0342540da479d2713edc68fb21f307473f68da896ad5c04215dae97630e0069 \
-    --hash=sha256:f997e21b4e26a3397cb7b255b8d1db5b9772c8e0c94b6d870a5a0ab5c27eacaa
-# Ignore PyQt5 updates until NXDRIVE-1391 is done
-pyqt5==5.11.2 \
+    --hash=sha256:f997e21b4e26a3397cb7b255b8d1db5b9772c8e0c94b6d870a5a0ab5c27eacaa \
+    # pyup: ignore
+pyqt5-sip==4.19.18 ; sys_platform != "darwin" \
+    --hash=sha256:889f2d71e7e94e370be726048a4632226846715c8b3cb0525572f857d408f7cf \
+    --hash=sha256:0a6c272ad2b6556a804a66bf808240ae0db88ab26f5ce37231da8c1d3e6910a6 \
+    --hash=sha256:a5bea998292a644525a34e1ec104090e4618f7b92f35d92310db39f8051f9ad0 \
+    --hash=sha256:7dd4d0bae586ab929e0e4f0d07008cb3b4449af48f7a4e73db4d66b806316778
+# [macOS] Ignore PyQt5 updates until NXDRIVE-1391 is done
+pyqt5==5.11.2 ; sys_platform == "darwin" \
     --hash=sha256:700b8bb0357bf0ac312bce283449de733f5773dfc77083664be188c8e964c007 \
     --hash=sha256:76d52f3627fac8bfdbc4857ce52a615cd879abd79890cde347682ff9b4b245a2 \
     --hash=sha256:7d0f7c0aed9c3ef70d5856e99f30ebcfe25a58300158dd46ee544cbe1c5b53db \
     --hash=sha256:d5dc2faf0aeacd0e8b69af1dc9f1276a64020193148356bb319bdfae22b78f88 \
     # pyup: ignore
+pyqt5==5.13.0 ; sys_platform != "darwin" \
+    --hash=sha256:aa75b829cd977ca796262fcfe0dc8fc72f8413da4e5e2795e63897e1abfd2258 \
+    --hash=sha256:70954a2d182c8634e3b5f9deeb4230f186b59ec1166f3142cb523b74876c0d98 \
+    --hash=sha256:4d51a245d64fbd85c77ba3dee12b8fe018a440ccb49fd1cb0e4587c360655d3c \
+    --hash=sha256:afbee0925439124b5c52dacaf9a6d8d4e160e36b636a6f9023832a696e15e3e9 \
 python-dateutil==2.8.0 \
     --hash=sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb \
     --hash=sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e

--- a/tools/scripts/check_update_process.py
+++ b/tools/scripts/check_update_process.py
@@ -142,7 +142,6 @@ def launch_drive(executable):
         "--update-site-url=http://localhost:8000",
         "--update-check-delay=12",
         "--channel=alpha",
-        "--ssl-no-verify",  # Needed until NXDRIVE-1747
     ]
     print(">>> Command:", cmd)
     return subprocess.check_output(cmd).decode("utf-8").strip()

--- a/tools/windows/deploy_jenkins_slave.ps1
+++ b/tools/windows/deploy_jenkins_slave.ps1
@@ -46,6 +46,9 @@ function add_missing_ddls {
 	if (Test-Path $folder) {
 		Get-ChildItem $folder | Copy -Verbose -Force -Destination "dist\ndrive"
 	}
+
+	# PyInstaller #4416
+	Copy -Verbose -Force -Destination "dist\ndrive\PyQt5\Qt\bin" "dist\ndrive\Qt5Core.dll"
 }
 
 function build($app_version, $script) {


### PR DESCRIPTION
Upgrading to PyQt 5.13 fixes the issue.
That upgrade is effective on GNU/Linux and Windows only as there are blocker issues on macOS (they will be tackled in specific tickets).

A small fix is needed on Windows until PyInstaller 3.6 comes out.