### PR TITLE
NXDRIVE-1984: Handle all errors when checking for opened files

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -6,6 +6,7 @@ Release date: `20xx-xx-xx`
 
 - [NXDRIVE-1976](https://jira.nuxeo.com/browse/NXDRIVE-1976): [macOS] Do not fail the auto-update on unmountable volume
 - [NXDRIVE-1981](https://jira.nuxeo.com/browse/NXDRIVE-1981): Better improvement patch for `safe_filename()`
+- [NXDRIVE-1984](https://jira.nuxeo.com/browse/NXDRIVE-1984): Handle all errors when checking for opened files
 - [NXDRIVE-1985](https://jira.nuxeo.com/browse/NXDRIVE-1985): Fix the custom memory handler buffer retrieval
 - [NXDRIVE-1987](https://jira.nuxeo.com/browse/NXDRIVE-1987): Inexistant database backups should not prevent backup
 

--- a/tests/unit/test_autolock.py
+++ b/tests/unit/test_autolock.py
@@ -77,7 +77,7 @@ def test_autolock(autolock, tmpdir):
         assert len(autolock._autolocked) == 2
 
 
-def test_get_opend_file():
+def test_get_open_files():
     """Just check get_open_files() works."""
     files = list(nxdrive.autolocker.get_open_files())
 


### PR DESCRIPTION
Let's skip all errors at the top the the function.
It would be an endless fight to catch specific errors only.