### PR TITLE
NXDRIVE-2027: Allow to Direct Edit any custom metadata values

### DIFF
--- a/tests/functional/test_direct_edit.py
+++ b/tests/functional/test_direct_edit.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 import pytest
 from nxdrive.constants import ROOT
 from nxdrive.engine.engine import Engine, ServerBindingSettings
-from nxdrive.objects import NuxeoDocumentInfo
 from nxdrive.translator import Translator
 from nxdrive.utils import find_resource
 
@@ -239,40 +238,3 @@ def test_url_resolver(manager_factory, nuxeo_url):
         manager.engines["0"] = MockUrlTestEngine("https://localhost/nuxeo", user)
         assert get_engine("https://localhost:443/nuxeo/", user=user)
         assert get_engine("https://localhost/nuxeo", user=user)
-
-
-def test_get_blob_custom_metadata():
-    """NXDRIVE-2027: Check Direct Edit works on custom blob metadata values."""
-    doc = NuxeoDocumentInfo.from_dict(
-        {
-            "root": "root",
-            "uid": "uid",
-            "path": "path",
-            "properties": {
-                "dc:title": "dc:title",
-                "foo:bar": [
-                    {
-                        "name": "custom-multi-0",
-                        "digest": "",
-                        "digestAlgorithm": "sha256",
-                        "length": 0,
-                        "mime-type": "text/plain",
-                        "data": "",
-                    },
-                    {
-                        "name": "custom-multi-1",
-                        "digest": "",
-                        "digestAlgorithm": "sha256",
-                        "length": 0,
-                        "mime-type": "text/plain",
-                        "data": "",
-                    },
-                ],
-            },
-            "facets": [],
-            "lastModified": "2020-02-03 18:34:35",
-        }
-    )
-
-    assert doc.get_blob("foo:bar/0")
-    assert doc.get_blob("foo:bar/1")

--- a/tests/unit/test_objects.py
+++ b/tests/unit/test_objects.py
@@ -1,0 +1,132 @@
+import pytest
+from nxdrive.objects import Blob, NuxeoDocumentInfo
+
+
+@pytest.fixture(scope="session")
+def doc() -> NuxeoDocumentInfo:
+    """Mega object with several blob xpaths."""
+    return NuxeoDocumentInfo.from_dict(
+        {
+            "root": "root",
+            "uid": "uid",
+            "path": "path",
+            "properties": {
+                "dc:title": "dc:title",
+                "blobholder:0": {
+                    "name": "blob.empty",
+                    "digest": "",
+                    "digestAlgorithm": "sha256",
+                    "length": 0,
+                    "mime-type": "text/plain",
+                    "data": "",
+                },
+                "blobholder:1": {
+                    "name": "blob.empty",
+                    "digest": "",
+                    "digestAlgorithm": "sha256",
+                    "length": 0,
+                    "mime-type": "text/plain",
+                    "data": "",
+                },
+                "file:content": {
+                    "name": "file.empty",
+                    "digest": "",
+                    "digestAlgorithm": "sha256",
+                    "length": 0,
+                    "mime-type": "text/plain",
+                    "data": "",
+                },
+                "files:files": [
+                    {
+                        "file": {
+                            "name": "file.empty",
+                            "digest": "",
+                            "digestAlgorithm": "sha256",
+                            "length": 0,
+                            "mime-type": "text/plain",
+                            "data": "",
+                        },
+                    },
+                ],
+                "foo:bar": [
+                    {
+                        "name": "file.empty",
+                        "digest": "",
+                        "digestAlgorithm": "sha256",
+                        "length": 0,
+                        "mime-type": "text/plain",
+                        "data": "",
+                    },
+                    {
+                        "name": "custom-multi-1",
+                        "digest": "",
+                        "digestAlgorithm": "sha256",
+                        "length": 0,
+                        "mime-type": "text/plain",
+                        "data": "",
+                    },
+                ],
+                "foo:baz": [
+                    [
+                        [
+                            {
+                                "real:file": {
+                                    "name": "file.empty",
+                                    "digest": "",
+                                    "digestAlgorithm": "sha256",
+                                    "length": 0,
+                                    "mime-type": "text/plain",
+                                    "data": "",
+                                },
+                            },
+                        ],
+                    ],
+                ],
+                "note:note": {
+                    "name": "note.empty",
+                    "digest": "",
+                    "digestAlgorithm": "sha256",
+                    "length": 0,
+                    "mime-type": "text/plain",
+                    "data": "",
+                },
+            },
+            "facets": [],
+            "lastModified": "2020-02-03 18:34:35",
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "xpath",
+    [
+        "blobholder:0",
+        "blobholder:1",
+        "file:content",
+        "files:files/0/file",
+        "foo:bar/0",
+        "foo:bar/1",
+        "foo:baz/0/0/0/real:file",
+        "note:note",
+    ],
+)
+def test_get_blob_xpath(xpath, doc):
+    """NXDRIVE-2027: Check (Direct Edit) works on all kind of custom blob metadata values."""
+    assert isinstance(doc.get_blob(xpath), Blob)
+
+
+@pytest.mark.parametrize(
+    "xpath",
+    [
+        "blobholder:2",
+        "file:contents",
+        "files:files/1/file",
+        "foo:bar/2",
+        "foo:baz/1/0/0/real:file",
+        "note:note/0",
+        "unknown",
+    ],
+)
+def test_get_blob_xpath_bad(xpath, doc):
+    """Ensure that invalid xpath will not throw an error but simply return None."""
+    assert doc.get_blob(xpath) is None


### PR DESCRIPTION
There is no more limitations on the `xpath`.
Those are all valid if they are present in the `properties` attribute (given "s" for string and "n" for number):

- s:s (file:content, foo:bar, note:note)
- s:s/n (files:files/0, foo:bar/0)
- s:s/n/s (files:files/0/file)
- s:s/n/n/n/n/s/n/s/... (foo:baz/0/0/0/0/file/0/real:file...)

Notes handling is stricter, only "note:note" `xpath` is taken into account.