### PR TITLE
NXDRIVE-1834: Test GNU/Linux binary on several distributions

### DIFF
--- a/docs/changes/4.2.0.md
+++ b/docs/changes/4.2.0.md
@@ -21,6 +21,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1816](https://jira.nuxeo.com/browse/NXDRIVE-1816): Remove access to private methods
 - [NXDRIVE-1824](https://jira.nuxeo.com/browse/NXDRIVE-1824): Resuming a download fails if the temporary file was deleted
 - [NXDRIVE-1832](https://jira.nuxeo.com/browse/NXDRIVE-1832): Fix a regression that prevents deep structure sync (introduced in 4.1.3 with [NXDRIVE-1636](https://jira.nuxeo.com/browse/NXDRIVE-1636))
+- [NXDRIVE-1842](https://jira.nuxeo.com/browse/NXDRIVE-1842): Skip update when no file is provided for a given version on a given OS
 
 ## GUI
 

--- a/docs/changes/4.2.0.md
+++ b/docs/changes/4.2.0.md
@@ -22,6 +22,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1824](https://jira.nuxeo.com/browse/NXDRIVE-1824): Resuming a download fails if the temporary file was deleted
 - [NXDRIVE-1832](https://jira.nuxeo.com/browse/NXDRIVE-1832): Fix a regression that prevents deep structure sync (introduced in 4.1.3 with [NXDRIVE-1636](https://jira.nuxeo.com/browse/NXDRIVE-1636))
 - [NXDRIVE-1842](https://jira.nuxeo.com/browse/NXDRIVE-1842): Skip update when no file is provided for a given version on a given OS
+- [NXDRIVE-1845](https://jira.nuxeo.com/browse/NXDRIVE-1845): Prevent a crash if the local folder does not exist anymore
 
 ## GUI
 

--- a/docs/changes/4.2.0.md
+++ b/docs/changes/4.2.0.md
@@ -35,6 +35,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1825](https://jira.nuxeo.com/browse/NXDRIVE-1825): Display the transfer speed at 1s interval (or more)
 - [NXDRIVE-1828](https://jira.nuxeo.com/browse/NXDRIVE-1828): [Windows] Report generation result line hides a line in the GUI
 - [NXDRIVE-1840](https://jira.nuxeo.com/browse/NXDRIVE-1840): Fix the progress bar animation duration
+- [NXDRIVE-1844](https://jira.nuxeo.com/browse/NXDRIVE-1844): Use light icons on Manjaro Linux
 
 ## Packaging / Build
 

--- a/docs/gnu_linux.md
+++ b/docs/gnu_linux.md
@@ -6,6 +6,14 @@ The easiest and safest way to build Nuxeo Drive is to follow the same steps as w
 
 Note that the `xclip` tool is needed for the clipboard copy/paste to work.
 
+## Binary
+
+When you downloaded an official binary (file `.AppImage`), you will have to make it executable before being able to run it:
+
+```shell
+chmod a+x *.AppImage
+```
+
 ## xattr
 
 First note that Nuxeo Drive uses [Extended file attributes](https://en.wikipedia.org/wiki/Extended_file_attributes) through the [xattr](https://pypi.python.org/pypi/xattr/) Python wrapper.

--- a/docs/gnu_linux_qa.md
+++ b/docs/gnu_linux_qa.md
@@ -4,8 +4,15 @@
 
 This is a table of minimum supported versions.
 
-| Nuxeo Drive | Arch Linux | Fedora | Ubuntu
-|---|---|---|---
-| 4.2.0+ | ? | ? | 16.04 LTS*
+| Nuxeo Drive | Debian | Ubuntu | Fedora | Manjaro
+|---|---|---|---|---
+| 4.2.0+ | 10 | 16.04 | 29 | 18.1.0
 
-*: No out-of-the-box SSL support.
+# No SSL Support on Ubuntu 16.04
+
+This is known and the root cause if the newer versions of Python and PyQt need OpenSSL 1.1 or newer.
+Ubuntu 16.04 has OpenSSL 1.0.2.
+
+## No Systray Icon on Fedora 29
+
+You will have to enable the system tray notification area.

--- a/docs/support.md
+++ b/docs/support.md
@@ -28,8 +28,10 @@ History:
 Officially supported platform vendors and versions:
 
 - GNU/Linux (most of distributions supported by AppImage), 64 bits
-  - Debian GNU/Linux >= 10
-  - Ubuntu >= 16.04
+  - Debian GNU/Linux >= 10 (not tested with < 10 but it should work too)
+  - Ubuntu >= 16.04 (and so Linux Mint and other Ubuntu based distributions)
+  - Manjaro >= 18.1.0
+  - Fedora >= 29
 - macOS >= 10.11, 64 bits
 - Windows 7, both 32 and 64 bits
 - Windows 8, both 32 and 64 bits
@@ -38,7 +40,7 @@ Officially supported platform vendors and versions:
 
 History:
 
-- `2019-xx-xx` (v4.2.0): added support for GNU/Linux
+- `2019-09-20` (v4.2.0): added support for GNU/Linux
 - `2018-06-11` (v3.1.1): dropped support for macOS 10.10
 - `2018-02-23` (v3.0.5): dropped support for macOS 10.4 - 10.9
 - `2017-04-11` (v2.4.0): dropped support for Windows Vista

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -52,6 +52,7 @@ from ..utils import (
     find_icon,
     find_resource,
     force_decode,
+    get_current_os_full,
     get_device,
     if_frozen,
     normalized_path,
@@ -1149,15 +1150,21 @@ class Application(QApplication):
             # Default value for GNU/Linux, macOS ans Windows 7
             use_light_icons = False
 
-            if WINDOWS:
+            if LINUX:
+                platform = get_current_os_full()
+                if "manjaro" in platform[0].lower():
+                    # Manjaro has a dark them by default and the notification area has the same color
+                    # as our dark icons, so use the light ones.
+                    use_light_icons = True
+            elif MAC and self.osi.dark_mode_in_use():
+                # The Dark mode on macOS is set
+                use_light_icons = True
+            elif WINDOWS:
                 win_ver = sys.getwindowsversion()
                 version = (win_ver.major, win_ver.minor)
                 if version > (6, 1):  # Windows 7
                     # Windows 8+ has a dark them by default
                     use_light_icons = True
-            elif MAC and self.osi.dark_mode_in_use():
-                # The Dark mode on macOS is set
-                use_light_icons = True
         else:
             # The value stored in DTB as a string '0' or '1', convert to boolean
             use_light_icons = bool(int(use_light_icons))

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -139,6 +139,9 @@ def find_suitable_tmp_dir(sync_folder: Path, home_folder: Path) -> Path:
     It _must_ be on the same partition of the local sync folder
     to prevent false FS events.
     """
+    sync_folder.mkdir(parents=True, exist_ok=True)
+    home_folder.mkdir(parents=True, exist_ok=True)
+
     if WINDOWS:
         # On Windows, we need to check for the drive letter
         if sync_folder.drive == home_folder.drive:

--- a/tests/functional/test_behavior.py
+++ b/tests/functional/test_behavior.py
@@ -41,6 +41,33 @@ AttributeError: 'Engine' object has no attribute '_local_watcher'
         assert manager.engines
 
 
+def test_crash_engine_no_local_folder(manager_factory):
+    """
+    Drive should not crash when the engine local folder is removed.  Traceback:
+
+Traceback (most recent call last):
+  File "nxdrive/__main__.py", line 113, in main
+  File "nxdrive/commandline.py", line 507, in handle
+  File "nxdrive/commandline.py", line 514, in get_manager
+  File "nxdrive/manager.py", line 175, in __init__
+  File "nxdrive/manager.py", line 377, in load
+  File "nxdrive/engine/engine.py", line 144, in __init__
+  File "nxdrive/utils.py", line 149, in find_suitable_tmp_dir
+  File "pathlib.py", line 1168, in stat
+FileNotFoundError: [Errno 2] No such file or directory: '/home/nuxeo/Drive/Company UAT'
+    """
+    import shutil
+
+    manager, engine = manager_factory()
+
+    shutil.rmtree(engine.local_folder)
+    assert not engine.local_folder.is_dir()
+
+    with manager:
+        # Trigger engines reload as it is done in __init__()
+        manager.load()
+
+
 @not_windows(reason="PermissionError when trying to delete the file.")
 def test_manager_engine_removal(manager_factory):
     """NXDRIVE-1618: Remove inexistant engines from the Manager engines list."""

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -194,6 +194,13 @@ def test_find_suitable_tmp_dir_same_partition(tmp):
     assert func(sync_folder, home_folder) == home_folder
 
 
+def test_find_suitable_tmp_dir_inexistant(tmp):
+    func = nxdrive.utils.find_suitable_tmp_dir
+    sync_folder = tmp()
+    home_folder = tmp()
+    assert func(sync_folder, home_folder) == home_folder
+
+
 @pytest.mark.parametrize(
     "name, state",
     [

--- a/tools/linux/deploy_jenkins_slave.sh
+++ b/tools/linux/deploy_jenkins_slave.sh
@@ -71,9 +71,7 @@ create_package() {
     cp -v "tools/linux/${app_id}.desktop" "${app_dir}/usr/share/applications"
     ln -srv "${app_dir}/usr/share/applications/${app_id}.desktop" "${app_dir}/${app_id}.desktop"
 
-    echo ">>> [AppImage ${app_version}] Adding more files to expand compatibility"
-    # Needed on Fedora 30+ (see https://github.com/slic3r/Slic3r/issues/4798)
-    cp -v /usr/lib64/libcrypt-2.17.so "${app_dir}/libcrypt.so.1"
+    more_compatibility
 
     echo ">>> [AppImage] Downloading the AppImage tool"
     [ -f "appimagetool-x86_64.AppImage" ] && rm -f "appimagetool-x86_64.AppImage"
@@ -89,6 +87,13 @@ create_package() {
     echo ">>> [AppImage] Clean-up"
     [ -f "appimagetool-x86_64.AppImage" ] && rm -f "appimagetool-x86_64.AppImage"
     [ -d "squashfs-root" ] && rm -rf "squashfs-root"
+}
+
+more_compatibility() {
+    echo ">>> [AppImage ${app_version}] Adding more files to expand compatibility"
+
+    # Needed on Fedora 30+ (see https://github.com/slic3r/Slic3r/issues/4798)
+    cp -v /usr/lib64/libcrypt-2.17.so "${app_dir}/libcrypt.so.1"
 }
 
 main "$@"


### PR DESCRIPTION
After testing from several people, we can assure this compatibilty table:

| Nuxeo Drive | Debian | Ubuntu | Fedora | Manjaro
|---|---|---|---|---
| 4.2.0+ | 10 | 16.04 | 29 | 18.1.0

And I did several fixes at the same time as they were spotted while testing:

-  NXDRIVE-1842: Skip update when no file is provided for a given version on a given OS
-  NXDRIVE-1844: Use light icons on Manjaro Linux
-  NXDRIVE-1845: Prevent a crash if the local folder does not exist anymore