### PR TITLE
NXDRIVE-1823: Update the sync count after resuming transfers at startup

### DIFF
--- a/docs/changes/4.2.0.md
+++ b/docs/changes/4.2.0.md
@@ -24,6 +24,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1782](https://jira.nuxeo.com/browse/NXDRIVE-1782): Provide information on transfer speed
 - [NXDRIVE-1802](https://jira.nuxeo.com/browse/NXDRIVE-1802): [macOS] Automatically use light icons if the dark mode is in use
 - [NXDRIVE-1806](https://jira.nuxeo.com/browse/NXDRIVE-1806): Fix transfered files list refreshing in the systray
+- [NXDRIVE-1819](https://jira.nuxeo.com/browse/NXDRIVE-1819): Use arrows to indicate transfer type in speed metrics
 - [NXDRIVE-1821](https://jira.nuxeo.com/browse/NXDRIVE-1821): Fix update from the systray after failing update
 - [NXDRIVE-1823](https://jira.nuxeo.com/browse/NXDRIVE-1823): Update the sync count after resuming transfers at startup
 

--- a/docs/changes/4.2.0.md
+++ b/docs/changes/4.2.0.md
@@ -25,6 +25,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1802](https://jira.nuxeo.com/browse/NXDRIVE-1802): [macOS] Automatically use light icons if the dark mode is in use
 - [NXDRIVE-1806](https://jira.nuxeo.com/browse/NXDRIVE-1806): Fix transfered files list refreshing in the systray
 - [NXDRIVE-1821](https://jira.nuxeo.com/browse/NXDRIVE-1821): Fix update from the systray after failing update
+- [NXDRIVE-1823](https://jira.nuxeo.com/browse/NXDRIVE-1823): Update the sync count after resuming transfers at startup
 
 ## Packaging / Build
 

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -474,6 +474,9 @@ class Engine(QObject):
             if doc_pair:
                 self.queue_manager.push(doc_pair)
 
+        # Update the systray icon and syncing count in the systray, if there are any resumed transfers
+        self._check_sync_start()
+
     def suspend(self) -> None:
         if self._pause:
             return

--- a/nxdrive/gui/view.py
+++ b/nxdrive/gui/view.py
@@ -210,10 +210,11 @@ class TransferModel(QAbstractListModel):
 
         percent = int(min(100, progress * 100 / (size or 1)))
         speed = row.get("speed", 0)
+        txt = f"{psize(progress)} / {psize(size)} ({percent}%)"
         if speed:
-            return f"{psize(progress)} / {psize(size)} [{percent}% @ {psize(speed)}/s]"
-        else:
-            return f"{psize(progress)} / {psize(size)} [{percent}%]"
+            icon = "↓" if row["transfer_type"] == "download" else "↑"
+            txt += f" {icon} {psize(speed)}/s"
+        return txt
 
     def data(self, index: QModelIndex, role: int = NAME) -> Any:
         row = self.transfers[index.row()]
@@ -240,6 +241,7 @@ class TransferModel(QAbstractListModel):
             idx = self.createIndex(i, 0)
 
             if action["action_type"] in ("Linking", "Verification"):
+                # Disable the speed to not show the speed at the final step
                 item["speed"] = 0
             else:
                 item["speed"] = action["speed"]


### PR DESCRIPTION
And:
- NXDRIVE-1819: Use arrows to indicate transfer type in speed metrics