### PR TITLE
NXDRIVE-1890: [Windows] Fix waiting during auto-upgrade

### DIFF
--- a/docs/changes/4.2.1.md
+++ b/docs/changes/4.2.1.md
@@ -17,6 +17,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1876](https://jira.nuxeo.com/browse/NXDRIVE-1876): Fix threads not totally released
 - [NXDRIVE-1879](https://jira.nuxeo.com/browse/NXDRIVE-1879): Drop the support for macOS 10.11 (**breaking change**)
 - [NXDRIVE-1881](https://jira.nuxeo.com/browse/NXDRIVE-1881): Fix ineffective metrics preferences
+- [NXDRIVE-1890](https://jira.nuxeo.com/browse/NXDRIVE-1890): [Windows] Fix waiting during auto-upgrade
 
 ## GUI
 

--- a/nxdrive/updater/windows.py
+++ b/nxdrive/updater/windows.py
@@ -30,7 +30,8 @@ class Updater(BaseUpdater):
         So, a big thank you to Inno Setup!
         """
 
-        cmd = f'timeout /t 5 /nobreak > nul && "{filename}" /verysilent /start=auto'
+        # Using ping instead of timeout to wait 5 seconds (see NXDRIVE-1890)
+        cmd = f'ping 127.0.0.1 -n 6 > nul && "{filename}" /verysilent /start=auto'
         log.info("Launching the auto-updater in 5 seconds ...")
         subprocess.Popen(cmd, shell=True, close_fds=True)
 


### PR DESCRIPTION
When cygwin is installed, the `timeout.exe` call was made using the one from cygwin rather than
the system one. This was causing that error:
```batch
timeout: invalid time interval ‘/t’
Try 'timeout --help' for more information.
```
Replacing timeout with ping is a reliable solution. Ping waits 1 second between attemps.