### PR TITLE
NXDRIVE-1957: Add a test volume pipeline for specific cases

### DIFF
--- a/docs/changes/4.3.1.md
+++ b/docs/changes/4.3.1.md
@@ -31,6 +31,7 @@ Release date: `2019-xx-xx`
 - [NXDRIVE-1936](https://jira.nuxeo.com/browse/NXDRIVE-1936): Fix a warning in tests
 - [NXDRIVE-1938](https://jira.nuxeo.com/browse/NXDRIVE-1938): Fix tests not starting on the CI
 - [NXDRIVE-1946](https://jira.nuxeo.com/browse/NXDRIVE-1946): Fix a deprecation warning in pytest 5.3.0
+- [NXDRIVE-1957](https://jira.nuxeo.com/browse/NXDRIVE-1957): Add a test volume pipeline for specific cases
 
 ## Doc
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,14 @@
+# Nuxeo Drive Tests
+
+You can customize several things using environment variables (see also [env.py](env.py)):
+
+- `REPORT_PATH`: If set to an existing local folder, a ZIP'ed report will be created when a test failed.
+- `SKIP_SENTRY`: Set to `1` to disable Sentry reports (enabled by default).
+- `SENTRY_ENV`: The environment name to ease filtering on Sentry (default is `testing`).
+- `SENTRY_DSN`: The Sentry DSN.
+- `TEST_VOLUME`: [specific to `test_volume.py`] 3 comma-separated values:
+  1. number of `folders`
+  2. number of `files` to create inside each folder
+  3. `depth`: the tree will be replicated into itself `depth` times
+  - total is `???`
+- `TEST_REMOTE_SCAN_VOLUME`: [specific to `test_volume.py`] Minimum number of documents to randomly import (default is `200,000`).

--- a/tests/cleanup.py
+++ b/tests/cleanup.py
@@ -1,28 +1,26 @@
 """Cleanup old test users and workspaces."""
-import os
-
+import env
 from nuxeo.client import Nuxeo
 
 
 def remove_old_ws(server: Nuxeo) -> None:
-    docs = server.documents.get_children(path="/default-domain/workspaces")
+    docs = server.documents.get_children(path=env.WS_DIR)
     for doc in docs:
         if doc.title.startswith(("ndt-", "test_")):
-            print(f"Deleting old {doc}")
             doc.delete()
+            print(f"Deleted old {doc}")
 
 
 def remove_old_users(server: Nuxeo) -> None:
     op = server.operations.new("User.Query")
     op.params = {"username": "ndt-%"}
     for user in op.execute()["users"]:
-        print(f"Deleting old {user}")
         server.users.delete(user["username"])
+        print(f"Deleted old {user}")
 
 
-url = os.getenv("NXDRIVE_TEST_NUXEO_URL", "http://localhost:8080/nuxeo")
-auth = ("Administrator", "Administrator")
-server = Nuxeo(host=url, auth=auth)
+auth = (env.NXDRIVE_TEST_USERNAME, env.NXDRIVE_TEST_PASSWORD)
+server = Nuxeo(host=env.NXDRIVE_TEST_NUXEO_URL, auth=auth)
 server.client.set(schemas=["dublincore"])
 
 remove_old_ws(server)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-import os
 import shutil
 import sys
 
@@ -8,11 +7,11 @@ import nuxeo.operations
 import pytest
 from nuxeo.client import Nuxeo
 
+from . import env
+
 
 pytest_plugins = "tests.pytest_random"
 
-
-DEFAULT_NUXEO_URL = "http://localhost:8080/nuxeo"
 
 # Operations cache
 OPS_CACHE = None
@@ -119,9 +118,7 @@ def version() -> str:
 @pytest.fixture(scope="session")
 def nuxeo_url() -> str:
     """Retrieve the Nuxeo URL."""
-    url = os.getenv("NXDRIVE_TEST_NUXEO_URL", DEFAULT_NUXEO_URL)
-    url = url.split("#")[0]
-    return url
+    return env.NXDRIVE_TEST_NUXEO_URL.split("#")[0]
 
 
 @pytest.fixture(scope="session")

--- a/tests/env.py
+++ b/tests/env.py
@@ -1,0 +1,14 @@
+from os import getenv
+
+
+# The server URL against to run tests
+NXDRIVE_TEST_NUXEO_URL = getenv("NXDRIVE_TEST_NUXEO_URL", "http://localhost:8080/nuxeo")
+
+# The user having administrator rights
+NXDRIVE_TEST_USERNAME = getenv("NXDRIVE_TEST_USERNAME", "Administrator")
+
+# The password associated to the username
+NXDRIVE_TEST_PASSWORD = getenv("NXDRIVE_TEST_PASSWORD", "Administrator")
+
+# The remote path where to store data. Must exist before running tests.
+WS_DIR = getenv("NXDRIVE_TEST_PATH", "/default-domain/workspaces")

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -10,6 +10,8 @@ from nuxeo.documents import Document
 from nuxeo.users import User
 from nxdrive.manager import Manager
 
+from .. import env
+
 log = getLogger(__name__)
 
 
@@ -102,17 +104,15 @@ def user_factory(request, server, faker):
 def obj_factory(request, server):
     """File/Folder/Workspace creation factory with automatic clean-up."""
 
-    parent = "/default-domain/workspaces"
-
     def _make(
         title: str = "",
         nature: str = "Folder",
-        parent: str = parent,
+        parent: str = env.WS_DIR,
         enable_sync: bool = False,
     ):
         title = title or str(uuid4())
         new = Document(name=title, type=nature, properties={"dc:title": title})
-        obj = server.documents.create(new, parent_path=parent)
+        obj = server.documents.create(new, parent_path=env.WS_DIR)
         request.addfinalizer(obj.delete)
         log.info(f"[FIXTURE] Created {obj}")
 

--- a/tests/integration/windows/_test_installer.py
+++ b/tests/integration/windows/_test_installer.py
@@ -5,8 +5,9 @@ from glob import glob
 from logging import getLogger
 
 import pytest
-
 from nxdrive.constants import WINDOWS
+
+from ... import env
 
 if not WINDOWS:
     pytestmark = pytest.mark.skip
@@ -69,13 +70,10 @@ def test_installer_arguments(installer_path):
         TARGETDRIVEFOLDER: The path to the user synchronisation folder that will be created.
         START=auto: Start Nuxeo Drive after the installation.
     """
-    url = os.environ.get("NXDRIVE_TEST_NUXEO_URL", "http://localhost:8080/nuxeo")
-    username = os.environ.get("NXDRIVE_TEST_USER", "Administrator")
-    password = os.environ.get("NXDRIVE_TEST_PASSWORD", "Administrator")
     with Installer(installer_path) as installer:
         args = [
-            '/TARGETURL="%s"' % url,
-            '/TARGETUSERNAME="%s"' % username,
-            '/TARGETPASSWORD="%s"' % password,
+            f'/TARGETURL="{env.NXDRIVE_TEST_NUXEO_URL}"',
+            f'/TARGETUSERNAME="{env.NXDRIVE_TEST_USERNAME}"',
+            f'/TARGETPASSWORD="{env.NXDRIVE_TEST_PASSWORD}"',
         ]
         installer.install(args)

--- a/tests/integration/windows/test_cli_sub_command.py
+++ b/tests/integration/windows/test_cli_sub_command.py
@@ -7,6 +7,7 @@ import pytest
 from nuxeo.documents import Document
 
 from .utils import cb_get, fatal_error_dlg  # , get_opened_url
+from ... import env
 
 
 log = getLogger(__name__)
@@ -129,7 +130,7 @@ def test_complete_scenario_synchronization_from_zero(nuxeo_url, exe, server, tmp
             type="Workspace",
             properties={"dc:title": "sync and stop"},
         )
-        ws = server.documents.create(new, parent_path="/default-domain/workspaces")
+        ws = server.documents.create(new, parent_path=env.WS_DIR)
 
         # 3rd, bind the root (e.g.: enable the sync of the workspace)
         args = f'bind-root "{ws.path}" {local_folder}'
@@ -200,7 +201,7 @@ def test_ctx_menu_entries(nuxeo_url, exe, server, tmp):
             type="Workspace",
             properties={"dc:title": "my workspace"},
         )
-        ws = server.documents.create(new, parent_path="/default-domain/workspaces")
+        ws = server.documents.create(new, parent_path=env.WS_DIR)
 
         # 3rd, bind the root (e.g.: enable the sync of the workspace)
         args = f'bind-root "{ws.path}" {local_folder}'

--- a/tests/old_functional/__init__.py
+++ b/tests/old_functional/__init__.py
@@ -9,7 +9,6 @@ import nuxeo.client
 import nuxeo.constants
 import nuxeo.operations
 from nuxeo.exceptions import HTTPError
-
 from nxdrive.client.local import LocalClient
 from nxdrive.client.remote_client import Remote
 from nxdrive.objects import NuxeoDocumentInfo, RemoteFileInfo

--- a/tests/old_functional/test_group_changes.py
+++ b/tests/old_functional/test_group_changes.py
@@ -3,7 +3,8 @@ from logging import getLogger
 
 from nuxeo.models import Document, Group
 
-from .common import OneUserTest, TEST_WS_DIR, root_remote, salt
+from .common import OneUserTest, root_remote, salt
+from .. import env
 
 log = getLogger(__name__)
 
@@ -36,7 +37,7 @@ class TestGroupChanges(OneUserTest):
                 type="Workspace",
                 properties={"dc:title": workspace_name},
             ),
-            parent_path=TEST_WS_DIR,
+            parent_path=env.WS_DIR,
         )
         self.workspace_path = self.workspace_group.path
 

--- a/tests/old_functional/test_local_move_and_rename.py
+++ b/tests/old_functional/test_local_move_and_rename.py
@@ -4,15 +4,15 @@ import time
 from itertools import product
 from pathlib import Path
 from time import sleep
+from unittest.mock import patch
 
 import pytest
-from unittest.mock import patch
 from nuxeo.exceptions import HTTPError
-
 from nxdrive.engine.dao.sqlite import EngineDAO
+
 from . import DocRemote, LocalTest
 from .common import OS_STAT_MTIME_RESOLUTION, OneUserTest, TwoUsersTest
-
+from .. import env
 
 # TODO NXDRIVE-170: refactor
 
@@ -571,10 +571,10 @@ class TestLocalMoveAndRename(OneUserTest):
         # test workspace.
         remote = DocRemote(
             self.nuxeo_url,
-            "Administrator",
+            env.NXDRIVE_TEST_USERNAME,
             "nxdrive-test-administrator-device",
             self.version,
-            password="Administrator",
+            password=env.NXDRIVE_TEST_PASSWORD,
             base_folder=self.workspace,
         )
         folder_1_uid = remote.get_info("/Original Folder 1").uid

--- a/tests/old_functional/test_remote_move_and_rename.py
+++ b/tests/old_functional/test_remote_move_and_rename.py
@@ -10,6 +10,7 @@ from nxdrive.engine.engine import Engine
 from nxdrive.options import Options
 
 from . import DocRemote, LocalTest
+from .. import env
 from .common import REMOTE_MODIFICATION_TIME_RESOLUTION, SYNC_ROOT_FAC_ID, OneUserTest
 from ..markers import windows_only
 
@@ -519,8 +520,7 @@ class TestRemoteMoveAndRename(OneUserTest):
 
     def test_remote_move_to_non_sync_root(self):
         # Grant ReadWrite permission on Workspaces for test user
-        workspaces_path = "/default-domain/workspaces"
-        input_obj = "doc:" + workspaces_path
+        input_obj = f"doc:{env.WS_DIR}"
         self.root_remote.execute(
             command="Document.SetACE",
             input_obj=input_obj,
@@ -529,7 +529,7 @@ class TestRemoteMoveAndRename(OneUserTest):
             grant=True,
         )
 
-        workspaces_info = self.root_remote.fetch(workspaces_path)
+        workspaces_info = self.root_remote.fetch(env.WS_DIR)
         workspaces = workspaces_info["uid"]
 
         # Get remote client with Workspaces as base folder and local client

--- a/tests/old_functional/test_volume.py
+++ b/tests/old_functional/test_volume.py
@@ -37,11 +37,14 @@ FOLDERS = FILES = DEPTH = 0
 
 if "TEST_VOLUME" in os.environ:
     values_ = os.getenv("TEST_VOLUME", "")
-    if values_.count(",") != 2:
-        # Low volume by default
-        values_ = "3,10,2"  # 200 documents
+    if not values_:
+        del os.environ["TEST_VOLUME"]
+    else:
+        if values_.count(",") != 2:
+            # Low volume by default
+            values_ = "3,10,2"  # 200 documents
 
-    FOLDERS, FILES, DEPTH = map(int, values_.split(","))
+        FOLDERS, FILES, DEPTH = map(int, values_.split(","))
     del values_
 
 
@@ -99,10 +102,8 @@ class TestVolume(OneUserTest):
             self.engine_1.stop()
 
         self.tree = {"childs": {}, "path": ROOT}
-        log.warning(
-            f"Creating {FILES * FILES * FOLDERS * DEPTH + FOLDERS * DEPTH} documents ..."
-        )
         items = self.create_tree(FOLDERS, FILES, DEPTH, self.tree)
+        log.warning(f"Created {items:,} local documents.")
 
         if not stopped:
             self.engine_1.start()
@@ -110,7 +111,6 @@ class TestVolume(OneUserTest):
         if wait_for_sync:
             self.wait_sync(timeout=items * 10)
 
-        log.warning(f"Created {items:,} documents.")
         return items
 
     def _check_folder(self, path: Path, removed=[], added=[]):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -13,6 +13,7 @@ import nxdrive.utils
 from nxdrive.constants import APP_NAME, WINDOWS
 from nxdrive.options import Options
 
+from .. import env
 from ..markers import not_windows, windows_only
 
 BAD_HOSTNAMES = [
@@ -416,7 +417,7 @@ def test_get_timestamp_from_date():
 def test_get_tree_list():
     location = nxdrive.utils.normalized_path(__file__).parent.parent
     path = location / "resources"
-    remote_ref = "/default-domain/workspaces/foo"
+    remote_ref = f"{env.WS_DIR}/foo"
     for ref, local_path in nxdrive.utils.get_tree_list(path, remote_ref):
         assert ref.startswith(remote_ref)
         assert "\\" not in ref

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -81,4 +81,4 @@ def salt(text: str, prefix: str = "ndt-", with_suffix: bool = True) -> str:
     To use for workspace titles, usernames, groups names ...
     """
     suffix = random.randint(1, 99999) if with_suffix else ""
-    return f"{prefix}{text}{suffix}"
+    return f"{prefix}{text}-{suffix}"

--- a/tools/jenkins/test_volume.groovy
+++ b/tools/jenkins/test_volume.groovy
@@ -12,8 +12,8 @@ properties([
     [$class: 'ParametersDefinitionProperty', parameterDefinitions: [
         [$class: 'StringParameterDefinition',
             name: 'TEST_VOLUME',
-            defaultValue: '10,1200,3',
-            description: '<ul><li>number of folders</li><li>number of files to create inside each folder</li><li>depth: the tree will be replicated into itself <i>depth</i> times</li><li>Total is <code>files * files * folders * depth + folders * depth</code> (here 363,600)</ul>'],
+            defaultValue: '6,1200,3',
+            description: '<ul><li>number of folders</li><li>number of files to create inside each folder</li><li>depth: the tree will be replicated into itself <i>depth</i> times</li><li>Total is <code>...</code> (here 309,858)</ul>'],
         [$class: 'StringParameterDefinition',
             name: 'TEST_REMOTE_SCAN_VOLUME',
             defaultValue: '200000',

--- a/tools/jenkins/test_volume_specific.groovy
+++ b/tools/jenkins/test_volume_specific.groovy
@@ -1,0 +1,115 @@
+#!groovy
+// Script to launch volume tests on Nuxeo Drive.
+
+// Pipeline properties
+properties([
+    disableConcurrentBuilds(),
+    pipelineTriggers([[$class: 'GitHubPushTrigger']]),
+    [$class: 'BuildDiscarderProperty', strategy:
+        [$class: 'LogRotator', daysToKeepStr: '60', numToKeepStr: '60', artifactNumToKeepStr: '5']],
+    [$class: 'SchedulerPreference', preferEvenload: true],
+    [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],
+    parameters([
+        string(name: 'BRANCH_NAME', defaultValue: 'master', description: 'The git branch to checkout.', trim: true),
+        string(name: 'NXDRIVE_TEST_NUXEO_URL', defaultValue: 'http://localhost:8080/nuxeo', description: 'The server URL against to run tests.', trim: true),
+        string(name: 'NXDRIVE_TEST_USERNAME', defaultValue: 'Administrator', description: 'The user having administrator rights.', trim: true),
+        string(name: 'NXDRIVE_TEST_PASSWORD', defaultValue: 'Administrator', description: 'The password associated to the username.', trim: true),
+        string(name: 'NXDRIVE_TEST_PATH', defaultValue: '/default-domain/workspaces', description: 'The remote path where to store data. Must exist.', trim: true),
+        string(name: 'TEST_VOLUME', defaultValue: '3,200,3', description: '<ul><li>number of folders</li><li>number of files to create inside each folder</li><li>depth: the tree will be replicated into itself <i>depth</i> times</li><li>Total is <code>...</code> (here 309,858)</ul>', trim: true),
+        string(name: 'TEST_REMOTE_SCAN_VOLUME', defaultValue: '200000', description: 'Minimum number of documents to randomly import (here > 200,000).', trim: true),
+        booleanParam(name: 'USE_MAC_DRIVE_1', defaultValue: true, description: 'macOS client n° 1.'),
+        booleanParam(name: 'USE_MAC_DRIVE_2', defaultValue: false, description: 'macOS client n° 2.'),
+        booleanParam(name: 'USE_SLAVE', defaultValue: true, description: 'GNU/Linux client'),
+        booleanParam(name: 'USE_WINDB1', defaultValue: true, description: 'Windows client n°1'),
+        booleanParam(name: 'USE_WINDB2', defaultValue: false, description: 'Windows client n°2'),
+        booleanParam(name: 'USE_WINDB3', defaultValue: false, description: 'Windows client n°3'),
+        booleanParam(name: 'USE_WINDB4', defaultValue: false, description: 'Windows client n°4'),
+        booleanParam(name: 'USE_WINDB5', defaultValue: false, description: 'Windows client n°5'),
+    ])
+])
+
+def checkout_custom() {
+    // git checkout on a custom branch
+    repos_url = 'https://github.com/nuxeo/nuxeo-drive'
+    repos_git = 'https://github.com/nuxeo/nuxeo-drive.git'
+    checkout([$class: 'GitSCM',
+        branches: [[name: params.BRANCH_NAME]],
+        browser: [$class: 'GithubWeb', repoUrl: repos_url],
+        userRemoteConfigs: [[url: repos_git]]])
+}
+
+// Available Jenkins agents
+agents = [
+    'MAC-DRIVE-1',
+    'MAC-DRIVE-2',
+    'SLAVE',
+    'windb1',
+    'windb2',
+    'windb3',
+    'windb4',
+    'windb5',
+]
+labels = [
+    'MAC-DRIVE-1': 'Mac-1',
+    'MAC-DRIVE-2': 'Mac-2',
+    'SLAVE': 'Linux',
+    'windb1': 'Windows-1',
+    'windb2': 'Windows-2',
+    'windb3': 'Windows-3',
+    'windb4': 'Windows-4',
+    'windb5': 'Windows-5',
+]
+builders = [:]
+
+for (x in agents) {
+    def agent = x
+    def agent_snake_case = agent.replace('-', '_').toUpperCase()
+    def osi = labels.get(agent)
+
+    // Check if agent is selected
+    if (!params["USE_${agent_snake_case}"]) {
+        continue
+    }
+
+    builders[agent] = {
+        node(agent) {
+            stage(osi) {
+                // Checkout (not inside a specific stage to have a better view in the job homepage)
+                try {
+                    checkout_custom()
+                } catch(e) {
+                    currentBuild.result = 'UNSTABLE'
+                    throw e
+                }
+
+                // The test
+                env.SPECIFIC_TEST = 'old_functional/test_volume.py'
+                env.SKIP = 'rerun'
+                env.PYTEST_ADDOPTS = '-n0 -x'
+
+                try {
+                    if (agent_snake_case.startsWith('MAC')) {
+                        // macOS
+                        sh 'tools/osx/deploy_jenkins_slave.sh --install'
+                        sh 'tools/osx/deploy_jenkins_slave.sh --tests'
+                    } else if (agent_snake_case.startsWith('WIN')) {
+                        // Windows
+                        bat 'powershell ".\\tools\\windows\\deploy_jenkins_slave.ps1" -install'
+                        bat 'powershell ".\\tools\\windows\\deploy_jenkins_slave.ps1" -tests'
+                    } else {
+                        // GNU/Linux
+                        sh 'tools/linux/deploy_jenkins_slave.sh --install'
+                        sh 'tools/linux/deploy_jenkins_slave.sh --tests'
+                    }
+                } catch(e) {
+                    currentBuild.result = 'FAILURE'
+                    throw e
+                }
+            }
+        }
+    }
+}
+
+timeout(480) {
+    parallel builders
+}

--- a/tools/scripts/check_update_process.py
+++ b/tools/scripts/check_update_process.py
@@ -439,7 +439,7 @@ def main():
         if not version_forced:
             # Add an account to be able to auto-update
             url = os.getenv("NXDRIVE_TEST_NUXEO_URL", "http://localhost:8080/nuxeo")
-            username = os.getenv("NXDRIVE_TEST_USER", "Administrator")
+            username = os.getenv("NXDRIVE_TEST_USERNAME", "Administrator")
             password = os.getenv("NXDRIVE_TEST_PASSWORD", "Administrator")
             launch_drive(
                 dst_file,


### PR DESCRIPTION
The goal is to allow the test to be run on a given server (typically a customer preprod) to validate or check for performance issues.