### PR TITLE
NXDRIVE-1976: [macOS] Do not fail the auto-update on unmountable volume

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -4,6 +4,7 @@ Release date: `20xx-xx-xx`
 
 ## Core
 
+- [NXDRIVE-1976](https://jira.nuxeo.com/browse/NXDRIVE-1976): [macOS] Do not fail the auto-update on unmountable volume
 - [NXDRIVE-1981](https://jira.nuxeo.com/browse/NXDRIVE-1981): Better improvement patch for `safe_filename()`
 - [NXDRIVE-1985](https://jira.nuxeo.com/browse/NXDRIVE-1985): Fix the custom memory handler buffer retrieval
 

--- a/nxdrive/updater/darwin.py
+++ b/nxdrive/updater/darwin.py
@@ -64,7 +64,13 @@ class Updater(BaseUpdater):
             self._cleanup(filename)
             self._set_progress(90)
             log.info(f"Unmounting {mount_dir!r}")
-            subprocess.check_call(["hdiutil", "unmount", mount_dir])
+            try:
+                subprocess.check_call(["hdiutil", "unmount", mount_dir, "-force"])
+            except subprocess.CalledProcessError:
+                log.warning(
+                    f"Unmount failed, you will have to do it manually (Catalina feature).",
+                    exc_info=True,
+                )
 
         # Check if the new application exists
         if not self.final_app.is_dir():


### PR DESCRIPTION
The last step of the auto-update is failing on some Catalina machines due to the new security framework. It is about unmounting the DMG volume. From the user POV, it always worked, the new version was effective at the next start.

We can "safely" ignore that error as the update actually did work.
Having smooth updates is the priority.