### PR TITLE
NXDRIVE-1803: Prevent unexpected downgrades

### DIFF
--- a/nxdrive/updater/base.py
+++ b/nxdrive/updater/base.py
@@ -221,16 +221,20 @@ class BaseUpdater(PollWorker):
                 self.server_ver,
                 login_type,
             )
+            log.debug(f"Guessed status {status!r} and version {version!r}.")
 
+        # Check the digest is available for that version on that OS
         if version:
             info = self.versions.get(version, {})
             checksums = info.get("checksum", {})
             checksum = checksums.get(self.ext, "").lower()
             if not checksum:
                 log.info(
-                    f"There is no downloadable file for the version ${version!r} on that OS."
+                    f"There is no downloadable file for the version {version!r} on that OS."
                 )
-        elif status and version:
+                return
+
+        if status and version:
             self._set_status(status, version=version)
         elif status:
             self.status = status

--- a/nxdrive/updater/utils.py
+++ b/nxdrive/updater/utils.py
@@ -165,7 +165,7 @@ def get_update_status(
     if current_version in versions.keys():
         # For the Centralized channel, this is not an issue as administrators must
         # have checked that the desired version is working fine whatever the channel
-        if original_channel == "centralized":
+        if original_channel == "centralized" and Options.client_version:
             return UPDATE_STATUS_UPDATE_AVAILABLE, latest
         else:
             return UPDATE_STATUS_WRONG_CHANNEL, latest


### PR DESCRIPTION
When using the centralized channel and the desired version is not set and the current version is from another channel than the release one, a downgrade is done. This should rather display a popup asking the user to either downgrade on the release channel or continue using the channel from the current version.