### PR TITLE
NXDRIVE-1946: Fix a deprecation warning in pytest 5.3.0

### DIFF
--- a/docs/changes/4.3.1.md
+++ b/docs/changes/4.3.1.md
@@ -21,6 +21,7 @@ Release date: `2019-xx-xx`
 
 - [NXDRIVE-1936](https://jira.nuxeo.com/browse/NXDRIVE-1936): Fix a warning in tests
 - [NXDRIVE-1938](https://jira.nuxeo.com/browse/NXDRIVE-1938): Fix tests not starting on the CI
+- [NXDRIVE-1946](https://jira.nuxeo.com/browse/NXDRIVE-1946): Fix a deprecation warning in pytest 5.3.0
 
 ## Doc
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ exclude =
     tools/whitelist.py
 
 [tool:pytest]
+junit_family = legacy
 addopts =
     --cov-report=
     --cov-report=html


### PR DESCRIPTION
Fixes:
```bash
PytestDeprecationWarning: The 'junit_family' default value will change to 'xunit2' in pytest 6.0.
Add 'junit_family=legacy' to your pytest.ini file to silence this warning and make your suite compatible.
```