### PR TITLE
NXDRIVE-1992: Fix old alpha files purgation

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -12,7 +12,7 @@ Release date: `20xx-xx-xx`
 
 ## Packaging / Build
 
-- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
+- [NXDRIVE-1992](https://jira.nuxeo.com/browse/NXDRIVE-1992): Fix old alpha files purgation
 
 ## Docs
 

--- a/tools/cleanup.sh
+++ b/tools/cleanup.sh
@@ -40,7 +40,7 @@ main() {
     while IFS= read release; do
         version="$(echo ${release} | sed s'/alpha-//')"
         echo " - ${version}"
-        ssh -T nuxeo@lethe.nuxeo.com "rm -vf ${path}/alpha/*${version}*" || true
+        ssh -T nuxeo@lethe.nuxeo.com "rm -vf ${path}/alpha/*${version}.* ${path}/alpha/*${version}-*" || true
         git tag --delete "${release}" || true
         git push --delete origin "wip-${release}" || true  # branch
         git push --delete origin "${release}" || true  # tag


### PR DESCRIPTION
The regexp used to deleted files was too greedy and so to remove 4.2.1.1 files, it was globbing 4.2.1.1* files. Thus 4.2.1.14 or any number greater then 4.2.1.1 was removed too.