### PR TITLE
NXDRIVE-1853: Allow to Direct Transfer a folder and its contents

### DIFF
--- a/docs/changes/4.2.1.md
+++ b/docs/changes/4.2.1.md
@@ -8,6 +8,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-619](https://jira.nuxeo.com/browse/NXDRIVE-619): Keynote files should be synced
 - [NXDRIVE-1838](https://jira.nuxeo.com/browse/NXDRIVE-1838): Allow for one time synchronization of a file (Direct Transfer)
 - [NXDRIVE-1851](https://jira.nuxeo.com/browse/NXDRIVE-1851): The config parser does not handle float values
+- [NXDRIVE-1853](https://jira.nuxeo.com/browse/NXDRIVE-1853): Allow to Direct Transfer a folder and its contents
 - [NXDRIVE-1855](https://jira.nuxeo.com/browse/NXDRIVE-1855): Add notifications for Direct Transfer actions
 - [NXDRIVE-1856](https://jira.nuxeo.com/browse/NXDRIVE-1856): Prevent duplicate creation via Direct Transfer
 - [NXDRIVE-1857](https://jira.nuxeo.com/browse/NXDRIVE-1857): Handle multi-account for Direct Transfers
@@ -122,6 +123,8 @@ Release date: `2019-xx-xx`
 - Added notification.py::`DirectTransferError()`
 - Added notification.py::`DirectTransferStatus()`
 - Added utils.py::`ga_user_agent()`
+- Added utils.py::`get_tree_size()`
+- Added utils.py::`get_tree_list()`
 - Added fatal_error.py::`check_os_version()`
 - Changed `LocalClient.has_folder_icon()` to return only a boolean
 - Removed `url` argument from `DirectEdit.__init__()`

--- a/nxdrive/client/local/base.py
+++ b/nxdrive/client/local/base.py
@@ -78,8 +78,7 @@ class FileInfo:
         # Function to use
         self._digest_func = kwargs.pop("digest_func", "MD5").lower()
 
-        # Precompute base name once and for all are it's often useful in
-        # practice
+        # Precompute base name once and for all as it's often useful in practice
         self.name = self.filepath.name
 
     def __repr__(self) -> str:

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -688,14 +688,19 @@ class Remote(Nuxeo):
             raise DirectTransferDuplicateFoundError(file, doc)
 
         if not doc:
-            # Create the file on the server
+            # Create the document on the server
+            nature = "File" if file.is_file() else "Folder"
             doc = self.documents.create(
                 Document(
-                    name=file.name, type="File", properties={"dc:title": file.name}
+                    name=file.name, type=nature, properties={"dc:title": file.name}
                 ),
                 parent_path=parent_path,
             )
             remote_ref = doc.uid
+
+        # If the path is a folder, there is no more work to do
+        if file.is_dir():
+            return
 
         # Save the remote document's UID into the file xattrs, in case next steps fails
         LocalClient.set_path_remote_id(file, remote_ref, name="remote")

--- a/nxdrive/data/i18n/i18n.json
+++ b/nxdrive/data/i18n/i18n.json
@@ -157,6 +157,7 @@
     "LOADING": "Loading …",
     "LOADING_ERROR": "Loading error",
     "LOCAL_FILE": "Local file",
+    "LOCAL_FOLDER": "Local folder",
     "LOCKED": "Locked document",
     "LOCKED_FILE": "Cannot update „%1“ as it was locked by %2 on %3",
     "LOCK_NOTIFICATION_DESCRIPTION": "The document „%1“ has been locked",

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -1423,13 +1423,7 @@ class Application(QApplication):
         return selected_engine
 
     def ctx_upload_local_file(self, path: Path) -> None:
-        """Direct Transfer of a local file to anywhere on the server."""
-        # For now, only files are handled
-        if not path.is_file():
-            log.warning(
-                f"Direct Transfer of {path!r} is not possible (a file is needed)"
-            )
-            return
+        """Direct Transfer of local files and folders to anywhere on the server."""
 
         # Direct Transfer is not allowed for synced files
         engines = list(self.manager.engines.values())
@@ -1442,6 +1436,7 @@ class Application(QApplication):
 
         log.info(f"Direct Transfer: {path!r}")
 
+        # Select the good account to use
         if len(engines) > 1:
             # The user has to select the desired account
             engine: Optional[Engine] = self._select_account(engines)

--- a/nxdrive/gui/folders_dialog.py
+++ b/nxdrive/gui/folders_dialog.py
@@ -17,7 +17,7 @@ from .folders_model import FoldersOnly, FilteredDocuments
 from ..constants import APP_NAME
 from ..engine.engine import Engine
 from ..translator import Translator
-from ..utils import sizeof_fmt
+from ..utils import get_tree_size, sizeof_fmt
 
 if TYPE_CHECKING:
     from .application import Application  # noqa
@@ -201,10 +201,17 @@ class FoldersDialog(DialogMixin):
 
         self.path = path
 
-        # Add a new widget at 1st position: a text input with the local file to upload
+        if path.is_dir():
+            label = "LOCAL_FOLDER"
+            file_size = get_tree_size(path)
+        else:
+            label = "LOCAL_FILE"
+            file_size = path.stat().st_size
+
+        # Add a new widget at 1st position: a text input with the local path and content size
         local_file_layout = QHBoxLayout()
-        local_file_lbl = QLabel(Translator.get("LOCAL_FILE"))
-        local_file_size_lbl = QLabel(sizeof_fmt(path.stat().st_size))
+        local_file_lbl = QLabel(Translator.get(label))
+        local_file_size_lbl = QLabel(sizeof_fmt(file_size))
         local_file = QLineEdit()
         local_file.setTextMargins(5, 0, 5, 0)
         local_file.setText(str(path))
@@ -235,5 +242,5 @@ class FoldersDialog(DialogMixin):
 
     def accept(self) -> None:
         """Action to do when the OK button is clicked."""
-        self.engine.direct_transfer(self.path, self.remote_folder.text())
         super().accept()
+        self.engine.direct_transfer(self.path, self.remote_folder.text())


### PR DESCRIPTION
I reviewed the notifications to not flood the user:

- When the user has selected the remote folder, a notif saying the upload is planned is shown.
- When a folder is uploaded, no notif.
- When a file is uploaded and it is considered a "big file" (depending of the `big_file` option), a notif saying the upload was done is shown.

If the folder already exists on the server, contents are merged. If there are duplicates, a popup asks the user what to do.