### PR TITLE
NXDRIVE-947: Duplicates are created when the parent is renamed while …

### DIFF
--- a/docs/changes/4.2.1.md
+++ b/docs/changes/4.2.1.md
@@ -22,7 +22,7 @@ Release date: `2019-xx-xx`
 
 ## Tests
 
-- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
+- [NXDRIVE-947](https://jira.nuxeo.com/browse/NXDRIVE-947): Duplicates are created when the parent is renamed while syncing up
 
 ## Doc
 

--- a/tests/old_functional/test_local_move_folders.py
+++ b/tests/old_functional/test_local_move_folders.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 import shutil
 from pathlib import Path
+from time import sleep
 
 from .common import OneUserTest
 from .. import ensure_no_exception
@@ -8,54 +9,56 @@ from ..utils import random_png
 
 
 class TestLocalMoveFolders(OneUserTest):
-
-    NUMBER_OF_LOCAL_IMAGE_FILES = 10
-
-    def _setup(self):
+    def _setup(self, count: int = 10, wait_for_sync: bool = True):
         """
-        1. Create folder a1 in Nuxeo Drive Test Workspace sycn root
-        2. Create folder a2 in Nuxeo Drive Test Workspace sycn root
-        3. Add 10 image files in a1
-        4. Add 10 image files in a2
+        1. Create folder a1 at the root
+        2. Create folder a2 at the root
+        3. Add *count* pictures in a1
+        4. Add *count* pictures in a2
         """
         self.engine_1.start()
         self.wait_sync(wait_for_async=True)
         self.engine_1.stop()
+
         local = self.local_1
         remote = self.remote_1
+
         # Create a1 and a2
         self.folder_path_1 = local.make_folder("/", "a1")
         self.folder_path_2 = local.make_folder("/", "a2")
 
-        num = self.NUMBER_OF_LOCAL_IMAGE_FILES
-        names = set(["file%03d.png" % file_num for file_num in range(1, num + 1)])
+        names = set([f"file{n + 1:03d}.png" for n in range(count)])
 
-        for path in {self.folder_path_1, self.folder_path_2}:
+        for path in (self.folder_path_1, self.folder_path_2):
             for name in names:
                 file_path = local.abspath(path) / name
                 random_png(file_path)
 
         self.engine_1.start()
-        self.wait_sync(timeout=30, wait_win=True)
+
+        if wait_for_sync:
+            self.wait_sync(timeout=30, wait_win=True)
 
         # Check /a1 and /a2
-        for folder in {"/a1", "/a2"}:
+        for folder in ("/a1", "/a2"):
             # Check local files
             assert local.exists(folder)
             children = [child.name for child in local.get_children_info(folder)]
-            assert len(children) == num
+            assert len(children) == count
             assert set(children) == names
 
-            # Check remote files
-            uid = local.get_remote_id(folder)
-            assert uid
-            assert remote.fs_exists(uid)
-            children = [child.name for child in remote.get_fs_children(uid)]
-            assert len(children) == num
-            assert set(children) == names
+            if wait_for_sync:
+                # Check remote files
+                uid = local.get_remote_id(folder)
+                assert uid
+                assert remote.fs_exists(uid)
+                children = [child.name for child in remote.get_fs_children(uid)]
+                assert len(children) == count
+                assert set(children) == names
 
     def test_local_move_folder_with_files(self):
-        self._setup()
+        count = 10
+        self._setup(count=count)
         local = self.local_1
         remote = self.remote_1
         remote_doc = self.remote_document_client_1
@@ -63,22 +66,21 @@ class TestLocalMoveFolders(OneUserTest):
         dst = local.abspath(self.folder_path_2)
         shutil.move(src, dst)
         self.wait_sync()
-        num = self.NUMBER_OF_LOCAL_IMAGE_FILES
-        names = set(["file%03d.png" % file_num for file_num in range(1, num + 1)])
+        names = set([f"file{n + 1:03d}.png" for n in range(count)])
 
         # Check that a1 doesn't exist anymore locally and remotely
         assert not local.exists("/a1")
         assert len(remote_doc.get_children_info(self.workspace)) == 1
 
         # Check /a2 and /a2/a1
-        for folder in {"/a2", "/a2/a1"}:
+        for folder in ("/a2", "/a2/a1"):
             assert local.exists(folder)
             children = [
                 child.name
                 for child in local.get_children_info(folder)
                 if not child.folderish
             ]
-            assert len(children) == num
+            assert len(children) == count
             assert set(children) == names
 
             uid = local.get_remote_id(folder)
@@ -89,7 +91,7 @@ class TestLocalMoveFolders(OneUserTest):
                 for child in remote.get_fs_children(uid)
                 if not child.folderish
             ]
-            assert len(children) == num
+            assert len(children) == count
             assert set(children) == names
 
     def test_local_move_folder_both_sides_while_stopped(self):
@@ -206,3 +208,71 @@ class TestLocalMoveFolders(OneUserTest):
             self.wait_sync()
 
         assert not local.exists("/")
+
+    def test_move_parent_while_syncing_a_lot_of_files(self):
+        """NXDRIVE-947: Duplicates are created when the parent is renamed while syncing up.
+
+        Steps:
+            - Create a new folder and named as temp8 in Nuxeo Drive to sync up
+            - Copy 1,000 files in the folder in Nuxeo Drive to sync up
+            - While syncing up, rename the folder temp8 to temp9
+        """
+        sync_count = self.engine_1.dao.get_sync_count
+        local = self.local_1
+        remote = self.remote_1
+        remote_doc = self.remote_document_client_1
+
+        count = 1000
+        self._setup(count=count, wait_for_sync=False)  # 2,000 files
+
+        # Wait for 1,000+ files to be synced before doing anything
+        while sync_count() <= 1000:
+            sleep(1)
+
+        # Rename a1 to "a1 moved"
+        src = local.abspath(self.folder_path_1)
+        dst = src.with_name(f"{src.name} moved")
+        shutil.move(src, dst)
+
+        # Rename a2 to "a2 moved"
+        src = local.abspath(self.folder_path_2)
+        dst = src.with_name(f"{src.name} moved")
+        shutil.move(src, dst)
+
+        # Wait for the sync to finish
+        self.wait_sync(timeout=100, wait_win=True)
+
+        # Expected files
+        names = set([f"file{n + 1:03d}.png" for n in range(count)])
+
+        # Check that a* doesn't exist anymore locally and remotely
+        assert not local.exists("/a1")
+        assert not local.exists("/a2")
+        children = remote_doc.get_children_info(self.workspace)
+        assert len(children) == 2
+        for child in children:
+            assert child.name in ("a1 moved", "a2 moved")
+
+        # Check "a* moved" content
+        for folder in ("/a1 moved", "/a2 moved"):
+            # Local checks
+            assert local.exists(folder)
+            children = [
+                child.name
+                for child in local.get_children_info(folder)
+                if not child.folderish
+            ]
+            assert len(children) == count
+            assert set(children) == names
+
+            # Remote checks
+            uid = local.get_remote_id(folder)
+            assert uid
+            assert remote.fs_exists(uid)
+            children = [
+                child.name
+                for child in remote.get_fs_children(uid)
+                if not child.folderish
+            ]
+            assert len(children) == count
+            assert set(children) == names


### PR DESCRIPTION
…syncing up

The scenario is no more reproductible, thanks to older fixes.
I just added a regression test.