### PR TITLE
NXDRIVE-1949: Fix 'Application' object has no attribute '_last_refres…

### DIFF
--- a/docs/changes/4.3.1.md
+++ b/docs/changes/4.3.1.md
@@ -9,6 +9,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1944](https://jira.nuxeo.com/browse/NXDRIVE-1944): Fix exception type when the parent folder is not yet sync on remote creation
 - [NXDRIVE-1945](https://jira.nuxeo.com/browse/NXDRIVE-1945): Fix mypy issues following the update to mypy 0.740
 - [NXDRIVE-1948](https://jira.nuxeo.com/browse/NXDRIVE-1948): Fix local variable 'upload' referenced before assignment in `Remote.upload_chunks()`
+- [NXDRIVE-1949](https://jira.nuxeo.com/browse/NXDRIVE-1949): Fix `Application` object has no attribute `_last_refresh_view`
 
 ## GUI
 

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -145,6 +145,9 @@ class Application(QApplication):
         self._init_translator()
         self.setQuitOnLastWindowClosed(False)
 
+        # Timer used to refresh the files list in the systray menu, see .refresh_files()
+        self._last_refresh_view = 0.0
+
         if not self.manager.preferences_metrics_chosen:
             self.show_metrics_acceptance()
             # Start the tracker now, if needed
@@ -196,9 +199,6 @@ class Application(QApplication):
         # Handle the eventual command via the custom URL scheme
         if Options.protocol_url:
             self._handle_nxdrive_url(Options.protocol_url)
-
-        # Timer used to refresh the files list in the systray menu, see .refresh_files()
-        self._last_refresh_view = 0.0
 
     @if_frozen
     def add_qml_import_path(self, view: QQuickView) -> None:


### PR DESCRIPTION
…h_view'

Declare the attribute earlier in `__init__()` to make it visible for everyone as soon as possible.