### PR TITLE
NXDRIVE-1391: [macOS] Upgrade PyQt from 5.11.2 to 5.13.1

### DIFF
--- a/docs/changes/4.2.1.md
+++ b/docs/changes/4.2.1.md
@@ -13,6 +13,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1868](https://jira.nuxeo.com/browse/NXDRIVE-1868): [macOS] Use a custom trash implementation instead of using Send2Trash
 - [NXDRIVE-1875](https://jira.nuxeo.com/browse/NXDRIVE-1875): Use more processors by default (5 -> 10)
 - [NXDRIVE-1876](https://jira.nuxeo.com/browse/NXDRIVE-1876): Fix threads not totally released
+- [NXDRIVE-1879](https://jira.nuxeo.com/browse/NXDRIVE-1879): Drop the support for macOS 10.11 (**breaking change**)
 
 ## GUI
 

--- a/docs/changes/4.2.1.md
+++ b/docs/changes/4.2.1.md
@@ -16,10 +16,13 @@ Release date: `2019-xx-xx`
 
 ## GUI
 
+- [NXDRIVE-1826](https://jira.nuxeo.com/browse/NXDRIVE-1826): Systray icon is blurry on macOS dark mode
+- [NXDRIVE-1827](https://jira.nuxeo.com/browse/NXDRIVE-1827): [macOS] Dark mode not correctly handled
 - [NXDRIVE-1839](https://jira.nuxeo.com/browse/NXDRIVE-1839): The GUI is not responsive when syncing a lot of files
 
 ## Packaging / Build
 
+- [NXDRIVE-1391](https://jira.nuxeo.com/browse/NXDRIVE-1391): [macOS] Upgrade PyQt from 5.11.2 to 5.13.1
 - [NXDRIVE-1396](https://jira.nuxeo.com/browse/NXDRIVE-1396): [macOS] Upgrade PyObjC to 5.2
 
 ## Tests
@@ -36,11 +39,14 @@ Release date: `2019-xx-xx`
 - Upgraded `certify` from 2019.6.16 to 2019.9.11
 - Upgraded `nuxeo` from 2.2.2 to 2.2.3
 - Upgraded `pypac` from 0.12.0 to 0.13.0
+- Upgraded `pyqt5` from 5.13.0 to 5.13.1 on GNU/Linux and Windows
+- Upgraded `pyqt5-sip` from 4.19.13 to 12.7.0 on macOS
+- Upgraded `pyqt5-sip` from 4.19.18 to 12.7.0 on GNU/Linux and Windows
 - Upgraded `pywin32` from 224 to 225
 - Upgraded `sentry-sdk` from 0.11.2 to 0.12.3
 - Upgraded `tld` from 0.9.3 to 0.9.6
 - Upgraded `urllib3` from 1.25.3 to 1.25.6
-- Added `pyobjc-framework-LaunchServices`
+- Removed `pyobjc-framework-LaunchServices`
 - Removed `send2trash` on macOS
 
 ## Technical Changes

--- a/docs/support.md
+++ b/docs/support.md
@@ -28,7 +28,7 @@ History:
 Officially supported platform vendors and versions:
 
 - GNU/Linux, 64 bits
-- macOS >= 10.11, 64 bits
+- macOS >= 10.12, 64 bits
 - Windows 7, both 32 and 64 bits
 - Windows 8, both 32 and 64 bits
 - Windows 8.1, both 32 and 64 bits
@@ -36,6 +36,7 @@ Officially supported platform vendors and versions:
 
 History:
 
+- `2019-10-xx` (v4.2.1): dropped support for macOS 10.11
 - `2019-09-26` (v4.2.0): added support for GNU/Linux
 - `2018-06-11` (v3.1.1): dropped support for macOS 10.10
 - `2018-02-23` (v3.0.5): dropped support for macOS 10.4 - 10.9

--- a/nxdrive/data/qml/AboutTab.qml
+++ b/nxdrive/data/qml/AboutTab.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
 import "icon-font/Icon.js" as MdiFont
 
 Rectangle {

--- a/nxdrive/data/qml/AccountsComboBox.qml
+++ b/nxdrive/data/qml/AccountsComboBox.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
 
 NuxeoComboBox {
     id: control

--- a/nxdrive/data/qml/AccountsTab.qml
+++ b/nxdrive/data/qml/AccountsTab.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
 import "icon-font/Icon.js" as MdiFont
 
 Rectangle {

--- a/nxdrive/data/qml/Alert.qml
+++ b/nxdrive/data/qml/Alert.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.10
+import QtQuick 2.13
 
 ShadowRectangle {
     id: control

--- a/nxdrive/data/qml/ChannelPopup.qml
+++ b/nxdrive/data/qml/ChannelPopup.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
 
 NuxeoPopup {
     id: control

--- a/nxdrive/data/qml/ConfirmPopup.qml
+++ b/nxdrive/data/qml/ConfirmPopup.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.10
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Layouts 1.13
 
 NuxeoPopup {
     id: control

--- a/nxdrive/data/qml/Conflicts.qml
+++ b/nxdrive/data/qml/Conflicts.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.3
-import QtQuick.Window 2.2
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
+import QtQuick.Window 2.13
 
 Rectangle {
     id: conflicts

--- a/nxdrive/data/qml/DeletionPopup.qml
+++ b/nxdrive/data/qml/DeletionPopup.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
 
 NuxeoPopup {
     id: control

--- a/nxdrive/data/qml/FileCard.qml
+++ b/nxdrive/data/qml/FileCard.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
 
 ShadowRectangle {
     id: control

--- a/nxdrive/data/qml/GeneralTab.qml
+++ b/nxdrive/data/qml/GeneralTab.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
 
 Rectangle {
     id: control

--- a/nxdrive/data/qml/HorizontalSeparator.qml
+++ b/nxdrive/data/qml/HorizontalSeparator.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.10
+import QtQuick 2.13
 
 Rectangle {
     property real factor: 1.0

--- a/nxdrive/data/qml/HoverRectangle.qml
+++ b/nxdrive/data/qml/HoverRectangle.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.10
+import QtQuick 2.13
 
 Rectangle {
     id: control

--- a/nxdrive/data/qml/IconLabel.qml
+++ b/nxdrive/data/qml/IconLabel.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.10
+import QtQuick 2.13
 
  ScaledText {
     id: control

--- a/nxdrive/data/qml/IconLink.qml
+++ b/nxdrive/data/qml/IconLink.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.10
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Layouts 1.13
 
 RowLayout {
     id: control

--- a/nxdrive/data/qml/Link.qml
+++ b/nxdrive/data/qml/Link.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.10
+import QtQuick 2.13
 
  ScaledText {
     id: control

--- a/nxdrive/data/qml/LogLevelPopup.qml
+++ b/nxdrive/data/qml/LogLevelPopup.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
 
 NuxeoPopup {
     id: control

--- a/nxdrive/data/qml/Main.qml
+++ b/nxdrive/data/qml/Main.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.3
-import QtQuick.Window 2.2
+import QtQuick 2.13
+import QtQuick.Window 2.13
 import SystrayWindow 1.0
 
 QtObject {

--- a/nxdrive/data/qml/NewAccountPopup.qml
+++ b/nxdrive/data/qml/NewAccountPopup.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.10
+import QtQuick 2.13
 import QtQuick.Dialogs 1.3
-import QtQuick.Layouts 1.3
+import QtQuick.Layouts 1.13
 import "icon-font/Icon.js" as MdiFont
 
 NuxeoPopup {

--- a/nxdrive/data/qml/NuxeoButton.qml
+++ b/nxdrive/data/qml/NuxeoButton.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
 
 Button {
     id: control

--- a/nxdrive/data/qml/NuxeoCheckBox.qml
+++ b/nxdrive/data/qml/NuxeoCheckBox.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
 
 CheckBox {
     id: control

--- a/nxdrive/data/qml/NuxeoComboBox.qml
+++ b/nxdrive/data/qml/NuxeoComboBox.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
 import "icon-font/Icon.js" as MdiFont
 
 ComboBox {

--- a/nxdrive/data/qml/NuxeoInput.qml
+++ b/nxdrive/data/qml/NuxeoInput.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.10
+import QtQuick 2.13
 
 TextInput {
     id: control

--- a/nxdrive/data/qml/NuxeoPopup.qml
+++ b/nxdrive/data/qml/NuxeoPopup.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
 
 Popup {
     id: control

--- a/nxdrive/data/qml/NuxeoProgressBar.qml
+++ b/nxdrive/data/qml/NuxeoProgressBar.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
 
 ProgressBar {
     id: control

--- a/nxdrive/data/qml/NuxeoRadioButton.qml
+++ b/nxdrive/data/qml/NuxeoRadioButton.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
 
 RadioButton {
     id: control

--- a/nxdrive/data/qml/NuxeoSwitch.qml
+++ b/nxdrive/data/qml/NuxeoSwitch.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
 
 Switch {
     id: control

--- a/nxdrive/data/qml/NuxeoToolTip.qml
+++ b/nxdrive/data/qml/NuxeoToolTip.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.1
+import QtQuick 2.13
+import QtQuick.Controls 2.13
 
 ToolTip {
     id: control

--- a/nxdrive/data/qml/PauseButton.qml
+++ b/nxdrive/data/qml/PauseButton.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.10
+import QtQuick 2.13
 import "icon-font/Icon.js" as MdiFont
 
 IconLabel {

--- a/nxdrive/data/qml/ProxyPopup.qml
+++ b/nxdrive/data/qml/ProxyPopup.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
 
 NuxeoPopup {
     id: control

--- a/nxdrive/data/qml/ScaledText.qml
+++ b/nxdrive/data/qml/ScaledText.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.10
+import QtQuick 2.13
 
 Text {
     property int pointSize: 12

--- a/nxdrive/data/qml/Settings.qml
+++ b/nxdrive/data/qml/Settings.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.3
-import QtQuick.Window 2.2
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
+import QtQuick.Window 2.13
 
 Item {
     id: settings

--- a/nxdrive/data/qml/SettingsTab.qml
+++ b/nxdrive/data/qml/SettingsTab.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
 
 TabButton {
     id: control

--- a/nxdrive/data/qml/ShadowRectangle.qml
+++ b/nxdrive/data/qml/ShadowRectangle.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.10
+import QtQuick 2.13
 
 Rectangle {
     id: control

--- a/nxdrive/data/qml/Systray.qml
+++ b/nxdrive/data/qml/Systray.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.3
-import QtQuick.Window 2.2
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
+import QtQuick.Window 2.13
 import "icon-font/Icon.js" as MdiFont
 
 Rectangle {

--- a/nxdrive/data/qml/SystrayFile.qml
+++ b/nxdrive/data/qml/SystrayFile.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
 import "icon-font/Icon.js" as MdiFont
 
 Rectangle {

--- a/nxdrive/data/qml/SystrayMenu.qml
+++ b/nxdrive/data/qml/SystrayMenu.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
 
 ShadowRectangle {
     id: control

--- a/nxdrive/data/qml/SystrayMenuItem.qml
+++ b/nxdrive/data/qml/SystrayMenuItem.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
 
 Rectangle {
     id: control
@@ -15,7 +15,7 @@ Rectangle {
         id: itemText
         text: control.text
         pointSize: control.size
-        
+
         padding: 10
         height: parent.height
         elide: Text.ElideRight

--- a/nxdrive/data/qml/SystrayStatus.qml
+++ b/nxdrive/data/qml/SystrayStatus.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
 import "icon-font/Icon.js" as MdiFont
 
 HoverRectangle {

--- a/nxdrive/data/qml/SystrayTransfer.qml
+++ b/nxdrive/data/qml/SystrayTransfer.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.10
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
 import "icon-font/Icon.js" as MdiFont
 
 Rectangle {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,8 +18,8 @@ macholib==1.11 ; sys_platform == "darwin" \
 pefile==2019.4.18 ; sys_platform == "win32" \
     --hash=sha256:a5d6e8305c6b210849b47a6174ddf9c452b2888340b8177874b862ba6c207645
     # via pyinstaller
-pyinstaller==3.5 \
-    --hash=sha256:ee7504022d1332a3324250faf2135ea56ac71fdb6309cff8cd235de26b1d0a96
+https://github.com/pyinstaller/pyinstaller/archive/3f57c91422c1e48d284fa66d09f6aa3e3c6dbf9c.zip \
+    --hash=sha256:21c19529d729333d614f604d7b74da88742a29aa5e1b1c3159cc5a23f6e1a8fc
 pywin32-ctypes==0.2.0 ; sys_platform == "win32" \
     --hash=sha256:9dc2d991b3479cc2df15930958b674a48a227d5361d413827a4cfd0b5876fc98
     # via pyinstaller

--- a/requirements.txt
+++ b/requirements.txt
@@ -147,38 +147,16 @@ pyobjc-framework-SystemConfiguration==5.2 ; sys_platform == "darwin" \
     # via pypac
 pypac==0.13.0 \
     --hash=sha256:a1eac0e3224939fcc691c8ad815f9cd24d737c8e0cf9c9905a01821bbe8f1414
-# [macOS] Ignore SIP updates until NXDRIVE-1719 is done
-pyqt5-sip==4.19.13 ; sys_platform == "darwin" \
-    --hash=sha256:125f77c087572c9272219cda030a63c2f996b8507592b2a54d7ef9b75f9f054d \
-    --hash=sha256:14c37b06e3fb7c2234cb208fa461ec4e62b4ba6d8b32ca3753c0b2cfd61b00e3 \
-    --hash=sha256:1cb2cf52979f9085fc0eab7e0b2438eb4430d4aea8edec89762527e17317175b \
-    --hash=sha256:4babef08bccbf223ec34464e1ed0a23caeaeea390ca9a3529227d9a57f0d6ee4 \
-    --hash=sha256:53cb9c1208511cda0b9ed11cffee992a5a2f5d96eb88722569b2ce65ecf6b960 \
-    --hash=sha256:549449d9461d6c665cbe8af4a3808805c5e6e037cd2ce4fd93308d44a049bfac \
-    --hash=sha256:5f5b3089b200ff33de3f636b398e7199b57a6b5c1bb724bdb884580a072a14b5 \
-    --hash=sha256:a4d9bf6e1fa2dd6e73f1873f1a47cee11a6ba0cf9ba8cf7002b28c76823600d0 \
-    --hash=sha256:a4ee6026216f1fbe25c8847f9e0fbce907df5b908f84816e21af16ec7666e6fe \
-    --hash=sha256:a91a308a5e0cc99de1e97afd8f09f46dd7ca20cfaa5890ef254113eebaa1adff \
-    --hash=sha256:b0342540da479d2713edc68fb21f307473f68da896ad5c04215dae97630e0069 \
-    --hash=sha256:f997e21b4e26a3397cb7b255b8d1db5b9772c8e0c94b6d870a5a0ab5c27eacaa \
-    # pyup: ignore
-pyqt5-sip==4.19.18 ; sys_platform != "darwin" \
-    --hash=sha256:889f2d71e7e94e370be726048a4632226846715c8b3cb0525572f857d408f7cf \
-    --hash=sha256:0a6c272ad2b6556a804a66bf808240ae0db88ab26f5ce37231da8c1d3e6910a6 \
-    --hash=sha256:a5bea998292a644525a34e1ec104090e4618f7b92f35d92310db39f8051f9ad0 \
-    --hash=sha256:7dd4d0bae586ab929e0e4f0d07008cb3b4449af48f7a4e73db4d66b806316778
-# [macOS] Ignore PyQt5 updates until NXDRIVE-1391 is done
-pyqt5==5.11.2 ; sys_platform == "darwin" \
-    --hash=sha256:700b8bb0357bf0ac312bce283449de733f5773dfc77083664be188c8e964c007 \
-    --hash=sha256:76d52f3627fac8bfdbc4857ce52a615cd879abd79890cde347682ff9b4b245a2 \
-    --hash=sha256:7d0f7c0aed9c3ef70d5856e99f30ebcfe25a58300158dd46ee544cbe1c5b53db \
-    --hash=sha256:d5dc2faf0aeacd0e8b69af1dc9f1276a64020193148356bb319bdfae22b78f88 \
-    # pyup: ignore
-pyqt5==5.13.0 ; sys_platform != "darwin" \
-    --hash=sha256:aa75b829cd977ca796262fcfe0dc8fc72f8413da4e5e2795e63897e1abfd2258 \
-    --hash=sha256:70954a2d182c8634e3b5f9deeb4230f186b59ec1166f3142cb523b74876c0d98 \
-    --hash=sha256:4d51a245d64fbd85c77ba3dee12b8fe018a440ccb49fd1cb0e4587c360655d3c \
-    --hash=sha256:afbee0925439124b5c52dacaf9a6d8d4e160e36b636a6f9023832a696e15e3e9
+pyqt5-sip==12.7.0 \
+    --hash=sha256:06bc66b50556fb949f14875a4c224423dbf03f972497ccb883fb19b7b7c3b346 \
+    --hash=sha256:482a910fa73ee0e36c258d7646ef38f8061774bbc1765a7da68c65056b573341 \
+    --hash=sha256:1c7ad791ec86247f35243bbbdd29cd59989afbe0ab678e0a41211f4407f21dd8 \
+    --hash=sha256:da69ba17f6ece9a85617743cb19de689f2d63025bf8001e2facee2ec9bcff18f
+pyqt5==5.13.1 \
+    --hash=sha256:f8e76070782e68ba200eb2b67babf89ac629df5e36d2f4c680ef34ae40c8f964 \
+    --hash=sha256:6420d8c9de8746917bd2afe24f29b3722aabde36d1e9f8c34354f5b7fb7b987d \
+    --hash=sha256:8e6125f110133069e8f4a085022cfc6b4a0af5b3c9009999a749007c299e965d \
+    --hash=sha256:73f982b60819cc6d7cb0007b8b0cd11073e2546d74e0463726149e6a9d087caa
 python-dateutil==2.8.0 \
     --hash=sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb \
     --hash=sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e

--- a/tools/jenkins/packages.groovy
+++ b/tools/jenkins/packages.groovy
@@ -21,8 +21,8 @@ properties([
 ])
 
 // Jenkins agents we will build on
-//   We are using TWANG because it is the oldest macOS version we support (10.11).
-//   The macOS installer needs to be built on that version to support 10.11+ because
+//   We are using TWANG because it is the oldest macOS version we support (10.12).
+//   The macOS installer needs to be built on that version to support 10.12+ because
 //   PyInstaller is not retro-compatible: if we would build on 10.13, the minimum
 //   supported macOS version would become 10.13.
 //

--- a/tools/jenkins/packages.groovy
+++ b/tools/jenkins/packages.groovy
@@ -90,8 +90,10 @@ for (x in agents) {
                                     branch = branch.replace('refs/tags/', 'wip-')
                                 }
 
-                                def image = docker.image('nuxeo-drive-build:py-3.7.4')  // XXX_PYTHON
-                                image.inside() { sh "/entrypoint.sh" }
+                                docker.withRegistry('https://dockerpriv.nuxeo.com/') {
+                                    def image = docker.image('nuxeo-drive-build:py-3.7.4')  // XXX_PYTHON
+                                    image.inside() { sh "/entrypoint.sh" }
+                                }
                                 sh 'tools/linux/deploy_jenkins_slave.sh --check'
                                 archiveArtifacts artifacts: 'dist/*.AppImage', fingerprint: true
                             } else if (osi == 'macOS') {

--- a/tools/osx/deploy_jenkins_slave.sh
+++ b/tools/osx/deploy_jenkins_slave.sh
@@ -66,7 +66,7 @@ create_package() {
     build_extension
     echo ">>> [package] Adding the extension to the package"
     mkdir "${pkg_path}/Contents/PlugIns"
-    mv -fv "${WORKSPACE_DRIVE}/NuxeoFinderSync.appex" "${pkg_path}/Contents/PlugIns/."
+    mv -fv "${WORKSPACE_DRIVE}/NuxeoFinderSync.appex" "${pkg_path}/Contents/PlugIns/"
 
     prepare_signing
     if [ "${SIGNING_ID:=unset}" != "unset" ]; then

--- a/tools/osx/deploy_jenkins_slave.sh
+++ b/tools/osx/deploy_jenkins_slave.sh
@@ -68,9 +68,6 @@ create_package() {
     mkdir "${pkg_path}/Contents/PlugIns"
     mv -fv "${WORKSPACE_DRIVE}/NuxeoFinderSync.appex" "${pkg_path}/Contents/PlugIns/."
 
-    echo ">>> [package] Creating the DMG file"
-    rm -fv ${output_dir}/*.dmg
-
     prepare_signing
     if [ "${SIGNING_ID:=unset}" != "unset" ]; then
         echo ">>> [sign] Signing the app and its extension"
@@ -94,15 +91,17 @@ create_package() {
         spctl --assess -v "${pkg_path}"
     fi
 
+    echo ">>> [package] Creating the DMG file"
+    # Clean-up
+    rm -fv ${output_dir}/*.dmg
+    rm -rf "${src_folder_tmp}" "${dmg_tmp}"
+    mkdir "${src_folder_tmp}"
+
     echo ">>> [DMG] ${bundle_name} version ${app_version}"
     # Compute DMG name and size
     local dmg_path="${output_dir}/nuxeo-drive-${app_version}.dmg"
     local dmg_size=$(( $(du -sm "${pkg_path}" | cut -d$'\t' -f1,1) + 20 ))
     echo ">>> [DMG ${app_version}] ${dmg_path} (${dmg_size} Mo)"
-
-    # Clean tmp directories
-    rm -rf "${src_folder_tmp}" "${dmg_tmp}"
-    mkdir "${src_folder_tmp}"
 
     echo ">>> [DMG ${app_version}] Preparing the DMG"
     cp -a "${pkg_path}" "${src_folder_tmp}"

--- a/tools/osx/drive/NuxeoFinderSync/FileStatus.swift
+++ b/tools/osx/drive/NuxeoFinderSync/FileStatus.swift
@@ -3,7 +3,11 @@
 //  NuxeoFinderSync
 //
 //  Created by Léa Klein on 26/03/2018.
-//  Copyright © 2018 Nuxeo. All rights reserved.
+//
+//  Contributors:
+//      Mickaël Schoentgen
+//
+//  Copyright © 2018-2019 Nuxeo. All rights reserved.
 //
 
 import Foundation
@@ -163,7 +167,7 @@ class FileStatus {
 
     func run(_ returnVal: Int32, error: SQLiteError) throws {
         if !(returnVal == SQLITE_OK || returnVal == SQLITE_DONE) {
-            let errmsg = String(cString: sqlite3_errmsg(db)!)
+            //let errmsg = String(cString: sqlite3_errmsg(db)!)
             //NSLog("\(error): \(errmsg)")
             throw error
         }

--- a/tools/osx/drive/NuxeoFinderSync/Socket.swift
+++ b/tools/osx/drive/NuxeoFinderSync/Socket.swift
@@ -3,7 +3,11 @@
 //  NuxeoFinderSync
 //
 //  Created by Léa Klein on 12/04/2018.
-//  Copyright © 2018 Nuxeo. All rights reserved.
+//
+//  Contributors:
+//      Mickaël Schoentgen
+//
+//  Copyright © 2018-2019 Nuxeo. All rights reserved.
 //
 import Foundation
 
@@ -75,7 +79,7 @@ class Socket : NSObject, StreamDelegate {
     }
 
     func send(_ content: Data) {
-        content.withUnsafeBytes {
+        _ = content.withUnsafeBytes {
             outputStream?.write($0, maxLength: content.count)
         }
     }

--- a/tools/osx/fix_app_qt_folder_names_for_codesign.py
+++ b/tools/osx/fix_app_qt_folder_names_for_codesign.py
@@ -16,7 +16,7 @@ def create_symlink(folder: Path) -> None:
     # PyQt5/Qt/qml/QtQml/Models.2
     root = str(sibbling).partition("Contents")[2].lstrip("/")
     # ../../../../
-    backward = "../" * len(root.split("/"))
+    backward = "../" * (root.count("/") + 1)
     # ../../../../Resources/PyQt5/Qt/qml/QtQml/Models.2
     good_path = f"{backward}Resources/{root}"
 
@@ -47,7 +47,7 @@ def fix_dll(dll: Path) -> None:
     # Resources/PyQt5/Qt/qml/QtQuick/Controls.2/Fusion
     root = str(dll.parent).partition("Contents")[2][1:]
     # /../../../../../../..
-    backward = "/.." * len(root.split("/"))
+    backward = "/.." * (root.count("/") + 1)
     # /../../../../../../../MacOS
     good_path = f"{backward}/MacOS"
 
@@ -68,7 +68,7 @@ def find_problematic_folders(folder: Path) -> Generator[Path, None, None]:
         if not path.is_dir() or path.is_symlink():
             # Skip simlinks as they are allowed (even with a dot)
             continue
-        if "." in path.name:
+        if "qml" == path.name:
             yield path
         else:
             yield from find_problematic_folders(path)
@@ -114,9 +114,9 @@ def main(args: List[str]) -> int:
         for folder in find_problematic_folders(path):
             for file in move_contents_to_resources(folder):
                 fix_dll(file)
+                print(f" !! Fixed DLL {str(file)!r}")
             shutil.rmtree(folder)
             create_symlink(folder)
-            print(f" !! Fixed {folder}")
         print(f">>> [{name}] Application fixed.")
     return 0
 

--- a/tools/posix/deploy_jenkins_slave.sh
+++ b/tools/posix/deploy_jenkins_slave.sh
@@ -53,7 +53,6 @@ build_installer() {
         # Remove broken symlinks pointing to an inexistant target
         find dist/*.app/Contents/MacOS -type l -exec sh -c 'for x; do [ -e "$x" ] || rm -v "$x"; done' _ {} +
     elif [ "${OSI}" = "linux" ]; then
-        ${PYTHON} tools/cleanup_application_tree.py dist/ndrive
         remove_blacklisted_files dist/ndrive
     fi
 

--- a/tools/windows/deploy_jenkins_slave.ps1
+++ b/tools/windows/deploy_jenkins_slave.ps1
@@ -46,9 +46,6 @@ function add_missing_ddls {
 	if (Test-Path $folder) {
 		Get-ChildItem $folder | Copy -Verbose -Force -Destination "dist\ndrive"
 	}
-
-	# PyInstaller #4416
-	Copy -Verbose -Force -Destination "dist\ndrive\PyQt5\Qt\bin" "dist\ndrive\Qt5Core.dll"
 }
 
 function build($app_version, $script) {


### PR DESCRIPTION
Also:
- NXDRIVE-1826: Systray icon is blurry on macOS dark mode
- NXDRIVE-1827: [macOS] Dark mode not correctly handle
- Upgraded `pyqt5` from 5.13.0 to 5.13.1 on GNU/Linux and Windows
- Upgraded `pyqt5-sip` from 4.19.13 to 12.7.0 on macOS
- Upgraded `pyqt5-sip` from 4.19.18 to 12.7.0 on GNU/Linux and Windows

And previous changes needs another one, more important:
- NXDRIVE-1879: Drop the support for macOS 10.11 (**breaking change**)

