### PR TITLE
NXDRIVE-1845: Fix PermissionError on Windows tests

### DIFF
--- a/tests/functional/test_behavior.py
+++ b/tests/functional/test_behavior.py
@@ -60,6 +60,7 @@ FileNotFoundError: [Errno 2] No such file or directory: '/home/nuxeo/Drive/Compa
 
     manager, engine = manager_factory()
 
+    engine.local.unset_readonly(engine.local_folder)
     shutil.rmtree(engine.local_folder)
     assert not engine.local_folder.is_dir()
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -560,6 +560,7 @@ def test_compute_urls(url):
     "url, result",
     [
         ("localhost", "http://localhost:8080/nuxeo"),
+        ("127.0.0.1", "http://127.0.0.1:8080/nuxeo"),
         # HTTPS domain
         (
             "intranet-prerod.nuxeocloud.com",
@@ -570,15 +571,24 @@ def test_compute_urls(url):
             "http://localhost:8080/nuxeo?TenantId=0xdeadbeaf",
             "http://localhost:8080/nuxeo?TenantId=0xdeadbeaf",
         ),
+        (
+            "http://127.0.0.1:8080/nuxeo?TenantId=0xdeadbeaf",
+            "http://127.0.0.1:8080/nuxeo?TenantId=0xdeadbeaf",
+        ),
         # Incomplete URL
         ("http://localhost", "http://localhost:8080/nuxeo"),
+        ("http://127.0.0.1", "http://127.0.0.1:8080/nuxeo"),
         # Bad IP
         ("1.2.3.4", ""),
         # Bad protocol
         ("htto://localhost:8080/nuxeo", "http://localhost:8080/nuxeo"),
+        ("htto://127.0.0.1:8080/nuxeo", "http://127.0.0.1:8080/nuxeo"),
     ],
 )
-def test_guess_server_url(url, result):
+def test_guess_server_url(nuxeo_url, url, result):
+    if "127.0.0.1" not in nuxeo_url and "localhost" not in nuxeo_url:
+        pytest.skip("Testing a non local server would fail")
+
     func = nxdrive.utils.guess_server_url
     if "intranet" in url:
         # The intranet is not stable enough to rely on it.


### PR DESCRIPTION
And:
- NXDRIVE-1686: Skip tests when the local sever is not local
  This is to prevent false failures on a VM where the server is not local.