### PR TITLE
NXDRIVE-445: [GNU/Linux] Better desktop integration

### DIFF
--- a/docs/changes/4.2.0.md
+++ b/docs/changes/4.2.0.md
@@ -28,6 +28,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1819](https://jira.nuxeo.com/browse/NXDRIVE-1819): Use arrows to indicate transfer type in speed metrics
 - [NXDRIVE-1821](https://jira.nuxeo.com/browse/NXDRIVE-1821): Fix update from the systray after failing update
 - [NXDRIVE-1823](https://jira.nuxeo.com/browse/NXDRIVE-1823): Update the sync count after resuming transfers at startup
+- [NXDRIVE-1825](https://jira.nuxeo.com/browse/NXDRIVE-1825): Display the transfer speed at 1s interval (or more)
 
 ## Packaging / Build
 
@@ -94,6 +95,7 @@ Release date: `2019-xx-xx`
 - Added `FileAction.chunk_transfer_end_time_ns`
 - Added `FileAction.chunk_transfer_start_time_ns`
 - Added `FileAction.last_chunk_transfer_speed`
+- Added `FileAction.transferred_chunks`
 - Removed `FileAction.end_time`
 - Removed `FileAction.start_time`
 - Removed `FileAction.transfer_duration`

--- a/docs/changes/4.2.0.md
+++ b/docs/changes/4.2.0.md
@@ -17,6 +17,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1813](https://jira.nuxeo.com/browse/NXDRIVE-1813): Ignore engines that cannot be initalized
 - [NXDRIVE-1814](https://jira.nuxeo.com/browse/NXDRIVE-1814): Gracefully exit the application on CTRL+C
 - [NXDRIVE-1816](https://jira.nuxeo.com/browse/NXDRIVE-1816): Remove access to private methods
+- [NXDRIVE-1824](https://jira.nuxeo.com/browse/NXDRIVE-1824): Resuming a download fails if the temporary file was deleted
 
 ## GUI
 

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -3,7 +3,6 @@ import os
 import socket
 from contextlib import suppress
 from logging import getLogger
-from os.path import isfile
 from pathlib import Path
 from time import monotonic_ns
 from typing import Any, Callable, Dict, List, Optional, Union, TYPE_CHECKING
@@ -274,10 +273,6 @@ class Remote(Nuxeo):
 
         # Retrieve the eventual ongoing download
         download = self.dao.get_download(path=file_path)
-
-        if download and download.tmpname and not isfile(download.tmpname):
-            # Reset if the TMP file does not exist anymore
-            download = None
 
         if not download:
             # Add a new download entry in the database

--- a/nxdrive/constants.py
+++ b/nxdrive/constants.py
@@ -19,7 +19,7 @@ COMPANY = "Nuxeo"
 
 TIMEOUT = 20  # Seconds
 STARTUP_PAGE_CONNECTION_TIMEOUT = 30  # Seconds
-FILE_BUFFER_SIZE = 1024 ** 2
+FILE_BUFFER_SIZE = 1024 ** 2  # 1 MiB
 MAX_LOG_DISPLAYED = 50000  # Lines
 BATCH_SIZE = 100  # Scroll descendants batch size
 

--- a/nxdrive/engine/activity.py
+++ b/nxdrive/engine/activity.py
@@ -120,6 +120,8 @@ class FileAction(Action):
         self.chunk_transfer_end_time_ns = 0.0  # nanoseconds
         # The transfer speed of the latest (down|up)loaded chunk
         self.last_chunk_transfer_speed = 0.0
+        # Number of chunks transferred since the last speed computation
+        self.transferred_chunks = 0
 
         self._connect_reporter(reporter)
         self.started.emit(self)

--- a/nxdrive/options.py
+++ b/nxdrive/options.py
@@ -394,7 +394,7 @@ class MetaOptions(type):
             log.info(
                 f"Option {item!r} updated: {old_value!r} -> {new_value!r} [{setter}]"
             )
-            log.debug(repr(Options))
+            log.debug(str(Options))
 
             # Callback for that option
             callback = MetaOptions.callbacks.get(item)

--- a/nxdrive/osi/linux/linux.py
+++ b/nxdrive/osi/linux/linux.py
@@ -67,17 +67,18 @@ class LinuxIntegration(AbstractOSIntegration):
             f"~/.local/share/applications/{NXDRIVE_SCHEME}.desktop"
         ).expanduser()
         desktop_content = f"""[Desktop Entry]
-Name={APP_NAME} Scheme Handler
-Exec="{original_executable}" %u
-StartupNotify=false
 Type=Application
+Name={APP_NAME}
+NoDisplay=true
+StartupNotify=false
+Terminal=false
+Exec="{original_executable}" %u
 MimeType=x-scheme-handler/{NXDRIVE_SCHEME};
 """
 
         try:
-            # Create the folder if it does not exist (maybe not ideal, at all)
-            if not desktop_file.parent.is_dir():
-                desktop_file.parent.mkdir(parents=True)
+            # Create the folder if it does not exist
+            desktop_file.parent.mkdir(parents=True, exist_ok=True)
 
             # Create the .desktop file
             with open(desktop_file, "w") as f:


### PR DESCRIPTION
Also:
- Do not log `repr(Options)` but `str(Options)` when an option is modified. It will output less data.
- NXDRIVE-1824: Resuming a download fails if the temporary file was deleted.
- NXDRIVE-1825: Display the transfer speed at 1s interval (or more)
The speed was displayed at each transferred chunk. But if the connection is fast, the speed is not
readable and so useless. Instead, it is printed/refreshed when the transfer duration is more than 1 second.