### PR TITLE
NXDRIVE-1897: The clean-folder CLI argument should ignore errors

### DIFF
--- a/docs/changes/4.2.1.md
+++ b/docs/changes/4.2.1.md
@@ -24,6 +24,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1890](https://jira.nuxeo.com/browse/NXDRIVE-1890): [Windows] Fix waiting during auto-upgrade
 - [NXDRIVE-1892](https://jira.nuxeo.com/browse/NXDRIVE-1892): [macOS] Allow the app to be run from `$HOME/Applications`
 - [NXDRIVE-1896](https://jira.nuxeo.com/browse/NXDRIVE-1896): Ensure to quit the application after an update in the console mode
+- [NXDRIVE-1897](https://jira.nuxeo.com/browse/NXDRIVE-1897): The `clean-folder` CLI argument should ignore errors
 - [NXDRIVE-1898](https://jira.nuxeo.com/browse/NXDRIVE-1898): Display a friendly message when the OS is not supported
 - [NXDRIVE-1902](https://jira.nuxeo.com/browse/NXDRIVE-1902): Add the update channel in analytics report
 
@@ -81,6 +82,9 @@ Release date: `2019-xx-xx`
 - Removed `FileModel.empty()`
 - Removed `FileModel.insertRows()`
 - Removed `FileModel.removeRows()`
+- added `cleanup` keyword argument to `LocalClientMixin.clean_xattr_folder_recursive()`
+- added `cleanup` keyword argument to `LocalClientMixin.remove_remote_id()`
+- added `cleanup` keyword argument to `LocalClientMixin.remove_root_id()`
 - Added `Manager.arch`
 - Added `Manager.check_metrics_preferences()`
 - Added `Manager.create_tracker()`


### PR DESCRIPTION
Added a test file mostly to only check the methods and it will also be usefull to validate NXDRIVE-988.