### PR TITLE
NXDRIVE-1847: [Windows] Fix endless synchronization on fast create-th…

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -4,6 +4,7 @@ Release date: `20xx-xx-xx`
 
 ## Core
 
+- [NXDRIVE-1847](https://jira.nuxeo.com/browse/NXDRIVE-1847): [Windows] Fix endless synchronization on fast create-then-rename folder
 - [NXDRIVE-1918](https://jira.nuxeo.com/browse/NXDRIVE-1918): Use Amazon S3 Direct Upload when available
 - [NXDRIVE-1945](https://jira.nuxeo.com/browse/NXDRIVE-1945): Fix mypy issues following the update to mypy 0.740
 - [NXDRIVE-1958](https://jira.nuxeo.com/browse/NXDRIVE-1958): [Direct Transfer] Create a remote subfolder when uploaing a folder

--- a/nxdrive/engine/watcher/local_watcher.py
+++ b/nxdrive/engine/watcher/local_watcher.py
@@ -197,8 +197,8 @@ class LocalWatcher(EngineWorker):
     @tooltip("Dequeue folder scan")
     def _win_dequeue_folder_scan(self) -> None:
         try:
-            for evt_time, evt_pair in list(self._folder_scan_events.values()):
-                local_path = evt_pair.local_path
+            events = list(self._folder_scan_events.items())
+            for local_path, (evt_time, evt_pair) in events:
                 delay = current_milli_time() - evt_time
 
                 if delay < self._windows_folder_scan_delay:

--- a/tests/old_functional/test_concurrent_synchronization.py
+++ b/tests/old_functional/test_concurrent_synchronization.py
@@ -253,6 +253,9 @@ class TestConcurrentSynchronization(TwoUsersTest):
         # Create a local folder in the test workspace and a file inside
         # this folder, then synchronize
         local1.make_folder("/", "Test folder")
+        if WINDOWS:
+            # Too fast folder create-then-rename are not well handled
+            time.sleep(1)
         local1.rename("/Test folder", "Renamed folder")
         self.wait_sync(wait_for_async=True, wait_for_engine_2=True)
         assert local1.exists("/Renamed folder")

--- a/tests/old_functional/test_local_creations.py
+++ b/tests/old_functional/test_local_creations.py
@@ -13,6 +13,31 @@ from .. import ensure_no_exception
 
 
 class TestLocalCreations(OneUserTest):
+    def test_create_then_rename_local_folder(self):
+        """Prevent regressions on fast create-then-rename folder."""
+        local = self.local_1
+
+        self.engine_1.start()
+        self.wait_sync(wait_for_async=True)
+
+        # Create a local folder, rename it
+        local.make_folder("/", "Test folder")
+        if WINDOWS:
+            # Too fast folder create-then-rename are not well handled
+            time.sleep(1)
+        local.rename("/Test folder", "Renamed folder")
+        assert local.exists("/Renamed folder")
+
+        # Sync and ensure the file is still renamed
+        self.wait_sync(wait_for_async=True)
+        assert local.exists("/Renamed folder")
+
+        # Ensure the folder is renamed on the server too
+        assert not self.engine_1.dao.get_errors()
+        children = self.remote_1.get_children_info(self.workspace)
+        assert len(children) == 1
+        assert children[0].name == "Renamed folder"
+
     def test_invalid_credentials_on_file_upload(self):
         local = self.local_1
         engine = self.engine_1


### PR DESCRIPTION
…en-rename folder

The error was when dequeuing a folder from the Windows scan events queue: instead of using the real dict key, the doc pair `local_path` was used. And in cases when the folder is quickly moved (fast create-then-rename), the key did not exist anymore.