### PR TITLE
NXDRIVE-1831: Set the root local folder icon on Linux

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -4,6 +4,7 @@ Release date: `20xx-xx-xx`
 
 ## Core
 
+- [NXDRIVE-1831](https://jira.nuxeo.com/browse/NXDRIVE-1831): [GNU/Linux] Set the root local folder icon
 - [NXDRIVE-1847](https://jira.nuxeo.com/browse/NXDRIVE-1847): [Windows] Fix endless synchronization on fast create-then-rename folder
 - [NXDRIVE-1918](https://jira.nuxeo.com/browse/NXDRIVE-1918): Use Amazon S3 Direct Upload when available
 - [NXDRIVE-1945](https://jira.nuxeo.com/browse/NXDRIVE-1945): Fix mypy issues following the update to mypy 0.740

--- a/nxdrive/client/local/linux.py
+++ b/nxdrive/client/local/linux.py
@@ -4,6 +4,7 @@
 import errno
 import os
 import re
+import shutil
 import subprocess
 import unicodedata
 from logging import getLogger
@@ -67,7 +68,22 @@ class LocalClient(LocalClientMixin):
     def set_folder_icon(self, ref: Path, icon: Path) -> None:
         """Use commandline to customize the folder icon."""
         log.debug(f"Setting the folder icon of {ref!r} using {icon!r}")
+
+        shared_icons_dir = Path("~/.local/share/icons/")
         folder_path = self.abspath(ref).as_posix()
+
+        # Create the shared icons folder if it doesn't already exist
+        shared_icons_dir.mkdir(parents=True, exist_ok=True)
+
+        # Emblems icons must be saved in ~/.local/share/icons/ to be accessible
+        try:
+            emblem_path = shared_icons_dir / "emblem-nuxeo.svg"
+            if emblem_path.is_file():
+                shutil.copy(str(icon), str(emblem_path))
+        except shutil.Error:
+            log.debug(f"Could not copy {icon!r} to {shared_icons_dir!r}")
+            return
+
         try:
             subprocess.check_output(
                 [

--- a/nxdrive/client/local/linux.py
+++ b/nxdrive/client/local/linux.py
@@ -3,6 +3,7 @@
 
 import errno
 import os
+import subprocess
 import unicodedata
 from logging import getLogger
 from pathlib import Path
@@ -55,6 +56,9 @@ class LocalClient(LocalClientMixin):
         """Create a special file to customize the folder icon."""
         log.debug(f"Setting the folder icon of {ref!r} using {icon!r}")
         # To be implementation with https://jira.nuxeo.com/browse/NXDRIVE-1831
+        subprocess.check_output(
+            ["gio", "set", "-t", "string", str(ref), "metadata::custom-icon", str(icon)]
+        )
         return
 
     @staticmethod

--- a/nxdrive/data/icons/emblem.svg
+++ b/nxdrive/data/icons/emblem.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
+    <title>Icons/Filled/Nuxeo/X-filled</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Icons/Filled/Nuxeo/X-filled" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <rect id="Rectangle" x="0" y="0" width="24" height="24"></rect>
+        <path d="M12.0000572,24 C18.627486,24 24,18.6274347 24,11.9999428 C24,5.3725653 18.627486,0 12.0000572,0 C5.37251404,0 0,5.3725653 0,11.9999428 C0,18.6274347 5.37251404,24 12.0000572,24" id="Fill-1" fill="#0066FF"></path>
+        <polygon id="Fill-3" fill="#FFFFFF" points="5 5 5 7.84392599 9.15596776 12 5 16.156074 5 19 7.84392599 19 12 14.843926 16.1559678 19 19 19 19 16.156074 14.843926 12 19 7.84392599 19 5 16.1559678 5 12 9.15607401 7.84392599 5"></polygon>
+    </g>
+</svg>

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -1083,6 +1083,7 @@ class Engine(QObject):
             icon = find_icon("folder_mac.dat")
         else:
             icon = find_icon("folder_windows.ico")
+
         if not icon:
             log.error(f"Missing icon from the package: {icon!r}")
             return

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -1078,7 +1078,7 @@ class Engine(QObject):
             return
 
         if LINUX:
-            icon = find_icon("disabled.svg")
+            icon = find_icon("emblem.svg")
         elif MAC:
             icon = find_icon("folder_mac.dat")
         else:

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -12,10 +12,9 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Type
 from urllib.parse import urlsplit
 
 import requests
-from PyQt5.QtCore import QObject, QThread, pyqtSignal, pyqtSlot
-
 from nuxeo.exceptions import HTTPError
 from nuxeo.models import Document
+from PyQt5.QtCore import QObject, QThread, pyqtSignal, pyqtSlot
 
 from ..client.local import LocalClient
 from ..client.local.base import LocalClientMixin
@@ -1079,13 +1078,11 @@ class Engine(QObject):
             return
 
         if LINUX:
-            # To be implementation with https://jira.nuxeo.com/browse/NXDRIVE-1831
-            return
+            icon = find_icon("disabled.svg")
         elif MAC:
             icon = find_icon("folder_mac.dat")
         else:
             icon = find_icon("folder_windows.ico")
-
         if not icon:
             log.error(f"Missing icon from the package: {icon!r}")
             return


### PR DESCRIPTION
- Updated the set_folder_icon on linux. It now use the gio set command to change the folder custom-icon metadata.

- For the moment, the folder_windows icon is used as there is no icon for linux in the project.

Signed-off-by: Romain Grasland <rgrasland@nuxeo.com>