### PR TITLE
NXDRIVE-1966: Use a custom parent folder for downloads on different p…

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -4,6 +4,7 @@ Release date: `20xx-xx-xx`
 
 ## Core
 
+- [NXDRIVE-1966](https://jira.nuxeo.com/browse/NXDRIVE-1966): Use a custom parent folder for downloads on different partition
 - [NXDRIVE-1969](https://jira.nuxeo.com/browse/NXDRIVE-1969): [Windows] Direct Edit should work when the sync folder is not on C:
 - [NXDRIVE-1976](https://jira.nuxeo.com/browse/NXDRIVE-1976): [macOS] Do not fail the auto-update on unmountable volume
 - [NXDRIVE-1981](https://jira.nuxeo.com/browse/NXDRIVE-1981): Better improvement patch for `safe_filename()`

--- a/tests/functional/test_local_client.py
+++ b/tests/functional/test_local_client.py
@@ -101,4 +101,5 @@ def test_rename_with_different_partitions(manager_factory):
             assert len(children) == 1
             assert children[0].name == "File LOWER.txt"
     finally:
+        local.unset_readonly(engine.local_folder)
         shutil.rmtree(local_folder)


### PR DESCRIPTION
…artition

Also prevent using the root of a filesystem as the local sync folder. It would then be problematic because the download folder would be inside the sync folder.