### PR TITLE
NXDRIVE-1857: Handle multi-account for Direct Transfers

### DIFF
--- a/docs/changes/4.2.1.md
+++ b/docs/changes/4.2.1.md
@@ -10,6 +10,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1851](https://jira.nuxeo.com/browse/NXDRIVE-1851): The config parser does not handle float values
 - [NXDRIVE-1855](https://jira.nuxeo.com/browse/NXDRIVE-1855): Add notifications for Direct Transfer actions
 - [NXDRIVE-1856](https://jira.nuxeo.com/browse/NXDRIVE-1856): Prevent duplicate creation via Direct Transfer
+- [NXDRIVE-1857](https://jira.nuxeo.com/browse/NXDRIVE-1857): Handle multi-account for Direct Transfers
 - [NXDRIVE-1859](https://jira.nuxeo.com/browse/NXDRIVE-1859): [Windows] Fix the special file check for folder icon
 - [NXDRIVE-1860](https://jira.nuxeo.com/browse/NXDRIVE-1860): Skip any `OSError` when trying to compress log files
 - [NXDRIVE-1861](https://jira.nuxeo.com/browse/NXDRIVE-1861): [macOS] Fix `AttributeError`: 'SBApplication' object has no attribute 'documents'

--- a/nxdrive/data/i18n/i18n.json
+++ b/nxdrive/data/i18n/i18n.json
@@ -248,6 +248,7 @@
     "SECTION_ABOUT": "About",
     "SECTION_ACCOUNTS": "Accounts",
     "SECTION_GENERAL": "General",
+    "SELECT_ACCOUNT": "Select an account:",
     "SELECT_ALL": "Select all",
     "SELECTIVE_SYNC": "Selective Sync",
     "SELECTIVE_SYNC_DESCR": "Select which folder you want to see on this computer. Any folders you unselect won't be shown on this computer, but you can still access them online.",


### PR DESCRIPTION
A popup with accounts is shown first when there is more than 1 account registered.

If the user hit ESC or click on Cancel, the upload is aborted.

When hitting ENTER or clicking on OK, the selected account is used for the Direct Transfer. There is no sorting on accounts yet, the first printed will be used by default.