### PR TITLE
Revert "Bump idna from 2.8 to 2.9 (#1360)"

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -66,7 +66,6 @@ Release date: `20xx-xx-xx`
 - Upgraded `certify` from 2019.9.11 to 2019.11.28
 - Upgraded `cffi` from 1.12.3 to 1.14.0
 - Upgraded `future` 0.18.0 to 0.18.2
-- Upgraded `idna` 2.8 to 2.9
 - Upgraded `macholib` from 1.11 to 1.14
 - Upgraded `markdown` from 3.1.1 to 3.2.1
 - Upgraded `nuxeo` 2.3.0 to 2.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,9 +78,9 @@ dukpy==0.2.2 \
     --hash=sha256:f8a526ec733b405e366f59c376530ce9f59797bbe6933a0ad6945628fad04626 \
     --hash=sha256:f9c63a0f7ae7696c4cba863e1cc45fb6c05b8f00c90eef2c2318dbea36ec3e90
     # via pypac
-idna==2.9 \
-    --hash=sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa \
-    --hash=sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb
+idna==2.8 \
+    --hash=sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407 \
+    --hash=sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c
     # via requests
 jmespath==0.9.4 \
     --hash=sha256:3720a4b1bd659dd2eecad0666459b9788813e032b83e7ba58578e48254e0a0e6 \


### PR DESCRIPTION
This reverts commit 8bd3c242f748808f15fbd235b448c2c260c71b87.

`requests` does not support it right now.