### PR TITLE
NXDRIVE-1832: Fix a regression that prevents deep structure sync

### DIFF
--- a/docs/changes/4.2.0.md
+++ b/docs/changes/4.2.0.md
@@ -19,6 +19,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1814](https://jira.nuxeo.com/browse/NXDRIVE-1814): Gracefully exit the application on CTRL+C
 - [NXDRIVE-1816](https://jira.nuxeo.com/browse/NXDRIVE-1816): Remove access to private methods
 - [NXDRIVE-1824](https://jira.nuxeo.com/browse/NXDRIVE-1824): Resuming a download fails if the temporary file was deleted
+- [NXDRIVE-1832](https://jira.nuxeo.com/browse/NXDRIVE-1832): Fix a regression that prevents deep structure sync (introduced in 4.1.3 with [NXDRIVE-1636](https://jira.nuxeo.com/browse/NXDRIVE-1636))
 
 ## GUI
 

--- a/nxdrive/constants.py
+++ b/nxdrive/constants.py
@@ -21,7 +21,7 @@ TIMEOUT = 20  # Seconds
 STARTUP_PAGE_CONNECTION_TIMEOUT = 30  # Seconds
 FILE_BUFFER_SIZE = 1024 ** 2  # 1 MiB
 MAX_LOG_DISPLAYED = 50000  # Lines
-BATCH_SIZE = 100  # Scroll descendants batch size
+BATCH_SIZE = 500  # Scroll descendants batch size (max is 1,000)
 
 # Transaction timeout: it is used by the server when generating the whole file after all chunks
 # have been uploaded. Setting a high value to be able to handle very big files. Most of the


### PR DESCRIPTION
(introduced in 4.1.3 with NXDRIVE-1636)

Also several improvement:

- Higher value for remote scrolling descendant batch size: 100 -> 500.
- Removed useless timings from `RemoteWatcher._scan_remote_scroll()`.
- Better sorting of remote descendants.

(see commit contents for details)