### PR TITLE
NXDRIVE-1944: Fix mypy issues following the update to mypy 0.740

### DIFF
--- a/docs/changes/4.3.1.md
+++ b/docs/changes/4.3.1.md
@@ -7,6 +7,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1932](https://jira.nuxeo.com/browse/NXDRIVE-1932): Send Direct Transfer analytics using its own category
 - [NXDRIVE-1942](https://jira.nuxeo.com/browse/NXDRIVE-1942): Small Direct Edit improvements
 - [NXDRIVE-1944](https://jira.nuxeo.com/browse/NXDRIVE-1944): Fix exception type when the parent folder is not yet sync on remote creation
+- [NXDRIVE-1945](https://jira.nuxeo.com/browse/NXDRIVE-1945): Fix mypy issues following the update to mypy 0.740
 
 ## GUI
 

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -333,7 +333,8 @@ class Remote(Nuxeo):
                 self.check_integrity(digest, action)
             else:
                 with memoryview(resp.content) as view, file_out.open(mode="wb") as f:
-                    f.write(view)
+                    # TODO: NXDRIVE-1945, remove "type: ignore" when mypy 0.750 comes out
+                    f.write(view)  # type: ignore
                     # Force write of file to disk
                     f.flush()
                     os.fsync(f.fileno())

--- a/nxdrive/commandline.py
+++ b/nxdrive/commandline.py
@@ -572,7 +572,7 @@ class CliHandler:
         named_pipe = f"{BUNDLE_IDENTIFIER}.protocol.{pid}"
         log.debug(
             f"Opening a local socket to the running instance on {named_pipe} "
-            f"(payload={self.redact_payload(payload)})"
+            f"(payload={self.redact_payload(payload)!r})"
         )
         client = QLocalSocket()
         try:

--- a/nxdrive/manager.py
+++ b/nxdrive/manager.py
@@ -633,7 +633,7 @@ class Manager(QObject):
 
     def _get_engine_name(self, server_url: str) -> str:
         urlp = urlparse(server_url)
-        return urlp.hostname
+        return urlp.hostname or ""
 
     def check_local_folder_available(self, path: Path) -> bool:
         if not self._engine_definitions:


### PR DESCRIPTION
Fixed these errors:
```bash
manager.py:636:
Incompatible return value type (got "Optional[str]", expected "str")

commandline.py:574:
On Python 3 '{}'.format(b'abc') produces "b'abc'"; use !r if this is a desired behavior
```

There is also a false positive ignored for now (should be fixed in the next mypy release, see python/mypy#7717).