### PR TITLE
NXDRIVE-1939: Use a temp dir located on the same drive as the local f…

### DIFF
--- a/docs/changes/4.4.1.md
+++ b/docs/changes/4.4.1.md
@@ -4,7 +4,7 @@ Release date: `20xx-xx-xx`
 
 ## Core
 
-- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
+- [NXDRIVE-1939](https://jira.nuxeo.com/browse/NXDRIVE-1939): Use a temp dir located on the same drive as the local folder in `LocalClient.rename()`
 
 ## GUI
 
@@ -28,4 +28,4 @@ Release date: `20xx-xx-xx`
 
 ## Technical Changes
 
--
+- Added `LocalClient.download_dir`

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -139,7 +139,9 @@ class Engine(QObject):
         self.local_folder = Path(definition.local_folder)
         self.folder = str(self.local_folder)
         self.local = self.local_cls(
-            self.local_folder, digest_callback=self.suspend_client
+            self.local_folder,
+            digest_callback=self.suspend_client,
+            download_dir=self.download_dir,
         )
 
         self.uid = definition.uid
@@ -286,6 +288,10 @@ class Engine(QObject):
         download_dir = download_dir / ".tmp" / self.uid
         log.info(f"Using temporary download folder {download_dir!r}")
         download_dir.mkdir(parents=True, exist_ok=True)
+
+        # Update the LocalClient attribute as it is needed by .rename()
+        self.local.download_dir = download_dir
+
         return download_dir
 
     def set_local_folder(self, path: Path) -> None:

--- a/tests/env.py
+++ b/tests/env.py
@@ -12,3 +12,6 @@ NXDRIVE_TEST_PASSWORD = getenv("NXDRIVE_TEST_PASSWORD", "Administrator")
 
 # The remote path where to store data. Must exist before running tests.
 WS_DIR = getenv("NXDRIVE_TEST_PATH", "/default-domain/workspaces")
+
+# On Windows, this is used to define the drive letter of a second NTFS partition
+SECOND_PARTITION = getenv("SECOND_PARTITION", "Q:\\")

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from logging import getLogger
-from typing import Callable
+from pathlib import Path
+from typing import Callable, Optional
 from random import randint
 from uuid import uuid4
 
@@ -34,7 +35,9 @@ def manager_factory(
 ) -> Callable[[], Manager]:
     """Manager instance with automatic clean-up."""
 
-    def _make_manager(home: str = "", with_engine: bool = True):
+    def _make_manager(
+        home: str = "", with_engine: bool = True, local_folder: Optional[Path] = None
+    ):
         manager = Manager(home or tmp())
 
         # Force deletion behavior to real deletion for all tests
@@ -45,7 +48,7 @@ def manager_factory(
         log.info(f"[FIXTURE] Created {manager}")
 
         if with_engine:
-            conf_folder = manager.home / "nuxeo-conf"
+            conf_folder = (local_folder or manager.home) / "nuxeo-conf"
             user = user_factory()
             manager.bind_server(
                 conf_folder, nuxeo_url, user.uid, user.password, start_engine=False

--- a/tests/functional/test_local_client.py
+++ b/tests/functional/test_local_client.py
@@ -1,8 +1,13 @@
 import pathlib
+import shutil
 from unittest.mock import patch
+from uuid import uuid4
 
+import pytest
 from nxdrive.client.local import LocalClient
-from nxdrive.constants import ROOT
+from nxdrive.constants import ROOT, WINDOWS
+
+from .. import env
 
 
 def test_get_path(tmp):
@@ -64,3 +69,36 @@ def test_set_get_xattr_invalid_start_byte(tmp):
     raw_value, result_needed = b"fdrpMACS\x80", "fdrpMACS"
     LocalClient.set_path_remote_id(file, raw_value)
     assert LocalClient.get_path_remote_id(file) == result_needed
+
+
+@pytest.mark.skipif(not WINDOWS, reason="Windows only")
+def test_rename_with_different_partitions(manager_factory):
+    """Ensure we can rename a file between different partitions."""
+    second_partoche = pathlib.Path(env.SECOND_PARTITION)
+    if not second_partoche.is_dir():
+        pytest.skip(f"There is no such {second_partoche!r} partition.")
+
+    local_folder = second_partoche / str(uuid4())
+    manager, engine = manager_factory(local_folder=local_folder)
+    local = engine.local
+
+    try:
+        with manager:
+            # Ensure folders are on different partitions
+            assert manager.home.drive != local.base_folder.drive
+
+            # Relax permissions for the rest of the test
+            local.unset_readonly(engine.local_folder)
+
+            # Create a file
+            (engine.local_folder / "file Lower.txt").write_text("azerty")
+
+            # Change the case
+            local.rename(pathlib.Path("file Lower.txt"), "File LOWER.txt")
+
+            # The file should have its case modified
+            children = local.get_children_info(ROOT)
+            assert len(children) == 1
+            assert children[0].name == "File LOWER.txt"
+    finally:
+        shutil.rmtree(local_folder)


### PR DESCRIPTION
…older in `LocalClient.rename()`.

Using the download folder from the engine will ensure both files are on the same drive.

[CI] Our Windows agents were updated to create a second partition available on "Q:\", it is customizable with the `SECOND_PARTITION` envar. See NXBT-3144 for details.

I also renforced `.is_case_sensitive()` for when `%TEMP%` is restricted on Windows. Before that change, Drive was unusable; now it will start.