### PR TITLE
NXDRIVE-1994: [Windows] Skip JUnit report when running a specific test

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -22,6 +22,10 @@ Release date: `20xx-xx-xx`
 - [NXDRIVE-1992](https://jira.nuxeo.com/browse/NXDRIVE-1992): Fix old alpha files purgation
 - [NXDRIVE-1993](https://jira.nuxeo.com/browse/NXDRIVE-1993): Use Dependabot to keep dependencies up-to-date
 
+## Tests
+
+- [NXDRIVE-1994](https://jira.nuxeo.com/browse/NXDRIVE-1994): [Windows] Skip JUnit report when running a specific test
+
 ## Docs
 
 - [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
@@ -42,10 +46,6 @@ Release date: `20xx-xx-xx`
 - Upgraded `tld` from 0.9.6 to 0.11.9
 - Upgraded `urllib3` from 1.25.6 to 1.25.7
 - Upgraded `xattr` from 0.9.6 to 0.9.7
-
-## Tests
-
-- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
 
 ## Technical Changes
 

--- a/tools/windows/deploy_jenkins_slave.ps1
+++ b/tools/windows/deploy_jenkins_slave.ps1
@@ -366,6 +366,12 @@ function junit_arg($path, $run) {
 function launch_test($path, $pytest_args) {
 	# Launch tests on a specific path. On failure, retry failed tests.
 	$junitxml = junit_arg $path 1
+	if ($Env:SPECIFIC_TEST -ne "tests") {
+		# Skip JUnit report when running a specific test as it will fail because
+		# of the "::" that may contain the report filename, see NXDRIVE-1994.
+		$junitxml = ""
+	}
+
 	& $Env:STORAGE_DIR\Scripts\python.exe $global:PYTHON_OPT -bb -Wall -m pytest $pytest_args $junitxml "$path"
 	if ($lastExitCode -eq 0) {
 		return


### PR DESCRIPTION
Skip JUnit report when running a specific test as it will fail because of the "::" that may contain the report filename.