### PR TITLE
NXDRIVE-1955: [macOS] Fix opened documents retrieval not interating-safe

### DIFF
--- a/docs/changes/4.3.1.md
+++ b/docs/changes/4.3.1.md
@@ -11,6 +11,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1948](https://jira.nuxeo.com/browse/NXDRIVE-1948): Fix local variable 'upload' referenced before assignment in `Remote.upload_chunks()`
 - [NXDRIVE-1949](https://jira.nuxeo.com/browse/NXDRIVE-1949): Fix `Application` object has no attribute `_last_refresh_view`
 - [NXDRIVE-1950](https://jira.nuxeo.com/browse/NXDRIVE-1950): [macOS] Remove obsolete backup folder before doing the backup
+- [NXDRIVE-1955](https://jira.nuxeo.com/browse/NXDRIVE-1955): [macOS] Fix opened documents retrieval not interating-safe
 
 ## GUI
 

--- a/nxdrive/osi/darwin/files.py
+++ b/nxdrive/osi/darwin/files.py
@@ -52,7 +52,7 @@ def _get_opened_files_adobe_cc(identifier: str) -> Iterator[Item]:
         return
 
     try:
-        documents = app.documents()
+        documents = list(app.documents())
     except AttributeError:
         return
     if not documents:


### PR DESCRIPTION
If the user closes one or more documents in-between the time the documents list was retrieved and the time the list is processed, that error happens:
```
NSRangeException - *** -[NSArray getObjects:range:]: range {...} extends beyond bounds [...]
````