### PR TITLE
NXDRIVE-1948: Fix local variable 'upload' referenced before assignmen…

### DIFF
--- a/docs/changes/4.3.1.md
+++ b/docs/changes/4.3.1.md
@@ -8,6 +8,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1942](https://jira.nuxeo.com/browse/NXDRIVE-1942): Small Direct Edit improvements
 - [NXDRIVE-1944](https://jira.nuxeo.com/browse/NXDRIVE-1944): Fix exception type when the parent folder is not yet sync on remote creation
 - [NXDRIVE-1945](https://jira.nuxeo.com/browse/NXDRIVE-1945): Fix mypy issues following the update to mypy 0.740
+- [NXDRIVE-1948](https://jira.nuxeo.com/browse/NXDRIVE-1948): Fix local variable 'upload' referenced before assignment in `Remote.upload_chunks()`
 
 ## GUI
 

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -445,6 +445,8 @@ class Remote(Nuxeo):
 
         batch = None
         chunk_size = None
+        upload: Optional[Upload] = None
+
         try:
             # See if there is already a transfer for this file
             upload = self.dao.get_upload(path=file_path)
@@ -566,7 +568,7 @@ class Remote(Nuxeo):
                 log.debug(f"Upload progression stopped at {percent:.2f}%")
 
                 # Save the progression
-                if upload:  # mypy fix ...
+                if upload:
                     upload.progress = percent
                     self.dao.set_transfer_progress("upload", upload)
 


### PR DESCRIPTION
…t in `Remote.upload_chunks()`.

Note to myself: listen to Mypy! :)