### PR TITLE
NXDRIVE-2008: Codespell adjustments

### DIFF
--- a/tools/codespell_skip.txt
+++ b/tools/codespell_skip.txt
@@ -1,5 +1,0 @@
-.git
-./nxdrive/data/i18n/i18n-*
-./tests/resources/i18n/i18n-*
-tools/windows/unofficial_i18n
-tools/codespell_whitelist.txt

--- a/tools/codespell_whitelist.txt
+++ b/tools/codespell_whitelist.txt
@@ -1,3 +1,0 @@
-alse
-datas
-wan

--- a/tools/posix/deploy_jenkins_slave.sh
+++ b/tools/posix/deploy_jenkins_slave.sh
@@ -242,18 +242,24 @@ launch_tests() {
     if should_run "spell"; then
         echo ">>> Checking the grammar"
         echo "    Add '--interactive=3 --write-changes' arguments to the following command to allow interactive modifications."
+
         local to_skip=""
-        for file in tools/codespell_skip.txt .gitignore; do
-              while read -r line; do
-                  # Codespell needs relative paths for folders
-                  [ -e "${line}" ] && line="./${line}"
-                  to_skip="${to_skip}${line},"
-              done < $file
+        for file in tools/spell.skip .gitignore; do
+            # Small santitization:
+            #   - skip empty lines and comments
+            #   - strip inline comments
+            excludes="$(cat "${file}" | sed '/^\s*$/d ; /^#.*$/d ; s/\s*#.*$//')"
+            for line in ${excludes}; do
+                # Codespell needs relative paths for folders
+                [ -e "${line}" ] && line="./${line}"
+                to_skip="${to_skip}${line},"
+            done
         done
+
         # Display the command to allow interactive mode later
         set -x
         codespell \
-            --ignore-words=tools/codespell_whitelist.txt \
+            --ignore-words=tools/spell.whitelist \
             --quiet-level=4 \
             --skip="${to_skip}" \
             2> /dev/null

--- a/tools/spell.skip
+++ b/tools/spell.skip
@@ -1,0 +1,16 @@
+.git  # Obviously!
+
+# No need to check foreign languages
+nxdrive/data/i18n/i18n-*
+
+# That file has false positives, it is not useful to test it
+nxdrive/data/qml/icon-font/Icon.js
+
+# No need to check foreign languages in tests
+tests/resources/i18n/i18n-*
+
+# No need to check foreign languages of the Windows installer
+tools/windows/unofficial_i18n
+
+# Hm, this seems weird but we also need to skip our own whitelist ...
+tools/spell.whitelist

--- a/tools/spell.whitelist
+++ b/tools/spell.whitelist
@@ -1,0 +1,5 @@
+# tools/windows/NuxeoDriveShellExtensions/NuxeoDriveUtil/jsoncpp.cpp:465
+alse
+
+# PyInstaller specific, we have no power on that part
+datas


### PR DESCRIPTION
- Renamed `codespell_skip.txt` to the generic `spell.skip`.
- Renamed `codespell_whitelist.txt` to the generic `spell.whitelist`.
- Empty lines and comments are now skipped. This allowes more sturctured and readable configuration files.
- Inline comments are handled too (they are removed from the line).