### PR TITLE
NXDRIVE-1916: Skip disappeared files when fetching their status for i…

### DIFF
--- a/docs/changes/4.4.1.md
+++ b/docs/changes/4.4.1.md
@@ -4,6 +4,7 @@ Release date: `20xx-xx-xx`
 
 ## Core
 
+- [NXDRIVE-1916](https://jira.nuxeo.com/browse/NXDRIVE-1916): Skip disappeared files when fetching their status for icon overlays
 - [NXDRIVE-1939](https://jira.nuxeo.com/browse/NXDRIVE-1939): Use a temp dir located on the same drive as the local folder in `LocalClient.rename()`
 
 ## GUI
@@ -29,3 +30,4 @@ Release date: `20xx-xx-xx`
 ## Technical Changes
 
 - Added `LocalClient.download_dir`
+- Changed osi/extensions.py::`get_formatted_status()` to return `None` when the file does not exist anymore

--- a/nxdrive/osi/darwin/darwin.py
+++ b/nxdrive/osi/darwin/darwin.py
@@ -252,10 +252,9 @@ class DarwinIntegration(AbstractOSIntegration):
         name = f"{BUNDLE_IDENTIFIER}.syncStatus"
         try:
             status = get_formatted_status(state, path)
-            log.debug(f"Sending status to FinderSync for {path!r}: {status}")
-            self._send_notification(name, {"statuses": [status]})
-        except FileNotFoundError:
-            pass
+            if status:
+                log.debug(f"Sending status to FinderSync for {path!r}: {status}")
+                self._send_notification(name, {"statuses": [status]})
         except Exception:
             log.exception("Error while trying to send status to FinderSync")
 
@@ -277,10 +276,11 @@ class DarwinIntegration(AbstractOSIntegration):
             batch_size = Options.findersync_batch_size
             for i in range(0, len(states), batch_size):
                 states_batch = states[i : i + batch_size]
-                statuses = [
-                    get_formatted_status(state, path / state.local_name)
-                    for state in states_batch
-                ]
+                statuses = []
+                for state in states_batch:
+                    status = get_formatted_status(state, path / state.local_name)
+                    if status:
+                        statuses.append(status)
                 log.debug(
                     f"Sending statuses to FinderSync for children of {path!r} "
                     f"(items {i}-{i + len(states_batch) - 1})"

--- a/nxdrive/osi/extension.py
+++ b/nxdrive/osi/extension.py
@@ -149,11 +149,17 @@ class ExtensionListener(QTcpServer):
         return None
 
 
-def get_formatted_status(state: DocPair, path: Path) -> Dict[str, str]:
+def get_formatted_status(state: DocPair, path: Path) -> Optional[Dict[str, str]]:
     """ For a given file and its state info, get a JSON-compatible status. """
     status = Status.UNSYNCED
 
-    readonly = (path.stat().st_mode & (stat.S_IWUSR | stat.S_IWGRP)) == 0
+    try:
+        readonly = (path.stat().st_mode & (stat.S_IWUSR | stat.S_IWGRP)) == 0
+    except FileNotFoundError:
+        return None
+    except PermissionError:
+        readonly = True
+
     if readonly:
         status = Status.LOCKED
     elif state:

--- a/tests/unit/test_extension_listener.py
+++ b/tests/unit/test_extension_listener.py
@@ -1,6 +1,17 @@
-from PyQt5.QtNetwork import QAbstractSocket, QHostAddress
+import pathlib
+from collections import namedtuple
+from unittest.mock import patch
 
-from nxdrive.osi.extension import ExtensionListener
+import pytest
+from PyQt5.QtNetwork import QAbstractSocket, QHostAddress
+from nxdrive.osi.extension import ExtensionListener, Status, get_formatted_status
+
+
+DocPair = namedtuple(
+    "DocPair",
+    "error_count, local_state, pair_state, processor",
+    defaults=(0, "", "", 0),
+)
 
 
 def test_host_to_addr():
@@ -13,3 +24,52 @@ def test_host_to_addr():
     assert isinstance(address, QHostAddress)
     assert address.protocol() == QAbstractSocket.IPv4Protocol
     assert address.toString() == "127.0.0.1"
+
+
+@pytest.mark.parametrize(
+    "doc_pair, path, status",
+    [
+        (DocPair(), pathlib.Path("."), Status.UNSYNCED),
+        (DocPair(error_count=1), pathlib.Path("."), Status.ERROR),
+        (DocPair(local_state="synchronized"), pathlib.Path("."), Status.SYNCED),
+        (DocPair(pair_state="conflicted"), pathlib.Path("."), Status.CONFLICTED),
+        (DocPair(pair_state="unsynchronized"), pathlib.Path("."), Status.UNSYNCED),
+        (DocPair(processor=42), pathlib.Path("."), Status.SYNCING),
+    ],
+)
+def test_get_formatted_status(doc_pair, path, status):
+    fmt_status = get_formatted_status(doc_pair, path)
+    assert fmt_status == {"path": ".", "value": str(status.value)}
+
+
+@patch("pathlib.Path.stat")
+def test_get_formatted_status_readonly(mocked_stat):
+    doc_pair = DocPair()
+    path = pathlib.Path(".")
+
+    class Stat:
+        st_mode = 0
+
+    mocked_stat.return_value = Stat
+    status = get_formatted_status(doc_pair, path)
+    mocked_stat.reset_mock()
+
+    assert status == {"path": ".", "value": str(Status.LOCKED.value)}
+
+
+@patch("pathlib.Path.stat")
+def test_get_formatted_status_permission_error(mocked_stat):
+    doc_pair = DocPair()
+    path = pathlib.Path(".")
+
+    mocked_stat.side_effect = PermissionError
+    status = get_formatted_status(doc_pair, path)
+    mocked_stat.reset_mock()
+
+    assert status == {"path": ".", "value": str(Status.LOCKED.value)}
+
+
+def test_get_formatted_status_file_not_found():
+    doc_pair = DocPair()
+    path = pathlib.Path("./inexistant")
+    assert get_formatted_status(doc_pair, path) is None


### PR DESCRIPTION
…con overlays.

Also handle `PermissionError` as read-only.