### PR TITLE
NXDRIVE-1834: Expand documentation with Ubuntu 16.04 output

### DIFF
--- a/docs/gnu_linux_qa.md
+++ b/docs/gnu_linux_qa.md
@@ -10,8 +10,40 @@ This is a table of minimum supported versions.
 
 # No SSL Support on Ubuntu 16.04
 
-This is known and the root cause if the newer versions of Python and PyQt need OpenSSL 1.1 or newer.
+This is known and the root cause is that newer versions of Python and PyQt need OpenSSL 1.1+.
 Ubuntu 16.04 has OpenSSL 1.0.2.
+
+```python
+qt.network.ssl: QSslSocket: cannot resolve OPENSSL_init_ssl
+qt.network.ssl: QSslSocket: cannot resolve OPENSSL_init_crypto
+qt.network.ssl: QSslSocket: cannot resolve ASN1_STRING_get0_data
+qt.network.ssl: QSslSocket: cannot resolve EVP_CIPHER_CTX_reset
+qt.network.ssl: QSslSocket: cannot resolve RSA_bits
+qt.network.ssl: QSslSocket: cannot resolve OPENSSL_sk_new_null
+qt.network.ssl: QSslSocket: cannot resolve OPENSSL_sk_push
+qt.network.ssl: QSslSocket: cannot resolve OPENSSL_sk_free
+qt.network.ssl: QSslSocket: cannot resolve OPENSSL_sk_num
+qt.network.ssl: QSslSocket: cannot resolve OPENSSL_sk_pop_free
+qt.network.ssl: QSslSocket: cannot resolve OPENSSL_sk_value
+qt.network.ssl: QSslSocket: cannot resolve DH_get0_pqg
+qt.network.ssl: QSslSocket: cannot resolve SSL_CTX_set_options
+qt.network.ssl: QSslSocket: cannot resolve SSL_CTX_set_ciphersuites
+qt.network.ssl: QSslSocket: cannot resolve SSL_set_psk_use_session_callback
+qt.network.ssl: QSslSocket: cannot resolve SSL_get_client_random
+qt.network.ssl: QSslSocket: cannot resolve SSL_SESSION_get_master_key
+qt.network.ssl: QSslSocket: cannot resolve SSL_session_reused
+qt.network.ssl: QSslSocket: cannot resolve SSL_set_options
+qt.network.ssl: QSslSocket: cannot resolve TLS_method
+qt.network.ssl: QSslSocket: cannot resolve TLS_client_method
+qt.network.ssl: QSslSocket: cannot resolve TLS_server_method
+qt.network.ssl: QSslSocket: cannot resolve X509_up_ref
+qt.network.ssl: QSslSocket: cannot resolve X509_STORE_CTX_get0_chain
+qt.network.ssl: QSslSocket: cannot resolve X509_getm_notBefore
+qt.network.ssl: QSslSocket: cannot resolve X509_getm_notAfter
+qt.network.ssl: QSslSocket: cannot resolve X509_get_version
+qt.network.ssl: QSslSocket: cannot resolve OpenSSL_version_num
+qt.network.ssl: QSslSocket: cannot resolve OpenS
+```
 
 ## No Systray Icon on Fedora 29
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,7 @@ def no_warnings(recwarn):
             continue
         elif "WaitForInputIdle" in message:
             # Happen while testing the integration on Windows, we can skip it:
-            # "Application is not loaded correctly (WaitForInputIdle failed)""
+            # "Application is not loaded correctly (WaitForInputIdle failed)"
             continue
 
         warn = f"{warning.filename}:{warning.lineno} {message}"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -198,6 +198,7 @@ def test_find_suitable_tmp_dir_inexistant(tmp):
     func = nxdrive.utils.find_suitable_tmp_dir
     sync_folder = tmp()
     home_folder = tmp()
+    home_folder.mkdir(parents=True)
     assert func(sync_folder, home_folder) == home_folder
 
 


### PR DESCRIPTION
- NXDRIVE-1842: Fix mypy
- NXDRIVE-1845: Better fix. 
  Creating the folder inside `find_suitable_tmp_dir()` was not a good idea. It would shadow the `rootDeleted()` event.