### PR TITLE
NXDRIVE-1900: Fix display scaling when zoom is set to > 100%

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -8,7 +8,7 @@ Release date: `20xx-xx-xx`
 
 ## GUI
 
-- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
+- [NXDRIVE-1900](https://jira.nuxeo.com/browse/NXDRIVE-1900): Fix display scaling when zoom is set to > 100%
 
 ## Packaging / Build
 

--- a/nxdrive/data/i18n/i18n.json
+++ b/nxdrive/data/i18n/i18n.json
@@ -238,7 +238,7 @@
     "RECENTLY_UPDATED": "Recently updated",
     "REMOTE_FOLDER": "Remote folder",
     "REPLACE": "Replace",
-    "REPORT_GENERATED": "Report available at:",
+    "REPORT_GENERATED": "Report available:",
     "REQUIRES_AUTHENTICATION": "Proxy server requires authentication",
     "RESOLVE": "Resolve",
     "RESTART_NEEDED": "Restart needed",

--- a/nxdrive/data/qml/AboutTab.qml
+++ b/nxdrive/data/qml/AboutTab.qml
@@ -69,7 +69,7 @@ Rectangle {
             id: licenseText
             width: parent.width
             wrapMode: Text.WordWrap
-            font.family: 'monospace'
+            font.family: "Courier"
             pointSize: 12
 
             Component.onCompleted: {

--- a/nxdrive/data/qml/FileCard.qml
+++ b/nxdrive/data/qml/FileCard.qml
@@ -58,7 +58,7 @@ ShadowRectangle {
 
             ScaledText {
                 id: errorDetails
-                font.family: "monospace"
+                font.family: "Courier"
                 text: fileData.last_error_details
                 visible: type != "conflict" && text
                 Layout.fillWidth: true

--- a/nxdrive/data/qml/GeneralTab.qml
+++ b/nxdrive/data/qml/GeneralTab.qml
@@ -116,7 +116,8 @@ Rectangle {
             text: qsTr("CREATE_REPORT") + tl.tr
             onClicked: {
                 var link = api.generate_report()
-                lastReportLink.text = link
+                lastReportLink.report_url = link
+                lastReportLink.text = link.split(/[\\/]/).pop()
             }
         }
 
@@ -127,7 +128,8 @@ Rectangle {
             }
             Link {
                 id: lastReportLink
-                onClicked: api.open_report(text)
+                property string report_url
+                onClicked: api.open_report(report_url)
             }
         }
 

--- a/nxdrive/data/qml/IconLabel.qml
+++ b/nxdrive/data/qml/IconLabel.qml
@@ -11,6 +11,7 @@ import QtQuick 2.13
     text: icon
     font.family: "Material Design Icons"
     pointSize: size
+    font.pointSize: pointSize / ratio
     color: mediumGray
 
     MouseArea {

--- a/nxdrive/data/qml/NewAccountPopup.qml
+++ b/nxdrive/data/qml/NewAccountPopup.qml
@@ -35,7 +35,7 @@ NuxeoPopup {
                 KeyNavigation.tab: folderInput
                 placeholderText: "your.nuxeo.platform.com"
                 text: api.default_server_url_value()
-                font.family: "monospace"
+                font.family: "Courier"
             }
 
             ScaledText {

--- a/nxdrive/data/qml/ProxyPopup.qml
+++ b/nxdrive/data/qml/ProxyPopup.qml
@@ -73,7 +73,7 @@ NuxeoPopup {
             id: urlInput
             visible: isManual
             Layout.fillWidth: true
-            font.family: 'monospace'
+            font.family: "Courier"
             placeholderText: 'https://username:password@proxy.tld:port'
             inputMethodHints: Qt.ImhUrlCharactersOnly
         }
@@ -87,7 +87,7 @@ NuxeoPopup {
             id: pacUrlInput
             visible: isAuto
             Layout.fillWidth: true
-            font.family: 'monospace'
+            font.family: "Courier"
             placeholderText: 'https://server.tld/proxy.pac\nfile://C:/proxy.pac'
             inputMethodHints: Qt.ImhUrlCharactersOnly
         }

--- a/nxdrive/data/qml/ScaledText.qml
+++ b/nxdrive/data/qml/ScaledText.qml
@@ -2,6 +2,5 @@ import QtQuick 2.13
 
 Text {
     property int pointSize: 12
-    font.pointSize: pointSize / ratio
     elide: Text.ElideRight
 }

--- a/nxdrive/fatal_error.py
+++ b/nxdrive/fatal_error.py
@@ -68,7 +68,7 @@ def fatal_error_qt(exc_formatted: str) -> None:
     dialog.setWindowIcon(QIcon(str(find_icon("app_icon.svg"))))
     dialog.resize(800, 600)
     layout = QVBoxLayout()
-    css = "font-family: monospace; font-size: 12px;"
+    css = "font-family: Courier; font-size: 12px;"
     details = []
 
     # Display a little message to apologize

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -158,7 +158,7 @@ class Application(QApplication):
         self.current_notification: Optional[Notification] = None
         self.default_tooltip = APP_NAME
 
-        font = QFont("Helvetica, Arial, sans-serif", 12)
+        font = QFont("Helvetica, Times", pointSize=12)
         self.setFont(font)
         self.ratio = sqrt(QFontMetricsF(font).height() / 12)
 
@@ -237,7 +237,7 @@ class Application(QApplication):
             self.conflicts_window.setMinimumHeight(600)
             self.settings_window = QQuickView()
             self.settings_window.setMinimumWidth(640)
-            self.settings_window.setMinimumHeight(540)
+            self.settings_window.setMinimumHeight(580)
             self.add_qml_import_path(self.settings_window)
             self.systray_window = SystrayWindow()
             self.add_qml_import_path(self.systray_window)


### PR DESCRIPTION
- Reduced the displayed report URL. Now only the basename is printed to fix missing parts of the final URL at different scalings.
- Removed the "monospace" font for "Courier". The former did not scale well on high zoom values.

Windows related changes:

- Removed "Arial" and "sans-serif" fonts as they did not scale well.
- Added the "Times" font as it scale well.
- The main window has a bigger height (540 -> 580).