### PR TITLE
NXDRIVE-1839: The GUI should be responsive when syncing a lot of files

### DIFF
--- a/docs/changes/4.2.1.md
+++ b/docs/changes/4.2.1.md
@@ -11,6 +11,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1860](https://jira.nuxeo.com/browse/NXDRIVE-1860): Skip any `OSError` when trying to compress log files
 - [NXDRIVE-1867](https://jira.nuxeo.com/browse/NXDRIVE-1867): Fix mypy issues following the update to mypy 0.730
 - [NXDRIVE-1868](https://jira.nuxeo.com/browse/NXDRIVE-1868): [macOS] Use a custom trash implementation instead of using Send2Trash
+- [NXDRIVE-1875](https://jira.nuxeo.com/browse/NXDRIVE-1875): Use more processors by default (5 -> 10)
 
 ## GUI
 

--- a/docs/changes/4.2.1.md
+++ b/docs/changes/4.2.1.md
@@ -12,6 +12,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1867](https://jira.nuxeo.com/browse/NXDRIVE-1867): Fix mypy issues following the update to mypy 0.730
 - [NXDRIVE-1868](https://jira.nuxeo.com/browse/NXDRIVE-1868): [macOS] Use a custom trash implementation instead of using Send2Trash
 - [NXDRIVE-1875](https://jira.nuxeo.com/browse/NXDRIVE-1875): Use more processors by default (5 -> 10)
+- [NXDRIVE-1876](https://jira.nuxeo.com/browse/NXDRIVE-1876): Fix threads not totally released
 
 ## GUI
 

--- a/docs/changes/4.2.1.md
+++ b/docs/changes/4.2.1.md
@@ -16,7 +16,7 @@ Release date: `2019-xx-xx`
 
 ## GUI
 
-- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
+- [NXDRIVE-1839](https://jira.nuxeo.com/browse/NXDRIVE-1839): The GUI is not responsive when syncing a lot of files
 
 ## Packaging / Build
 
@@ -46,10 +46,18 @@ Release date: `2019-xx-xx`
 ## Technical Changes
 
 - Added `Application.ctx_upload_local_file()`
+- Added `Application.force_refresh_files()`
 - Added `Application.show_server_folders()`
 - Added `CliHandler.ctx_direct_upload()`
+- Changed `EngineDAO.get_download()` to return a generator instead of a list
+- Changed `EngineDAO.get_upload()` to return a generator instead of a list
 - Added `local_state` keyword argument to `EngineDAO.insert_local_state()`, defaults to `created` to not change the behavior.
+- Renamed `FileModel.addFiles()` to `add_files()`
+- Removed `FileModel.empty()`
+- Removed `FileModel.insertRows()`
+- Removed `FileModel.removeRows()`
 - Added `check` keyword argument to `LocalClient.get_info()`, defaults to `True` to not change the behavior.
+- Added `Remote.check_integrity_simple()`
 - Added `Remote.direct_upload()`
 - Added client/local/base.py
 - Added client/local/darwin.py

--- a/nxdrive/__main__.py
+++ b/nxdrive/__main__.py
@@ -122,4 +122,4 @@ def main() -> int:
     return ret
 
 
-sys.exit((main()))
+sys.exit(main())

--- a/nxdrive/engine/dao/sqlite.py
+++ b/nxdrive/engine/dao/sqlite.py
@@ -18,7 +18,17 @@ from datetime import datetime
 from logging import getLogger
 from pathlib import Path
 from threading import RLock, local
-from typing import Any, Dict, List, Optional, Tuple, Type, Union, TYPE_CHECKING
+from typing import (
+    Any,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    TYPE_CHECKING,
+)
 
 from PyQt5.QtCore import QObject, pyqtSignal
 
@@ -1949,11 +1959,11 @@ class EngineDAO(ConfigurationDAO):
             self._filters = self.get_filters()
             self.get_syncing_count()
 
-    def get_downloads(self) -> List[Download]:
+    def get_downloads(self) -> Generator[Download, None, None]:
         con = self._get_read_connection()
         c = con.cursor()
-        return [
-            Download(
+        for res in c.execute("SELECT * FROM Downloads"):
+            yield Download(
                 res.uid,
                 Path(res.path),
                 TransferStatus(res.status),
@@ -1965,14 +1975,12 @@ class EngineDAO(ConfigurationDAO):
                 tmpname=res.tmpname,
                 url=res.url,
             )
-            for res in c.execute("SELECT * FROM Downloads").fetchall()
-        ]
 
-    def get_uploads(self) -> List[Upload]:
+    def get_uploads(self) -> Generator[Upload, None, None]:
         con = self._get_read_connection()
         c = con.cursor()
-        return [
-            Upload(
+        for res in c.execute("SELECT * FROM Uploads"):
+            yield Upload(
                 res.uid,
                 Path(res.path),
                 TransferStatus(res.status),
@@ -1984,8 +1992,6 @@ class EngineDAO(ConfigurationDAO):
                 idx=res.idx,
                 chunk_size=res.chunk_size,
             )
-            for res in c.execute("SELECT * FROM Uploads").fetchall()
-        ]
 
     def get_downloads_with_status(self, status: TransferStatus) -> List[Download]:
         return [d for d in self.get_downloads() if d.status == status]

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -714,11 +714,10 @@ class Engine(QObject):
 
     def _thread_finished(self) -> None:
         for thread in self._threads:
-            if thread == self._local_watcher.thread:
-                continue
-            if thread == self._remote_watcher.thread:
+            if thread in (self._local_watcher.thread, self._remote_watcher.thread):
                 continue
             if thread.isFinished():
+                thread.quit()
                 self._threads.remove(thread)
 
     def is_started(self) -> bool:

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -107,7 +107,7 @@ class Engine(QObject):
         manager: "Manager",
         definition: EngineDef,
         binder: Binder = None,
-        processors: int = 5,
+        processors: int = 10,
         remote_cls: Type[Remote] = Remote,
         local_cls: Type[LocalClientMixin] = LocalClient,
     ) -> None:

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -1008,7 +1008,8 @@ class Processor(EngineWorker):
         if pair:
             locker = unlock_path(file_out)
             try:
-                shutil.copy(self.local.abspath(pair.local_path), file_out)
+                # copyfile() is used to prevent metadata copy
+                shutil.copyfile(self.local.abspath(pair.local_path), file_out)
             except FileNotFoundError:
                 # Let's re-download the file
                 pass

--- a/nxdrive/engine/queue_manager.py
+++ b/nxdrive/engine/queue_manager.py
@@ -340,6 +340,7 @@ class QueueManager(QObject):
         with self._thread_inspection:
             for thread in self._processors_pool:
                 if thread.isFinished():
+                    thread.quit()
                     self._processors_pool.remove(thread)
             if (
                 self._local_folder_thread is not None

--- a/nxdrive/engine/watcher/local_watcher.py
+++ b/nxdrive/engine/watcher/local_watcher.py
@@ -56,7 +56,7 @@ class LocalWatcher(EngineWorker):
     fileAlreadyExists = pyqtSignal(Path, Path)
 
     def __init__(self, engine: "Engine", dao: "EngineDAO") -> None:
-        super().__init__(engine, dao)
+        super().__init__(engine, dao, name="LocalWatcher")
         self.lock = Lock()
         self._event_handler: Optional[DriveFSEventHandler] = None
         # Delay for the scheduled recursive scans of

--- a/nxdrive/engine/watcher/remote_watcher.py
+++ b/nxdrive/engine/watcher/remote_watcher.py
@@ -36,7 +36,7 @@ class RemoteWatcher(EngineWorker):
     remoteWatcherStopped = pyqtSignal()
 
     def __init__(self, engine: "Engine", dao: "EngineDAO", delay: int) -> None:
-        super().__init__(engine, dao)
+        super().__init__(engine, dao, name="RemoteWatcher")
         self.server_interval = delay
 
         self.empty_polls = 0

--- a/nxdrive/gui/api.py
+++ b/nxdrive/gui/api.py
@@ -184,13 +184,19 @@ class QMLDriveApi(QObject):
     @pyqtSlot(result=list)
     def get_transfers(self) -> List[Dict[str, Any]]:
         result: List[Dict[str, Any]] = []
+        limit = 5  # 10 files are displayed in the systray, so take 5 of each kind
 
         for engine in self._manager.engines.values():
             dao = engine.dao
-            for download in dao.get_downloads():
+            for count, download in enumerate(dao.get_downloads()):
+                if count >= limit:
+                    break
                 result.append(asdict(download))
-            for upload in dao.get_uploads():
+            for count, upload in enumerate(dao.get_uploads()):
+                if count >= limit:
+                    break
                 result.append(asdict(upload))
+
         return result
 
     @pyqtSlot(str, str, int, float)

--- a/tests/old_functional/test_transfer.py
+++ b/tests/old_functional/test_transfer.py
@@ -41,7 +41,7 @@ class TestDownload(OneUserTest):
                     - raise DownloadPaused(download.uid)
             """
             # Ensure we have 1 ongoing download
-            downloads = dao.get_downloads()
+            downloads = list(dao.get_downloads())
             assert downloads
             download = downloads[0]
             assert download.status == TransferStatus.ONGOING
@@ -75,7 +75,7 @@ class TestDownload(OneUserTest):
         ).uid.split("#")[-1]
 
         # There is no download, right now
-        assert not dao.get_downloads()
+        assert not list(dao.get_downloads())
 
         with patch.object(engine.remote, "download_callback", new=callback):
             with ensure_no_exception():
@@ -83,9 +83,9 @@ class TestDownload(OneUserTest):
             assert dao.get_downloads_with_status(TransferStatus.PAUSED)
 
         # Resume the download
-        engine.resume_transfer("download", dao.get_downloads()[0].uid)
+        engine.resume_transfer("download", list(dao.get_downloads())[0].uid)
         self.wait_sync(wait_for_async=True)
-        assert not dao.get_downloads()
+        assert not list(dao.get_downloads())
 
     def test_pause_download_automatically(self):
         """
@@ -96,7 +96,7 @@ class TestDownload(OneUserTest):
         def callback(*_, **__):
             """This will mimic what is done in SystrayMenu.qml: suspend the app."""
             # Ensure we have 1 ongoing download
-            downloads = dao.get_downloads()
+            downloads = list(dao.get_downloads())
             assert downloads
             download = downloads[0]
             assert download.status == TransferStatus.ONGOING
@@ -120,7 +120,7 @@ class TestDownload(OneUserTest):
         )
 
         # There is no download, right now
-        assert not dao.get_downloads()
+        assert not list(dao.get_downloads())
 
         with patch.object(engine.remote, "download_callback", new=callback):
             with ensure_no_exception():
@@ -130,7 +130,7 @@ class TestDownload(OneUserTest):
         # Resume the download
         self.manager_1.resume()
         self.wait_sync(wait_for_async=True)
-        assert not dao.get_downloads()
+        assert not list(dao.get_downloads())
 
     def test_modifying_paused_download(self):
         """Modifying a paused download should discard the current download."""
@@ -142,7 +142,7 @@ class TestDownload(OneUserTest):
 
             if count == 1:
                 # Ensure we have 1 ongoing download
-                downloads = dao.get_downloads()
+                downloads = list(dao.get_downloads())
                 assert downloads
                 download = downloads[0]
                 assert download.status == TransferStatus.ONGOING
@@ -171,7 +171,7 @@ class TestDownload(OneUserTest):
         )
 
         # There is no download, right now
-        assert not dao.get_downloads()
+        assert not list(dao.get_downloads())
 
         with patch.object(engine.remote, "download_callback", new=callback):
             with ensure_no_exception():
@@ -179,7 +179,7 @@ class TestDownload(OneUserTest):
 
         # Resync and check the local content is correct
         self.wait_sync(wait_for_async=True)
-        assert not dao.get_downloads()
+        assert not list(dao.get_downloads())
         assert self.local_1.get_content("/test.bin") == b"remotely changed"
 
     def test_deleting_paused_download(self):
@@ -188,7 +188,7 @@ class TestDownload(OneUserTest):
         def callback(*_, **__):
             """Pause the download and delete the document."""
             # Ensure we have 1 ongoing download
-            downloads = dao.get_downloads()
+            downloads = list(dao.get_downloads())
             assert downloads
             download = downloads[0]
             assert download.status == TransferStatus.ONGOING
@@ -216,7 +216,7 @@ class TestDownload(OneUserTest):
         )
 
         # There is no download, right now
-        assert not dao.get_downloads()
+        assert not list(dao.get_downloads())
 
         with patch.object(engine.remote, "download_callback", new=callback):
             with ensure_no_exception():
@@ -224,7 +224,7 @@ class TestDownload(OneUserTest):
 
         # Resync and check the file does not exist
         self.wait_sync(wait_for_async=True)
-        assert not dao.get_downloads()
+        assert not list(dao.get_downloads())
         assert not self.local_1.exists("/test.bin")
 
 
@@ -257,7 +257,7 @@ class TestUpload(OneUserTest):
             Then the upload will be paused in Remote.upload().
             """
             # Ensure we have 1 ongoing upload
-            uploads = dao.get_uploads()
+            uploads = list(dao.get_uploads())
             assert uploads
             upload = uploads[0]
             assert upload.status == TransferStatus.ONGOING
@@ -272,7 +272,7 @@ class TestUpload(OneUserTest):
         self.local_1.make_file("/", "test.bin", content=b"0" * FILE_BUFFER_SIZE * 2)
 
         # There is no upload, right now
-        assert not dao.get_uploads()
+        assert not list(dao.get_uploads())
 
         with patch.object(engine.remote, "upload_callback", new=callback):
             with ensure_no_exception():
@@ -280,9 +280,9 @@ class TestUpload(OneUserTest):
             assert dao.get_uploads_with_status(TransferStatus.PAUSED)
 
         # Resume the upload
-        engine.resume_transfer("upload", dao.get_uploads()[0].uid)
+        engine.resume_transfer("upload", list(dao.get_uploads())[0].uid)
         self.wait_sync()
-        assert not dao.get_uploads()
+        assert not list(dao.get_uploads())
 
     def test_pause_upload_automatically(self):
         """
@@ -293,7 +293,7 @@ class TestUpload(OneUserTest):
         def callback(*_):
             """This will mimic what is done in SystrayMenu.qml: suspend the app."""
             # Ensure we have 1 ongoing upload
-            uploads = dao.get_uploads()
+            uploads = list(dao.get_uploads())
             assert uploads
             upload = uploads[0]
             assert upload.status == TransferStatus.ONGOING
@@ -308,7 +308,7 @@ class TestUpload(OneUserTest):
         self.local_1.make_file("/", "test.bin", content=b"0" * FILE_BUFFER_SIZE * 2)
 
         # There is no upload, right now
-        assert not dao.get_uploads()
+        assert not list(dao.get_uploads())
 
         with patch.object(engine.remote, "upload_callback", new=callback):
             with ensure_no_exception():
@@ -318,7 +318,7 @@ class TestUpload(OneUserTest):
         # Resume the upload
         self.manager_1.resume()
         self.wait_sync()
-        assert not dao.get_uploads()
+        assert not list(dao.get_uploads())
 
     def test_modifying_paused_upload(self):
         """Modifying a paused upload should discard the current upload."""
@@ -326,7 +326,7 @@ class TestUpload(OneUserTest):
         def callback(*_):
             """Pause the upload and apply changes to the document."""
             # Ensure we have 1 ongoing upload
-            uploads = dao.get_uploads()
+            uploads = list(dao.get_uploads())
             assert uploads
             upload = uploads[0]
             assert upload.status == TransferStatus.ONGOING
@@ -345,7 +345,7 @@ class TestUpload(OneUserTest):
         self.local_1.make_file("/", "test.bin", content=b"0" * FILE_BUFFER_SIZE * 2)
 
         # There is no upload, right now
-        assert not dao.get_uploads()
+        assert not list(dao.get_uploads())
 
         with patch.object(engine.remote, "upload_callback", new=callback):
             with ensure_no_exception():
@@ -353,7 +353,7 @@ class TestUpload(OneUserTest):
 
         # Resync and check the local content is correct
         self.wait_sync()
-        assert not dao.get_uploads()
+        assert not list(dao.get_uploads())
         assert self.local_1.get_content("/test.bin") == b"locally changed"
 
     @not_windows(
@@ -365,7 +365,7 @@ class TestUpload(OneUserTest):
         def callback(*_):
             """Pause the upload and delete the document."""
             # Ensure we have 1 ongoing upload
-            uploads = dao.get_uploads()
+            uploads = list(dao.get_uploads())
             assert uploads
             upload = uploads[0]
             assert upload.status == TransferStatus.ONGOING
@@ -387,7 +387,7 @@ class TestUpload(OneUserTest):
         self.local_1.make_file("/", "test.bin", content=b"0" * FILE_BUFFER_SIZE * 2)
 
         # There is no upload, right now
-        assert not dao.get_uploads()
+        assert not list(dao.get_uploads())
 
         with patch.object(engine.remote, "upload_callback", new=callback):
             with ensure_no_exception():
@@ -395,7 +395,7 @@ class TestUpload(OneUserTest):
 
         # Resync and check the file does not exist
         self.wait_sync()
-        assert not dao.get_uploads()
+        assert not list(dao.get_uploads())
         assert not self.remote_1.exists("/test.bin")
 
     def test_not_server_error_upload(self):
@@ -412,14 +412,14 @@ class TestUpload(OneUserTest):
         self.local_1.make_file("/", "test.bin", content=b"0" * FILE_BUFFER_SIZE * 2)
 
         # There is no upload, right now
-        assert not dao.get_uploads()
+        assert not list(dao.get_uploads())
 
         with patch.object(engine.remote, "link_blob_to_doc", new=link_blob_to_doc):
             with ensure_no_exception():
                 self.wait_sync()
 
                 # There should be 1 upload with DONE transfer status
-                uploads = dao.get_uploads()
+                uploads = list(dao.get_uploads())
                 assert len(uploads) == 1
                 upload = uploads[0]
                 assert upload.status == TransferStatus.DONE
@@ -436,7 +436,7 @@ class TestUpload(OneUserTest):
 
         # Resync and check the file exist
         self.wait_sync()
-        assert not dao.get_uploads()
+        assert not list(dao.get_uploads())
         assert self.remote_1.exists("/test.bin")
 
     def test_server_error_but_upload_ok(self):
@@ -453,7 +453,7 @@ class TestUpload(OneUserTest):
             assert self.remote_1.exists(f"/{file}")
 
             # There should be 1 upload with ONGOING transfer status
-            uploads = dao.get_uploads()
+            uploads = list(dao.get_uploads())
             assert len(uploads) == 1
             upload = uploads[0]
             assert upload.status == TransferStatus.ONGOING
@@ -473,7 +473,7 @@ class TestUpload(OneUserTest):
         self.local_1.make_file("/", file, content=b"0" * FILE_BUFFER_SIZE * 2)
 
         # There is no upload, right now
-        assert not dao.get_uploads()
+        assert not list(dao.get_uploads())
 
         with patch.object(engine.remote, "link_blob_to_doc", new=link_blob_to_doc):
             with ensure_no_exception():
@@ -481,11 +481,11 @@ class TestUpload(OneUserTest):
 
                 # There should be no upload as the Processor has checked the file existence
                 # on the server and so deleted the upload from the database
-                assert not dao.get_uploads()
+                assert not list(dao.get_uploads())
 
         # Resync and check the file still exists
         self.wait_sync()
-        assert not dao.get_uploads()
+        assert not list(dao.get_uploads())
         assert self.remote_1.exists(f"/{file}")
         assert not dao.get_errors(limit=0)
 
@@ -503,14 +503,14 @@ class TestUpload(OneUserTest):
         self.local_1.make_file("/", "test.bin", content=b"0" * FILE_BUFFER_SIZE * 2)
 
         # There is no upload, right now
-        assert not dao.get_uploads()
+        assert not list(dao.get_uploads())
 
         with patch.object(engine.remote, "link_blob_to_doc", new=link_blob_to_doc):
             with ensure_no_exception():
                 self.wait_sync()
 
                 # There should be 1 upload with DONE transfer status
-                uploads = dao.get_uploads()
+                uploads = list(dao.get_uploads())
                 assert len(uploads) == 1
                 upload = uploads[0]
                 assert upload.status == TransferStatus.DONE
@@ -520,7 +520,7 @@ class TestUpload(OneUserTest):
 
         # Resync and check the file exists
         self.wait_sync()
-        assert not dao.get_uploads()
+        assert not list(dao.get_uploads())
         assert self.remote_1.exists("/test.bin")
 
     def test_chunk_upload_error(self):
@@ -544,14 +544,14 @@ class TestUpload(OneUserTest):
         self.local_1.make_file("/", "test.bin", content=b"0" * FILE_BUFFER_SIZE * 4)
 
         # There is no upload, right now
-        assert not dao.get_uploads()
+        assert not list(dao.get_uploads())
 
         with patch.object(engine, "remote", new=bad_remote):
             with ensure_no_exception():
                 self.wait_sync()
 
                 # There should be 1 upload with ONGOING transfer status
-                uploads = dao.get_uploads()
+                uploads = list(dao.get_uploads())
                 assert len(uploads) == 1
                 upload = uploads[0]
                 assert upload.status == TransferStatus.ONGOING
@@ -561,5 +561,5 @@ class TestUpload(OneUserTest):
 
         # Resync and check the file exists
         self.wait_sync()
-        assert not dao.get_uploads()
+        assert not list(dao.get_uploads())
         assert self.remote_1.exists("/test.bin")

--- a/tools/whitelist.py
+++ b/tools/whitelist.py
@@ -23,7 +23,6 @@ FolderTreeview.resizeEvent  # Internal use of PyQt
 install_addons  # Used in QML
 getTag  # Used in QML
 getName  # Internal use of QML
-insertRows  # Internal use of QML
 Manager.set_light_icons  # Used in QML
 MetaOptions.mock  # Used in tests
 nameRoles  # Internal use of QML


### PR DESCRIPTION
Added timers to control when the files list in the systray can be updated. Same for syncing docs and synced docs counts.

Some refactoring in `view.py` on how rows insertion and deletion are done. The new code is cleaner and less resources greedy.

There is a small downside though: the remaining docs to sync (at the last iteration) is not updated
until the sync is actually over. But this is another issue not related to the subject and should be tackled another time.

Also:

- NXDRIVE-1875: Use more processors by default (5 -> 10)
- NXDRIVE-1876: Fix threads not totally released