### PR TITLE
NXDRIVE-1951: Do not try to update contents of a folderish document

### DIFF
--- a/docs/changes/4.4.1.md
+++ b/docs/changes/4.4.1.md
@@ -7,6 +7,7 @@ Release date: `20xx-xx-xx`
 - [NXDRIVE-1737](https://jira.nuxeo.com/browse/NXDRIVE-1737): Fix document deletion for unsynced ones
 - [NXDRIVE-1916](https://jira.nuxeo.com/browse/NXDRIVE-1916): Skip disappeared files when fetching their status for icon overlays
 - [NXDRIVE-1939](https://jira.nuxeo.com/browse/NXDRIVE-1939): Use a temp dir located on the same drive as the local folder in `LocalClient.rename()`
+- [NXDRIVE-1951](https://jira.nuxeo.com/browse/NXDRIVE-1951): Do not try to update contents of a folderish document
 - [NXDRIVE-1952](https://jira.nuxeo.com/browse/NXDRIVE-1952): Fix local file rename rollback
 
 ## GUI

--- a/nxdrive/client/local/base.py
+++ b/nxdrive/client/local/base.py
@@ -60,12 +60,15 @@ class FileInfo:
             log.info(f"Forcing normalization of {filepath!r} to {self.filepath!r}")
             safe_rename(filepath, self.filepath)
 
-        # Guess the file size to help catching file changes in the watcher.
-        # This will prevent to do checksum comparisons, which are expensive.
-        size = kwargs.pop("size", 0)
-        if size == 0:
-            with suppress(FileNotFoundError):
-                size = self.filepath.stat().st_size
+        if folderish:
+            size = 0
+        else:
+            # Guess the file size to help catching file changes in the watcher.
+            # This will prevent to do checksum comparisons, which are expensive.
+            size = kwargs.pop("size", 0)
+            if size == 0:
+                with suppress(FileNotFoundError):
+                    size = self.filepath.stat().st_size
         self.size = size
 
         self.folderish = folderish  # True if a Folder
@@ -82,7 +85,7 @@ class FileInfo:
 
     def __repr__(self) -> str:
         return (
-            f"FileInfo<path={self.path!r}, filepath={self.filepath!r},"
+            f"{type(self).__name__}<path={self.path!r}, filepath={self.filepath!r},"
             f" name={self.name!r}, folderish={self.folderish!r},"
             f" size={self.size}, remote_ref={self.remote_ref!r}>"
         )

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -1123,8 +1123,12 @@ class Processor(EngineWorker):
     def _synchronize_remotely_modified(self, doc_pair: DocPair) -> None:
         is_renaming = safe_filename(doc_pair.remote_name) != doc_pair.local_name
         try:
-            if doc_pair.local_digest is not None and not self.local.is_equal_digests(
-                doc_pair.local_digest, doc_pair.remote_digest, doc_pair.local_path
+            if (
+                not doc_pair.folderish
+                and doc_pair.local_digest is not None
+                and not self.local.is_equal_digests(
+                    doc_pair.local_digest, doc_pair.remote_digest, doc_pair.local_path
+                )
             ):
                 self._update_remotely(doc_pair, is_renaming)
             else:

--- a/tests/old_functional/test_local_client.py
+++ b/tests/old_functional/test_local_client.py
@@ -50,6 +50,7 @@ class StubLocalClient:
         assert doc_1_info.path == doc_1
         assert doc_1_info.get_digest() == EMPTY_DIGEST
         assert not doc_1_info.folderish
+        assert doc_1_info.size == 0
 
         doc_2 = local.make_file("/", "Document 2.txt", content=SOME_TEXT_CONTENT)
         assert local.exists(doc_2)
@@ -59,6 +60,7 @@ class StubLocalClient:
         assert doc_2_info.path == doc_2
         assert doc_2_info.get_digest() == SOME_TEXT_DIGEST
         assert not doc_2_info.folderish
+        assert doc_2_info.size > 0
 
         local.delete(doc_2)
         assert local.exists(doc_1)
@@ -70,6 +72,8 @@ class StubLocalClient:
         assert folder_1_info.name == "A new folder"
         assert folder_1_info.path == folder_1
         assert folder_1_info.folderish
+        # A folder has no size
+        assert folder_1_info.size == 0
 
         doc_3 = local.make_file(folder_1, "Document 3.txt", content=SOME_TEXT_CONTENT)
         local.delete(folder_1)

--- a/tests/old_functional/test_remote_move_and_rename.py
+++ b/tests/old_functional/test_remote_move_and_rename.py
@@ -313,16 +313,20 @@ class TestRemoteMoveAndRename(OneUserTest):
 
         # Move a non empty folder with some content
         remote.move(self.folder_1_id, self.folder_2_id)
-        assert remote.get_fs_info(self.folder_1_id).name == "Original Fold\xe9r 1"
-        assert remote.get_fs_info(self.folder_1_id).parent_uid == self.folder_2_id
+        remote_info = remote.get_fs_info(self.folder_1_id)
+        assert remote_info is not None
+        assert remote_info.name == "Original Fold\xe9r 1"
+        assert remote_info.parent_uid == self.folder_2_id
 
         # Synchronize: only the folder move is detected: all
         # the descendants are automatically realigned
         self.wait_sync(wait_for_async=True)
 
         # Check remote folder
-        assert remote.get_fs_info(self.folder_1_id).name == "Original Fold\xe9r 1"
-        assert remote.get_fs_info(self.folder_1_id).parent_uid == self.folder_2_id
+        remote_info = remote.get_fs_info(self.folder_1_id)
+        assert remote_info is not None
+        assert remote_info.name == "Original Fold\xe9r 1"
+        assert remote_info.parent_uid == self.folder_2_id
 
         # Check local folder
         assert not local.exists("/Original Fold\xe9r 1")


### PR DESCRIPTION
Folderish documents were not properly checked on remote modifications.
So the scenario of trying to update folderish contents was happening.

The fix is to filter out those documents.

Another smaller fix was applied to not get the size of a folder.
Even if it is a valid operation, it is useless and not required.