### PR TITLE
NXDRIVE-1993: Use Dependabot to keep dependencies up-to-date

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,5 +1,0 @@
-# https://pyup.io/docs/bot/config/
-schedule: "every day"
-label_prs: dependencies
-branch_prefix: wip-
-assignees: BoboTiG

--- a/dependabot/config.yml
+++ b/dependabot/config.yml
@@ -1,0 +1,11 @@
+version: 1
+
+update_configs:
+  - package_manager: python
+    directory: /
+    update_schedule: live
+    target_branch: master
+    default_reviewers:
+      - BoboTiG
+    default_labels:
+      - dependencies

--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -13,6 +13,7 @@ Release date: `20xx-xx-xx`
 ## Packaging / Build
 
 - [NXDRIVE-1992](https://jira.nuxeo.com/browse/NXDRIVE-1992): Fix old alpha files purgation
+- [NXDRIVE-1993](https://jira.nuxeo.com/browse/NXDRIVE-1993): Use Dependabot to keep dependencies up-to-date
 
 ## Docs
 


### PR DESCRIPTION
Pyup-bot is removed for Dependabot.