### PR TITLE
NXDRIVE-1864: Retry later when a MaxRetryError occures

### DIFF
--- a/docs/changes/4.2.1.md
+++ b/docs/changes/4.2.1.md
@@ -17,6 +17,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1861](https://jira.nuxeo.com/browse/NXDRIVE-1861): [macOS] Fix `AttributeError`: 'SBApplication' object has no attribute 'documents'
 - [NXDRIVE-1862](https://jira.nuxeo.com/browse/NXDRIVE-1862): Only upload files from the DirectEdit directory
 - [NXDRIVE-1863](https://jira.nuxeo.com/browse/NXDRIVE-1863): Handle pair state modified-created as a conflict
+- [NXDRIVE-1864](https://jira.nuxeo.com/browse/NXDRIVE-1864): Retry later when a `MaxRetryError` occures
 - [NXDRIVE-1867](https://jira.nuxeo.com/browse/NXDRIVE-1867): Fix mypy issues following the update to mypy 0.730
 - [NXDRIVE-1868](https://jira.nuxeo.com/browse/NXDRIVE-1868): [macOS] Use a custom trash implementation instead of using Send2Trash
 - [NXDRIVE-1871](https://jira.nuxeo.com/browse/NXDRIVE-1871): Use the public Batch upload index

--- a/nxdrive/constants.py
+++ b/nxdrive/constants.py
@@ -3,6 +3,7 @@ import errno
 from enum import Enum, auto
 from pathlib import Path
 from sys import platform
+from urllib3.exceptions import MaxRetryError
 
 from requests.exceptions import ChunkedEncodingError, ConnectionError, Timeout
 
@@ -78,7 +79,7 @@ if WINDOWS:
     # OSError: Couldn't perform operation. Error code: 1223 (seems related to long paths)
     LONG_FILE_ERRORS.add(1223)
 
-CONNECTION_ERROR = (ChunkedEncodingError, ConnectionError, Timeout)
+CONNECTION_ERROR = (ChunkedEncodingError, ConnectionError, MaxRetryError, Timeout)
 
 
 class DelAction(Enum):


### PR DESCRIPTION
Added `MaxRetryError` to the `CONNECTION_ERROR` constant.