### PR TITLE
NXDRIVE-1853: [Windows] Fix blob check for TestDirectTransferFolder tests

### DIFF
--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -490,6 +490,14 @@ class Processor(EngineWorker):
 
         # The remote path is stored as the remote ref in xattrs of the file
         parent_path = self.local.get_remote_id(file)
+        if not parent_path:
+            self.engine.directTranferError.emit(file)
+            log.warning(
+                f"Cancelling Direct Transfer of {file!r} because it has no remote path set"
+            )
+            self.dao.remove_state(doc_pair)
+            self.dao.remove_transfer("upload", file)
+            return
 
         # Do the upload
         self.remote.direct_transfer(

--- a/tests/old_functional/test_direct_transfer.py
+++ b/tests/old_functional/test_direct_transfer.py
@@ -546,12 +546,14 @@ class TestDirectTransferFolder(OneUserTest):
 
         # Check files exist on the server with their attached blob
         for file in self.files:
-            doc = str(file.relative_to(self.folder))
-            assert self.has_blob(doc)
+            # .as_posix() is needed to replace "\\" with "/" on Windows
+            doc = file.relative_to(self.folder).as_posix()
+            assert self.has_blob(str(doc))
 
         # Check subfolders
         for folder in self.folders:
-            doc = str(folder.relative_to(self.folder))
+            # .as_posix() is needed to replace "\\" with "/" on Windows
+            doc = folder.relative_to(self.folder).as_posix()
             assert self.root_remote.documents.get(path=f"{self.ws.path}/{doc}")
 
     def test_folder(self):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -423,6 +423,12 @@ def test_get_tree_list():
         assert isinstance(local_path, Path)
 
 
+def test_get_tree_size():
+    location = nxdrive.utils.normalized_path(__file__).parent.parent
+    path = location / "resources"
+    assert nxdrive.utils.get_tree_size(path) == 3111940
+
+
 @Options.mock()
 def test_if_frozen_decorator():
     @nxdrive.utils.if_frozen

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -413,6 +413,16 @@ def test_get_timestamp_from_date():
     assert nxdrive.utils.get_timestamp_from_date(dtime) == 1_560_988_800
 
 
+def test_get_tree_list():
+    location = nxdrive.utils.normalized_path(__file__).parent.parent
+    path = location / "resources"
+    remote_ref = "/default-domain/workspaces/foo"
+    for ref, local_path in nxdrive.utils.get_tree_list(path, remote_ref):
+        assert ref.startswith(remote_ref)
+        assert "\\" not in ref
+        assert isinstance(local_path, Path)
+
+
 @Options.mock()
 def test_if_frozen_decorator():
     @nxdrive.utils.if_frozen


### PR DESCRIPTION
Also:
- NXDRIVE-1956: Handle the case when the remote path is no more set in the xattrs.
- Added more tests for new functions.