### PR TITLE
NXDRIVE-1986: [Windows] Ignore FS moves with no source path

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -11,6 +11,7 @@ Release date: `20xx-xx-xx`
 - [NXDRIVE-1981](https://jira.nuxeo.com/browse/NXDRIVE-1981): Better improvement patch for `safe_filename()`
 - [NXDRIVE-1984](https://jira.nuxeo.com/browse/NXDRIVE-1984): Handle all errors when checking for opened files
 - [NXDRIVE-1985](https://jira.nuxeo.com/browse/NXDRIVE-1985): Fix the custom memory handler buffer retrieval
+- [NXDRIVE-1986](https://jira.nuxeo.com/browse/NXDRIVE-1986): [Windows] Ignore FS moves with no source path
 - [NXDRIVE-1987](https://jira.nuxeo.com/browse/NXDRIVE-1987): Inexistant database backups should not prevent backup
 
 ## GUI


### PR DESCRIPTION
Sometimes a FS event is targetting the NTFS stream and it triggers another event(s) with no source path.

The cause is not clear, but such events are now skipped.