### PR TITLE
NXDRIVE-1969: [Windows] Direct Edit should work when the sync folder …

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -4,6 +4,7 @@ Release date: `20xx-xx-xx`
 
 ## Core
 
+- [NXDRIVE-1969](https://jira.nuxeo.com/browse/NXDRIVE-1969): [Windows] Direct Edit should work when the sync folder is not on C:
 - [NXDRIVE-1976](https://jira.nuxeo.com/browse/NXDRIVE-1976): [macOS] Do not fail the auto-update on unmountable volume
 - [NXDRIVE-1981](https://jira.nuxeo.com/browse/NXDRIVE-1981): Better improvement patch for `safe_filename()`
 - [NXDRIVE-1984](https://jira.nuxeo.com/browse/NXDRIVE-1984): Handle all errors when checking for opened files

--- a/nxdrive/direct_edit.py
+++ b/nxdrive/direct_edit.py
@@ -418,7 +418,7 @@ class DirectEdit(Worker):
 
         log.info(f"Editing {filename!r}")
         file_path = dir_path / filename
-        tmp_folder = engine.download_dir / doc_id
+        tmp_folder = self._folder / f"{doc_id}.dl"
         tmp_folder.mkdir(parents=True, exist_ok=True)
         file_out = tmp_folder / filename
 


### PR DESCRIPTION
…is not on C:

The call to `safe_rename()` was failing as it is using `os.rename()` and it does not work cross partitions.

Ensuring the folder used to download the blob is on the same partition as the manager's home one fixed the issue.