### PR TITLE
NXDRIVE-1953: Fix the cursor loading logic when the QTreeView…

### DIFF
--- a/docs/changes/4.3.1.md
+++ b/docs/changes/4.3.1.md
@@ -14,7 +14,7 @@ Release date: `2019-xx-xx`
 
 ## GUI
 
-- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
+- [NXDRIVE-1953](https://jira.nuxeo.com/browse/NXDRIVE-1953): Fix the cursor loading logic when the QTreeView window is deleted early
 
 ## Packaging / Build
 

--- a/nxdrive/gui/folders_treeview.py
+++ b/nxdrive/gui/folders_treeview.py
@@ -65,10 +65,15 @@ class TreeViewMixin(QTreeView):
         When busy, it means children are being fetched (i.e. a HTTP call is ongoing).
         In that case, change the cursor to let the user know something is happening.
         """
-        if busy:
-            self.setCursor(Qt.BusyCursor)
-        else:
-            self.unsetCursor()
+        try:
+            if busy:
+                self.setCursor(Qt.BusyCursor)
+            else:
+                self.unsetCursor()
+        except RuntimeError:
+            # RuntimeError: wrapped C/C++ object of type FolderTreeView has been deleted
+            # May happen if the window is deleted early.
+            pass
 
 
 class DocumentTreeView(TreeViewMixin):


### PR DESCRIPTION
… window is deleted early