### PR TITLE
NXDRIVE-1396: [macOS] Upgrade PyObjC to 5.2

### DIFF
--- a/docs/changes/4.2.1.md
+++ b/docs/changes/4.2.1.md
@@ -16,7 +16,7 @@ Release date: `2019-xx-xx`
 
 ## Packaging / Build
 
-- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
+- [NXDRIVE-1396](https://jira.nuxeo.com/browse/NXDRIVE-1396): [macOS] Upgrade PyObjC to 5.2
 
 ## Tests
 

--- a/nxdrive/client/local_client.py
+++ b/nxdrive/client/local_client.py
@@ -16,8 +16,9 @@ from time import mktime, strptime
 from typing import Any, List, Optional, Tuple, Union
 
 from nuxeo.utils import get_digest_algorithm
-from send2trash import send2trash
-from send2trash.exceptions import TrashPermissionError
+
+# from send2trash import send2trash
+# from send2trash.exceptions import TrashPermissionError
 
 from ..constants import LINUX, MAC, ROOT, WINDOWS
 from ..exceptions import DuplicationDisabledError, NotFound, UnknownDigest
@@ -568,12 +569,14 @@ FolderType=Generic
         log.debug(f"Trashing {os_path!r}")
         locker = self.unlock_ref(os_path, is_abs=True)
         try:
-            send2trash(str(os_path))
-        except TrashPermissionError:
-            log.warning(
-                f"Trash not possible, deleting permanently {os_path!r}", exc_info=True
-            )
-            self.delete_final(ref)
+            # send2trash(str(os_path))
+            # TODO: NXDRIVE-1868
+            pass
+        # except TrashPermissionError:
+        #    log.warning(
+        #        f"Trash not possible, deleting permanently {os_path!r}", exc_info=True
+        #    )
+        #    self.delete_final(ref)
         except OSError as exc:
             log.warning(f"Cannot trash {os_path!r}")
             with suppress(Exception):

--- a/nxdrive/engine/tracker.py
+++ b/nxdrive/engine/tracker.py
@@ -73,7 +73,7 @@ class Tracker(Worker):
             )
             l10n = locale.windows_locale[l10n_code]
         elif MAC:
-            from Foundation import NSLocale
+            from CoreServices import NSLocale
 
             l10n_code = NSLocale.currentLocale()
             l10n = NSLocale.localeIdentifier(l10n_code)

--- a/nxdrive/osi/darwin/darwin.py
+++ b/nxdrive/osi/darwin/darwin.py
@@ -10,8 +10,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import xattr
-from Foundation import NSBundle, NSDistributedNotificationCenter, NSUserDefaults
-from LaunchServices import (
+from CoreServices import (
     CFURLCreateWithString,
     LSSetDefaultHandlerForURLScheme,
     LSSharedFileListCopySnapshot,
@@ -19,6 +18,9 @@ from LaunchServices import (
     LSSharedFileListInsertItemURL,
     LSSharedFileListItemCopyDisplayName,
     LSSharedFileListItemRemove,
+    NSBundle,
+    NSDistributedNotificationCenter,
+    NSUserDefaults,
     kLSSharedFileListFavoriteItems,
     kLSSharedFileListItemBeforeFirst,
 )

--- a/nxdrive/osi/darwin/pyNotificationCenter.py
+++ b/nxdrive/osi/darwin/pyNotificationCenter.py
@@ -2,7 +2,7 @@
 """ Python integration macOS notification center. """
 from typing import Dict, TYPE_CHECKING
 
-from Foundation import (
+from CoreServices import (
     NSBundle,
     NSMutableDictionary,
     NSObject,

--- a/requirements.txt
+++ b/requirements.txt
@@ -130,27 +130,20 @@ pycryptodomex==3.9.0 \
     --hash=sha256:e530b77bdff5c2bf3065e6a088e1602ad193b43e285bac196d4b8820308ec6bb \
     --hash=sha256:f048069aa7b530f1c5e84d55c2b28ca7a7272bb3b8d28829d454a94bec6529a8 \
     --hash=sha256:f6a9271c842e93c349b6007676a62d03dca712c9f4dff66c3270d50504ca9014
-# [macOS] Ignore pyobjc updates until NXDRIVE-1396 is done
-pyobjc-core==4.2.2 ; sys_platform == "darwin" \
-    --hash=sha256:19b98162bb42de01b05bb6c3c32e2c533085ce98799c6451177550416430188a \
-    # pyup: ignore
+pyobjc-core==5.2 ; sys_platform == "darwin" \
+    --hash=sha256:046449f510c1f33d41bdd0d4c8eb2f084593a2ee4573a25d604bdccabb7a909e \
     # via pyobjc-framework-Cocoa
-pyobjc-framework-Cocoa==4.2.2 ; sys_platform == "darwin" \
-    --hash=sha256:d97fd162a60e4dc8384b4fe2cc4916039f3a8b6c8545d9df0ad35c580c1424ea \
-    # pyup: ignore
-pyobjc-framework-FSEvents==4.2.2 ; sys_platform == "darwin" \
-    --hash=sha256:039649dd48dd298fe4437c5dbbc3429a40c87421edb42be89e66181b811f0447 \
-    # pyup: ignore
+pyobjc-framework-Cocoa==5.2 ; sys_platform == "darwin" \
+    --hash=sha256:d72d48cf2e24c2f540a1b1348a880fde87b1f8cb7e1be5e95550a306152d48d0
+pyobjc-framework-CoreServices==5.2 ; sys_platform == "darwin" \
+    --hash=sha256:6faa326afa2a77bdd8ea182d4ae5d5095089d8ec9e1605ce3c82546fe396f986
+pyobjc-framework-FSEvents==5.2 ; sys_platform == "darwin" \
+    --hash=sha256:bf4cf7c8ee0b3f5d5f3842a0c4b1a4148398fd4aac0f6ca5ce967477e289af1b \
     # via watchdog
-pyobjc-framework-LaunchServices==4.2.2 ; sys_platform == "darwin" \
-    --hash=sha256:b5d2288155e8a952d46740f448a92f621953190b88a356ff49c963f20eaee5f1 \
-    # pyup: ignore
-pyobjc-framework-ScriptingBridge==4.2.2 ; sys_platform == "darwin" \
-    --hash=sha256:f6b5a001452dde16affafa47468e3081863c8847b591cb3ca47fbf69318fa590 \
-    # pyup: ignore
-pyobjc-framework-SystemConfiguration==4.2.2 ; sys_platform == "darwin" \
-    --hash=sha256:78ec4adba535b65125328153a82704d734fd070c7a0c4de533367380a0e2ea9d \
-    # pyup: ignore
+pyobjc-framework-ScriptingBridge==5.2 ; sys_platform == "darwin" \
+    --hash=sha256:74c01c439b5ca1a2b9811010d27dda4f4b1e2e76bbf9b9e8a0f5ebaa69d999fe
+pyobjc-framework-SystemConfiguration==5.2 ; sys_platform == "darwin" \
+    --hash=sha256:b301db045b58df0a5052aacaa26e1eed9e19e8f5cd011991937982dc6dcc9f79 \
     # via pypac
 pypac==0.13.0 \
     --hash=sha256:a1eac0e3224939fcc691c8ad815f9cd24d737c8e0cf9c9905a01821bbe8f1414

--- a/tools/osx/deploy_jenkins_slave.sh
+++ b/tools/osx/deploy_jenkins_slave.sh
@@ -71,11 +71,6 @@ create_package() {
     echo ">>> [package] Creating the DMG file"
     rm -fv ${output_dir}/*.dmg
 
-    # Fix an issue with send2trash (NXDRIVE-1294)
-    pushd "${pkg_path}/Contents/MacOS"
-    ln -sv Foundation/_Foundation.*.so Foundation.dylib
-    popd
-
     prepare_signing
     if [ "${SIGNING_ID:=unset}" != "unset" ]; then
         echo ">>> [sign] Signing the app and its extension"


### PR DESCRIPTION
Send2Trash has been commented out and will be vendored with NXDRIVE-1868.