### PR TITLE
NXDRIVE-1830: Rotating logs check-up

### DIFF
--- a/docs/changes/4.2.0.md
+++ b/docs/changes/4.2.0.md
@@ -20,6 +20,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1814](https://jira.nuxeo.com/browse/NXDRIVE-1814): Gracefully exit the application on CTRL+C
 - [NXDRIVE-1816](https://jira.nuxeo.com/browse/NXDRIVE-1816): Remove access to private methods
 - [NXDRIVE-1824](https://jira.nuxeo.com/browse/NXDRIVE-1824): Resuming a download fails if the temporary file was deleted
+- [NXDRIVE-1830](https://jira.nuxeo.com/browse/NXDRIVE-1830): Rotating logs check-up
 - [NXDRIVE-1832](https://jira.nuxeo.com/browse/NXDRIVE-1832): Fix a regression that prevents deep structure sync (introduced in 4.1.3 with [NXDRIVE-1636](https://jira.nuxeo.com/browse/NXDRIVE-1636))
 - [NXDRIVE-1842](https://jira.nuxeo.com/browse/NXDRIVE-1842): Skip update when no file is provided for a given version on a given OS
 - [NXDRIVE-1845](https://jira.nuxeo.com/browse/NXDRIVE-1845): Prevent a crash if the local folder does not exist anymore


### PR DESCRIPTION
* Compress old rotated log files at startup.
  This should fix the issue when several rotated (old) files were not compressed.

* Remove old compressed log files at startup.