### PR TITLE
NXDRIVE-2041: [macOS] Fix the notarization in the auto-updater

### DIFF
--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from urllib.parse import unquote
 
 import requests
+from markdown import markdown
+from nuxeo.models import Document
 from PyQt5.QtCore import QEvent, QRect, Qt, QTimer, QUrl, pyqtSlot
 from PyQt5.QtGui import QCursor, QFont, QFontMetricsF, QIcon, QWindow
 from PyQt5.QtNetwork import QLocalServer, QLocalSocket
@@ -27,9 +29,6 @@ from PyQt5.QtWidgets import (
     QTextEdit,
     QVBoxLayout,
 )
-
-from markdown import markdown
-from nuxeo.models import Document
 
 from ..constants import (
     APP_NAME,
@@ -1543,10 +1542,10 @@ class Application(QApplication):
         info.setWordWrap(True)
         layout.addWidget(info)
 
-        def analytics_choice(state: Qt.CheckSate) -> None:
+        def analytics_choice(state: Qt.CheckState) -> None:
             Options.use_analytics = bool(state)
 
-        def errors_choice(state: Qt.CheckSate) -> None:
+        def errors_choice(state: Qt.CheckState) -> None:
             Options.use_sentry = bool(state)
 
         # Checkboxes

--- a/nxdrive/osi/darwin/darwin.py
+++ b/nxdrive/osi/darwin/darwin.py
@@ -336,7 +336,9 @@ class DarwinIntegration(AbstractOSIntegration):
 
     @staticmethod
     def _get_favorite_list() -> List[str]:
-        return list(LSSharedFileListCreate(None, kLSSharedFileListFavoriteItems, None))
+        return LSSharedFileListCreate(
+            None, kLSSharedFileListFavoriteItems, None
+        )  # type: ignore
 
     @staticmethod
     def _find_item_in_list(lst: List[str], name: str) -> Optional[str]:

--- a/tools/scripts/check_update_process.py
+++ b/tools/scripts/check_update_process.py
@@ -43,7 +43,7 @@ import yaml
 # Alter the lookup path to be able to find Nuxeo Drive sources
 sys.path.insert(0, os.getcwd())
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 EXT = {"darwin": "dmg", "linux": "appimage", "win32": "exe"}[sys.platform]
 Server = http.server.SimpleHTTPRequestHandler
@@ -193,7 +193,10 @@ def launch_drive(executable, args=None):
     if EXT == "appimage":
         cmd = [executable, *args]
     elif EXT == "dmg":
-        cmd = ["open", f"{Path.home()}/Applications/Nuxeo Drive.app", "--args", *args]
+        cmd = ["open", f"{Path.home()}/Applications/Nuxeo Drive.app"]
+        if args:
+            cmd.append("--args")
+            cmd.extend(*args)
     else:
         cmd = [
             expandvars(
@@ -378,8 +381,8 @@ def webserver(folder, port=8000):
     """ Start a local web server. """
 
     def stop(server):
-        """Stop the server after 30 seconds."""
-        time.sleep(30)
+        """Stop the server after 60 seconds."""
+        time.sleep(60)
         try:
             server.shutdown()
         except Exception:
@@ -389,7 +392,7 @@ def webserver(folder, port=8000):
 
     httpd = socketserver.TCPServer(("", port), Server)
     print(">>> Serving", folder, f"at http://localhost:{port}", flush=True)
-    print(">>> CTRL+C to terminate (or wait 30 sec)", flush=True)
+    print(">>> CTRL+C to terminate (or wait 60 sec)", flush=True)
     try:
         threading.Thread(target=stop, args=(httpd,)).start()
         httpd.serve_forever()


### PR DESCRIPTION
This is required to be able to use alpha versions as we will notarize official releases only.

Also:
- NXDRIVE-2041: Minor clean-up in `check_update_process.py`
- NXDRIVE-2045: [macOS] Fix a `TypeError` in `DarwinIntegration._get_favorite_list()`
- NXDRIVE-2044: Fix mispelled `Qt.CheckSate` attribute

Note: none of those tickets needs a changelog entry as for NXDRIVE-2044 and 2045 are regressions introduced in the current dev version; and the real fix for NXDRIVE-2041 will come later.
