### PR TITLE
NXDRIVE-1892: [macOS] Allow the app to be run from $HOME/Applications

### DIFF
--- a/docs/changes/4.2.1.md
+++ b/docs/changes/4.2.1.md
@@ -18,6 +18,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1879](https://jira.nuxeo.com/browse/NXDRIVE-1879): Drop the support for macOS 10.11 (**breaking change**)
 - [NXDRIVE-1881](https://jira.nuxeo.com/browse/NXDRIVE-1881): Fix ineffective metrics preferences
 - [NXDRIVE-1890](https://jira.nuxeo.com/browse/NXDRIVE-1890): [Windows] Fix waiting during auto-upgrade
+- [NXDRIVE-1892](https://jira.nuxeo.com/browse/NXDRIVE-1892): [macOS] Allow the app to be run from `$HOME/Applications`
 
 ## GUI
 

--- a/nxdrive/fatal_error.py
+++ b/nxdrive/fatal_error.py
@@ -196,7 +196,7 @@ def fatal_error_mac(text: str) -> None:
 def check_executable_path() -> bool:
     """Check that the app runs from the right path, and quit if not."""
 
-    if not MAC:
+    if not MAC or not Options.is_frozen:
         return True
 
     import re
@@ -207,7 +207,10 @@ def check_executable_path() -> bool:
     m = re.match(r"(.*\.app).*", exe_path)
     path = Path(m.group(1) if m else exe_path)
 
-    if not Options.is_frozen or path == Path(f"/Applications/{APP_NAME}.app"):
+    if path in (
+        Path(f"/Applications/{APP_NAME}.app"),
+        Path.home() / "Applications" / f"{APP_NAME}.app",
+    ):
         return True
 
     try:

--- a/nxdrive/osi/darwin/darwin.py
+++ b/nxdrive/osi/darwin/darwin.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 import os
 import psutil
+import re
 import stat
 import subprocess
 import sys
@@ -29,7 +30,7 @@ from nuxeo.compat import quote
 from .extension import DarwinExtensionListener
 from .. import AbstractOSIntegration
 from ..extension import get_formatted_status
-from ...constants import APP_NAME, BUNDLE_IDENTIFIER, NXDRIVE_SCHEME
+from ...constants import BUNDLE_IDENTIFIER, NXDRIVE_SCHEME
 from ...objects import DocPair
 from ...options import Options
 from ...translator import Translator
@@ -39,6 +40,13 @@ from ...utils import if_frozen
 __all__ = ("DarwinIntegration",)
 
 log = getLogger(__name__)
+
+
+def _get_app() -> str:
+    """Return the path to the application, when bundled."""
+    exe_path = sys.executable
+    m = re.match(r"(.*\.app).*", exe_path)
+    return m.group(1) if m else exe_path
 
 
 class DarwinIntegration(AbstractOSIntegration):
@@ -61,9 +69,7 @@ class DarwinIntegration(AbstractOSIntegration):
         "</plist>"
     )
     FINDERSYNC_ID = f"{BUNDLE_IDENTIFIER}.NuxeoFinderSync"
-    FINDERSYNC_PATH = (
-        f"/Applications/{APP_NAME}.app/Contents/PlugIns/NuxeoFinderSync.appex/"
-    )
+    FINDERSYNC_PATH = f"{_get_app()}/Contents/PlugIns/NuxeoFinderSync.appex/"
 
     @if_frozen
     def init(self) -> None:

--- a/tools/scripts/check_update_process.py
+++ b/tools/scripts/check_update_process.py
@@ -30,8 +30,9 @@ import threading
 import time
 from contextlib import suppress
 from os.path import expanduser
+from pathlib import Path
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 
 EXT = {"darwin": "dmg", "linux": "appimage", "win32": "exe"}[sys.platform]
@@ -106,7 +107,7 @@ def install_drive(installer):
         mount_dir = mount_info.splitlines()[-1].split("\t")[-1]
 
         src = "{}/Nuxeo Drive.app".format(mount_dir)
-        dst = "/Applications/Nuxeo Drive.app"
+        dst = f"{Path.home()}/Applications/Nuxeo Drive.app"
         if os.path.isdir(dst):
             print(">>> Deleting", dst)
             shutil.rmtree(dst)
@@ -133,7 +134,7 @@ def launch_drive(executable):
     if EXT == "appimage":
         cmd = [executable]
     elif EXT == "dmg":
-        cmd = ["open", "/Applications/Nuxeo Drive.app", "--args"]
+        cmd = ["open", f"{Path.home()}/Applications/Nuxeo Drive.app", "--args"]
     else:
         cmd = [expanduser("~\\AppData\\Local\\Nuxeo Drive\\ndrive.exe")]
 
@@ -170,10 +171,10 @@ def uninstall_drive():
     if EXT == "appimage":
         # Nothing to uninstall on GNU/Linux"
         pass
-    if EXT == "dmg":
-        path = "/Applications/Nuxeo Drive.app"
-        print(">>> Deleting", path)
-        with suppress(OSError):
+    elif EXT == "dmg":
+        path = f"{Path.home()}/Applications/Nuxeo Drive.app"
+        if os.path.isdir(path):
+            print(">>> Deleting", path, flush=True)
             shutil.rmtree(path)
     else:
         cmd = [


### PR DESCRIPTION
Those changes do not modify default behaviors:

- Updated `tools/scripts/check_update_process.py` to use the user folder.
- Made the FinderSync extension location agnostic.
- Made the auto-updater location agnostic.