### PR TITLE
NXDRIVE-1932: Send Direct Transfer analytics using its own category

### DIFF
--- a/docs/changes/4.3.1.md
+++ b/docs/changes/4.3.1.md
@@ -4,7 +4,7 @@ Release date: `2019-xx-xx`
 
 ## Core
 
-- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
+- [NXDRIVE-1932](https://jira.nuxeo.com/browse/NXDRIVE-1932): Send Direct Transfer analytics using its own category
 
 ## GUI
 
@@ -28,4 +28,5 @@ Release date: `2019-xx-xx`
 
 ## Technical Changes
 
--
+- Added `Manager.directTransferStats` signal
+- Added `Tracker.send_direct_transfer()`

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -505,6 +505,8 @@ class Processor(EngineWorker):
         if not doc_pair.folderish and doc_pair.size >= Options.big_file * 1024 * 1024:
             self.engine.directTranferStatus.emit(file, False)
 
+        self.engine.manager.directTransferStats.emit(doc_pair.folderish, doc_pair.size)
+
     def _synchronize_direct_transfer_replace_blob(self, doc_pair: DocPair) -> None:
         """Force the blob replacement of the remote document (choice done by the user)."""
         self._synchronize_direct_transfer(doc_pair, replace_blob=True)

--- a/nxdrive/engine/tracker.py
+++ b/nxdrive/engine/tracker.py
@@ -189,6 +189,13 @@ class Tracker(PollWorker):
             category="DirectEdit", action="Edit", label=extension.lower(), value=timing
         )
 
+    @pyqtSlot(bool, int)
+    def send_direct_transfer(self, folderish: bool, size: int) -> None:
+        nature = "folder" if folderish else "file"
+        self.send_event(
+            category="DirectTransfer", action="Sent", label=nature, value=size
+        )
+
     @pyqtSlot()
     def send_stats(self) -> None:
         for engine in self._manager.engines.values():

--- a/nxdrive/manager.py
+++ b/nxdrive/manager.py
@@ -76,6 +76,10 @@ class Manager(QObject):
     resumed = pyqtSignal()
     directEdit = pyqtSignal(str, str, str, str)
 
+    # Direct Transfer statistics
+    # args: folderish document, document size
+    directTransferStats = pyqtSignal(bool, int)
+
     _instances: Dict[Path, CallableProxyType] = {}
     __device_id = None
     autolock_service: ProcessAutoLockerWorker
@@ -269,6 +273,9 @@ class Manager(QObject):
 
         # Start the tracker when we launch
         self.started.connect(tracker.thread.start)
+
+        # Connect Direct Transfer metrics
+        self.directTransferStats.connect(tracker.send_direct_transfer)
 
         # Connect DirectEdit metrics
         self.direct_edit.openDocument.connect(tracker.send_directedit_open)

--- a/tests/functional/test_tracker.py
+++ b/tests/functional/test_tracker.py
@@ -31,5 +31,7 @@ def test_tracker_send_methods(manager_factory, monkeypatch):
         tracker.send_directedit_open("Jean-Michel Jarre - Oxygen.ogg", 42)
         tracker.send_directedit_edit("Jean-Michel Jarre - Oxygen", 42)
         tracker.send_directedit_edit("Jean-Michel Jarre - Oxygen.ogg", 42)
+        tracker.send_direct_transfer(True, 0)
+        tracker.send_direct_transfer(False, 42)
         tracker.send_sync_event(metrics)
         tracker._poll()


### PR DESCRIPTION
A new category "DirectTransfer" is added with one action "Sent". Events will have the document's type (either file or folder) and the document's size in bytes (0 for folders).
Events will be sent when the Direct Transfer is done.