### PR TITLE
NXDRIVE-1579: Disable synchronization upon server configuration

### DIFF
--- a/docs/changes/4.3.1.md
+++ b/docs/changes/4.3.1.md
@@ -4,6 +4,7 @@ Release date: `2019-xx-xx`
 
 ## Core
 
+- [NXDRIVE-1579](https://jira.nuxeo.com/browse/NXDRIVE-1579): Disable synchronization upon server configuration
 - [NXDRIVE-1932](https://jira.nuxeo.com/browse/NXDRIVE-1932): Send Direct Transfer analytics using its own category
 - [NXDRIVE-1941](https://jira.nuxeo.com/browse/NXDRIVE-1941): Handle invalid filenames when solving duplicate issue in the RemoteWatcher
 - [NXDRIVE-1942](https://jira.nuxeo.com/browse/NXDRIVE-1942): Small Direct Edit improvements
@@ -40,4 +41,5 @@ Release date: `2019-xx-xx`
 
 - Removed `Engine.get_remote_token()`
 - Added `Manager.directTransferStats` signal
+- Added `Options.synchronization_enabled`
 - Added `Tracker.send_direct_transfer()`

--- a/docs/changes/4.3.1.md
+++ b/docs/changes/4.3.1.md
@@ -38,5 +38,6 @@ Release date: `2019-xx-xx`
 
 ## Technical Changes
 
+- Removed `Engine.get_remote_token()`
 - Added `Manager.directTransferStats` signal
 - Added `Tracker.send_direct_transfer()`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,6 +59,7 @@ Parameter values are taken as is, except for booleans. In that case, you can spe
 | `proxy-server` | None | str | 2 | Define the address of the proxy server (e.g. `http://proxy.example.com:3128`). This can also be set up by the user from the Settings window.
 | `ssl-no-verify` | False | bool | 4.0.1 | Define if SSL errors should be ignored. Highly unadvised to enable this option.
 | `sync-and-quit` | False | bool | 4.2.0 | Launch the synchronization and then exit the application.
+| `synchronization_enabled` | True | bool | 4.4.0 | Synchronization features are enabled. If set to `False`, nothing will be downloaded/uploaded/synchronized but Direct Edit and Direct Transfer will work.
 | `tmp_file_limit` | 10.0 | float | 4.1.4 | File size in MiB. Files smaller than this limit will be written at once to the file rather than chunk by chunk.
 | `timeout` | 30 | int | 2 | Define the socket timeout.
 | `update-check-delay` | 3600 | int | 2 | Define the auto-update check delay. 0 means disabled.

--- a/nxdrive/data/qml/AccountsTab.qml
+++ b/nxdrive/data/qml/AccountsTab.qml
@@ -32,7 +32,7 @@ Rectangle {
             id: accountSelect
             anchors {
                 left: parent.left
-                leftMargin: 185
+                leftMargin: sync_enabled ? 185 : 105
             }
         }
     }
@@ -95,7 +95,6 @@ Rectangle {
                         onClicked: api.set_server_ui(uid, "web")
                         checked: (forceUi == "web")
                         Layout.alignment: Qt.AlignTop
-                        Layout.leftMargin: -8
                         Layout.topMargin: -10
                     }
                     NuxeoRadioButton {
@@ -106,25 +105,32 @@ Rectangle {
                         onClicked: api.set_server_ui(uid, "jsf")
                         checked: (forceUi == "jsf")
                         Layout.alignment: Qt.AlignTop
-                        Layout.leftMargin: -8
                         Layout.topMargin: -5
                     }
                 }
 
                 // Local folder
-                ScaledText { text: qsTr("ENGINE_FOLDER") + tl.tr; color: mediumGray }
+                ScaledText {
+                    text: qsTr("ENGINE_FOLDER") + tl.tr
+                    visible: sync_enabled
+                    color: mediumGray
+                }
                 Link {
                     text: folder
+                    visible: sync_enabled
                     onClicked: api.open_local(accountSelect.getRole("uid"), "/")
                 }
 
                 // Filters
                 ScaledText {
                     text: qsTr("SELECTIVE_SYNC") + tl.tr
+                    visible: sync_enabled
                     color: mediumGray
                     Layout.alignment: Qt.AlignTop
                 }
                 ColumnLayout {
+                    visible: sync_enabled
+
                     ScaledText {
                         text: qsTr("SELECTIVE_SYNC_DESCR") + tl.tr
                         Layout.maximumWidth: 400
@@ -139,10 +145,12 @@ Rectangle {
 
                 // Conflicts/Errors
                 ScaledText {
+                    visible: sync_enabled
                     text: qsTr("CONFLICTS_AND_ERRORS") + tl.tr
                     color: mediumGray
                 }
                 Link {
+                    visible: sync_enabled
                     text: qsTr("OPEN_WINDOW") + tl.tr
                     onClicked: api.show_conflicts_resolution(uid)
                 }

--- a/nxdrive/data/qml/Systray.qml
+++ b/nxdrive/data/qml/Systray.qml
@@ -253,7 +253,7 @@ Rectangle {
             id: syncState
             state: ""  // Synced
             visible: !(errorState.visible || updateState.visible)
-            text: qsTr("SYNCHRONIZATION_COMPLETED") + tl.tr
+            text: sync_enabled ? qsTr("SYNCHRONIZATION_COMPLETED") + tl.tr : ""
 
             states: [
                 State {

--- a/nxdrive/data/qml/SystrayMenu.qml
+++ b/nxdrive/data/qml/SystrayMenu.qml
@@ -36,7 +36,7 @@ ShadowRectangle {
             id: engineToggle
             property bool isPaused
             property string suspendAction: isPaused ? "RESUME": "SUSPEND"
-            visible: !api.restart_needed()
+            visible: !api.restart_needed() && sync_enabled
 
             text: qsTr(suspendAction) + tl.tr
             onClicked: {

--- a/nxdrive/engine/queue_manager.py
+++ b/nxdrive/engine/queue_manager.py
@@ -390,6 +390,7 @@ class QueueManager(QObject):
 
     def get_metrics(self) -> Metrics:
         metrics = {
+            "is_paused": self.is_paused(),
             "local_folder_queue": self._local_folder_queue.qsize(),
             "local_file_queue": self._local_file_queue.qsize(),
             "remote_folder_queue": self._remote_folder_queue.qsize(),

--- a/nxdrive/engine/watcher/remote_watcher.py
+++ b/nxdrive/engine/watcher/remote_watcher.py
@@ -15,6 +15,7 @@ from ...client.local import FileInfo
 from ...constants import BATCH_SIZE, CONNECTION_ERROR, ROOT, WINDOWS
 from ...exceptions import NotFound, ScrollDescendantsError, ThreadInterrupt
 from ...objects import Metrics, RemoteFileInfo, DocPair, DocPairs
+from ...options import Options
 from ...utils import safe_filename, get_date_from_sqlite
 
 if TYPE_CHECKING:
@@ -597,6 +598,15 @@ class RemoteWatcher(EngineWorker):
         return not online
 
     def _handle_changes(self, first_pass: bool = False) -> bool:
+        # If synchronization features are disabled, we just need to emit
+        # the appropriate signal to let the systray icon be updated.
+        if not Options.synchronization_enabled:
+            if first_pass:
+                self.initiate.emit()
+                return True
+            self.updated.emit()
+            return False
+
         if self._check_offline():
             return False
 

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -330,6 +330,7 @@ class Application(QApplication):
         context.setContextProperty("updater", self.manager.updater)
         context.setContextProperty("ratio", self.ratio)
         context.setContextProperty("update_check_delay", Options.update_check_delay)
+        context.setContextProperty("sync_enabled", Options.synchronization_enabled)
         context.setContextProperty("isFrozen", Options.is_frozen)
         context.setContextProperty("LINUX", LINUX)
         context.setContextProperty("WINDOWS", WINDOWS)

--- a/nxdrive/manager.py
+++ b/nxdrive/manager.py
@@ -339,7 +339,6 @@ class Manager(QObject):
         for uid, engine in self.engines.items():
             if euid is not None and euid != uid:
                 continue
-            log.info(f"Resume engine {uid}")
             engine.resume()
         self.resumed.emit()
 
@@ -350,7 +349,6 @@ class Manager(QObject):
         for uid, engine in self.engines.items():
             if euid is not None and euid != uid:
                 continue
-            log.info(f"Suspend engine {uid}")
             engine.suspend()
         self.suspended.emit()
 
@@ -362,7 +360,6 @@ class Manager(QObject):
             if euid is not None and euid != uid:
                 continue
             if engine.is_started():
-                log.info(f"Stop engine {uid}")
                 engine.stop()
         self.osi.cleanup()
         self.dispose_db()
@@ -374,7 +371,6 @@ class Manager(QObject):
             if euid is not None and euid != uid:
                 continue
             if not self._pause:
-                log.info(f"Launch engine {uid}")
                 try:
                     engine.start()
                 except Exception:

--- a/nxdrive/options.py
+++ b/nxdrive/options.py
@@ -223,6 +223,7 @@ class MetaOptions(type):
         "ssl_no_verify": (False, "default"),
         "startup_page": ("drive_login.jsp", "default"),
         "sync_and_quit": (False, "default"),
+        "synchronization_enabled": (True, "default"),
         "system_wide": (_is_system_wide(), "default"),
         "theme": ("ui5", "default"),
         "timeout": (30, "default"),

--- a/nxdrive/poll_workers.py
+++ b/nxdrive/poll_workers.py
@@ -76,6 +76,18 @@ class ServerOptionsUpdater(PollWorker):
                 # We cannot use fail_on_error=True because the server may
                 # be outdated and still have obsolete options.
                 Options.update(conf, setter="server", fail_on_error=False)
+
+                # Save this option so that it has direct effect at the next start
+                skey = "synchronization_enabled"
+                if skey in conf:
+                    vkey = conf[skey]
+                    if isinstance(vkey, bool):
+                        self.manager.dao.update_config(skey, vkey)
+                    else:
+                        log.warning(
+                            f"Bad value from the server's config.ini: {skey!r}={vkey!r} (a boolean is required)"
+                        )
+
                 break
 
         return True

--- a/tests/old_functional/common.py
+++ b/tests/old_functional/common.py
@@ -820,3 +820,11 @@ class OneUserTest(TwoUsersTest):
         if wait_for_engine_1 and count:
             err += f" for engine 1 (syncing_count={count})"
         log.warning(err)
+
+
+class OneUserNoSync(OneUserTest):
+    """ Tests requiring only one user with synchronization features disabled. """
+
+    def setup_method(self, *args, **kwargs):
+        Options.synchronization_enabled = False
+        super().setup_method(*args, **kwargs)

--- a/tests/old_functional/test_direct_edit.py
+++ b/tests/old_functional/test_direct_edit.py
@@ -14,7 +14,7 @@ from nxdrive.utils import parse_protocol_url, safe_os_filename
 
 from . import LocalTest, make_tmp_file
 from .. import ensure_no_exception
-from .common import OneUserTest, TwoUsersTest
+from .common import OneUserTest, OneUserNoSync, TwoUsersTest
 from ..utils import random_png
 
 log = getLogger(__name__)
@@ -55,7 +55,7 @@ class DirectEditSetup:
             self.direct_edit.stop_client()
 
 
-class TestDirectEdit(OneUserTest, DirectEditSetup):
+class MixinTests(DirectEditSetup):
     def _direct_edit_update(
         self,
         doc_id: str,
@@ -410,31 +410,6 @@ class TestDirectEdit(OneUserTest, DirectEditSetup):
         self.remote.lock(doc_id)
         self._direct_edit_update(doc_id, filename, b"Test")
 
-    def test_synced_file(self):
-        """Test the fact that instead of downloading the file, we get it from the local sync folder."""
-        filename = "M'ode opératoire ツ .txt"
-        doc_id = self.remote.make_file("/", filename, content=b"Some content.")
-
-        self.engine_1.start()
-        self.wait_sync(wait_for_async=True)
-        assert self.local_1.exists(f"/{filename}")
-
-        def download(*_, **__):
-            """
-            Patch Remote.download() and Remote.get_blob()
-            to be able to check that nothing will
-            be downloaded as local data is already there.
-            """
-            assert 0, "No download should be done!"
-
-        with patch.object(self.engine_1.remote, "download", new=download), patch.object(
-            self.engine_1.remote, "get_blob", new=download
-        ), ensure_no_exception():
-            path = self.direct_edit._prepare_edit(self.nuxeo_url, doc_id)
-            assert isinstance(path, Path)
-
-        assert not list(self.engine_1.dao.get_downloads())
-
     def test_url_with_spaces(self):
         scheme, host = self.nuxeo_url.split("://")
         filename = "My file with spaces.txt"
@@ -509,6 +484,41 @@ class TestDirectEdit(OneUserTest, DirectEditSetup):
 
         # Second time: OK
         assert self.direct_edit._lock(self.remote, uid)
+
+
+class TestDirectEdit(OneUserTest, MixinTests):
+    """Direct Edit in "normal" mode, i.e.: when synchronization features are enabled."""
+
+    def test_synced_file(self):
+        """Test the fact that instead of downloading the file, we get it from the local sync folder."""
+        filename = "M'ode opératoire ツ .txt"
+        doc_id = self.remote.make_file("/", filename, content=b"Some content.")
+
+        self.engine_1.start()
+        self.wait_sync(wait_for_async=True)
+        assert self.local_1.exists(f"/{filename}")
+
+        def download(*_, **__):
+            """
+            Patch Remote.download() and Remote.get_blob()
+            to be able to check that nothing will
+            be downloaded as local data is already there.
+            """
+            assert 0, "No download should be done!"
+
+        with patch.object(self.engine_1.remote, "download", new=download), patch.object(
+            self.engine_1.remote, "get_blob", new=download
+        ), ensure_no_exception():
+            path = self.direct_edit._prepare_edit(self.nuxeo_url, doc_id)
+            assert isinstance(path, Path)
+
+        assert not list(self.engine_1.dao.get_downloads())
+
+
+class TestDirectEditNoSync(OneUserNoSync, MixinTests):
+    """Direct Edit should work when synchronization features are not enabled."""
+
+    pass
 
 
 class TestDirectEditLock(TwoUsersTest, DirectEditSetup):


### PR DESCRIPTION
Introduced a new option: `synchronization_enabled` (defaults to `True`).

When that option is set to `False`, local and remote whatchers will be started but nothing will be synced at all; Direct Edit and Direct Transfer features will continue to work as expected. I tried to be the less intrusive as possible.

I duplicated tests for those 2 features: one class in "normal" mode, when sync is effective; and one class with sync disabled.