### PR TITLE
NXDRIVE-1919: Remove staled transfers at startup

### DIFF
--- a/docs/changes/4.2.1.md
+++ b/docs/changes/4.2.1.md
@@ -33,7 +33,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1902](https://jira.nuxeo.com/browse/NXDRIVE-1902): Add the update channel in analytics report
 - [NXDRIVE-1909](https://jira.nuxeo.com/browse/NXDRIVE-1909): [Context Menu] Remove the token from generated URLs
 - [NXDRIVE-1915](https://jira.nuxeo.com/browse/NXDRIVE-1915): Fix local file creation when checking for an already synced file on the HDD
-
+- [NXDRIVE-1919](https://jira.nuxeo.com/browse/NXDRIVE-1919): Remove staled transfers at startup
 ## GUI
 
 - [NXDRIVE-1826](https://jira.nuxeo.com/browse/NXDRIVE-1826): Systray icon is blurry on macOS dark mode
@@ -88,6 +88,7 @@ Release date: `2019-xx-xx`
 - Added `Engine.direct_transfer()`
 - Added `Engine.direct_transfer_cancel()`
 - Added `Engine.direct_transfer_replace_blob()`
+- Added `Engine.remove_staled_transfers()`
 - Added `EngineDAO.update_pair_state()`
 - Changed `EngineDAO.get_download()` to return a generator instead of a list
 - Changed `EngineDAO.get_upload()` to return a generator instead of a list

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -298,6 +298,7 @@ class Remote(Nuxeo):
                 filesize=size,
                 doc_pair=kwargs.pop("doc_pair_id", None),
                 engine=kwargs.pop("engine_uid", None),
+                is_direct_edit=kwargs.pop("is_direct_edit", False),
             )
             self.dao.save_download(download)
 

--- a/nxdrive/direct_edit.py
+++ b/nxdrive/direct_edit.py
@@ -293,6 +293,8 @@ class DirectEdit(Worker):
                         file_out,
                         blob.digest,
                         callback=self.stop_client,
+                        is_direct_edit=True,
+                        engine_uid=engine.uid,
                     )
                 finally:
                     engine.dao.remove_transfer("download", file_path)

--- a/tests/old_functional/test_remote_client.py
+++ b/tests/old_functional/test_remote_client.py
@@ -96,7 +96,9 @@ class TestRemoteFileSystemClient(OneUserTest):
         ).uid
         file_path = self.local_test_folder_1 / "Document 1.txt"
         file_out = Path(mkdtemp()) / file_path.name
-        tmp_file = remote.stream_content(fs_item_id, file_path, file_out)
+        tmp_file = remote.stream_content(
+            fs_item_id, file_path, file_out, engine_uid=self.engine_1.uid
+        )
         assert tmp_file.exists()
         assert tmp_file.name == "Document 1.txt"
         assert tmp_file.read_bytes() == b"Content of doc 1."


### PR DESCRIPTION
The issue fixed is that there may have transfers with the ONGOING status at startup. This is nonsens and reflect an past error. The fix is quite simple: remove them.

I also refactored `Engine.resume_suspended_transfers()`.