### PR TITLE
NXDRIVE-2047: Wait for the server config retrieval before checking fo…

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -101,6 +101,7 @@ Release date: `20xx-xx-xx`
 - Added `CustomMemoryHandler.flush()`
 - Added `EngineDAO.update_upload()`
 - Changed `Manager.is_paused()` from a function to an attribute
+- Removed `Manager.refresh_update_status()`. Use `.updater.refresh_status()` instead.
 - Added `Remote.personal_space()`
 - Changed `Upload.batch` from `str` to `nuxeo.models.Batch`
 - Removed `Upload.idx`. Use `Upload.batch["upload_idx"]` instead.

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -818,9 +818,8 @@ class Engine(QObject):
         # Checking root in case of failed migration
         self._check_root()
 
-        # Launch the server confg file updater
-        if self.manager.server_config_updater:
-            self.manager.server_config_updater.force_poll()
+        # Launch the server config file updater
+        self.manager.server_config_updater.force_poll()
 
         self.remove_staled_transfers()
         self.resume_suspended_transfers()

--- a/nxdrive/engine/workers.py
+++ b/nxdrive/engine/workers.py
@@ -267,10 +267,10 @@ class PollWorker(Worker):
         self._next_check = 0
 
     def _execute(self) -> None:
-        while self.enable:
+        while True:
             self._interact()
             if self.get_next_poll() <= 0:
-                if self._poll():
+                if self.enable and self._poll():
                     self._metrics["last_poll"] = int(time())
                 self._next_check = int(time()) + self._check_interval
             sleep(1)

--- a/nxdrive/manager.py
+++ b/nxdrive/manager.py
@@ -887,6 +887,7 @@ class Manager(QObject):
             self.osi.send_content_sync_status(states, path)
             return
 
+    @if_frozen
     def _write_version_file(self) -> None:
         """Save the current version in a VERSION file inside the home directory.
         This is for information purpose and used by the auto-update checker script."""

--- a/nxdrive/manager.py
+++ b/nxdrive/manager.py
@@ -339,11 +339,6 @@ class Manager(QObject):
         self.started.connect(self._extension_listener.start_listening)
         self.stopped.connect(self._extension_listener.close)
 
-    @if_frozen
-    def refresh_update_status(self) -> None:
-        if self.updater:
-            self.updater.refresh_status()
-
     def _create_direct_edit(self) -> "DirectEdit":
         self.direct_edit = DirectEdit(self, self.direct_edit_folder)
         self.started.connect(self.direct_edit.thread.start)
@@ -431,8 +426,6 @@ class Manager(QObject):
         return self.home / f"ndrive_{uid}.db"
 
     def _force_autoupdate(self) -> None:
-        if not self.updater:
-            return
         if self.updater.get_next_poll() > 60 and self.updater.get_last_poll() > 1800:
             self.updater.force_poll()
 
@@ -537,7 +530,7 @@ class Manager(QObject):
         self.prompted_wrong_channel = False
         # Trigger update status refresh
         if self.updater.enable:
-            self.refresh_update_status()
+            self.updater.refresh_status()
 
     @pyqtSlot(result=str)
     def get_log_level(self) -> str:
@@ -744,7 +737,7 @@ class Manager(QObject):
         self._engine_definitions.append(engine_def)
 
         # As new engine was just bound, refresh application update status
-        self.refresh_update_status()
+        self.updater.refresh_status()
 
         if starts:
             self.engines[uid].start()

--- a/nxdrive/updater/base.py
+++ b/nxdrive/updater/base.py
@@ -119,7 +119,7 @@ class BaseUpdater(PollWorker):
 
     @pyqtSlot(str)
     def update(self, version: str) -> None:
-        log.info(f"Starting application update process to version {version}")
+        log.info(f"Starting application update process to version {version!r}")
         self._set_status(UPDATE_STATUS_UPDATING, version=version, progress=10)
         try:
             self._install(version, self._download(version))
@@ -212,11 +212,13 @@ class BaseUpdater(PollWorker):
             if os.getenv("FORCE_USE_LATEST_VERSION", "0") == "1":
                 version = max(self.versions)
                 if version_lt(self.manager.version, version):
-                    log.info(f"FORCE_USE_LATEST_VERSION is set, ugrading to {version}")
+                    log.info(
+                        f"FORCE_USE_LATEST_VERSION is set, upgrading to {version!r}"
+                    )
                     self._set_status(UPDATE_STATUS_UPDATE_AVAILABLE, version=version)
                 else:
                     log.info(
-                        f"FORCE_USE_LATEST_VERSION is set, but {version} not newer than the current version"
+                        f"FORCE_USE_LATEST_VERSION is set, but {version!r} not newer than the current version"
                     )
                 return
 
@@ -227,8 +229,8 @@ class BaseUpdater(PollWorker):
 
             channel = self.manager.get_update_channel()
             log.info(
-                f"Getting update status for version {self.manager.version}"
-                f" (channel={channel}, desired client_version={Options.client_version})"
+                f"Getting update status for version {self.manager.version!r}"
+                f" (channel={channel}, desired client_version={Options.client_version!r})"
                 f" on server {self.server_ver}"
             )
             status, version = get_update_status(
@@ -246,7 +248,7 @@ class BaseUpdater(PollWorker):
             checksums = info.get("checksum", {})
             checksum = checksums.get(self.ext, "").lower()
             if not checksum:
-                log.info(
+                log.warning(
                     f"There is no downloadable file for the version {version!r} on that OS."
                 )
                 return

--- a/tools/jenkins/packages.groovy
+++ b/tools/jenkins/packages.groovy
@@ -14,6 +14,10 @@ properties([
             name: 'BRANCH_NAME',
             defaultValue: 'master'],
         [$class: 'BooleanParameterDefinition',
+            name: 'BYPASS_ACCOUNT',
+            defaultValue: true,
+            description: 'Used by the auto-updater to bypass the need for an account.'],
+        [$class: 'BooleanParameterDefinition',
             name: 'CLEAN_WORKSPACE',
             defaultValue: false,
             description: 'Clean the entire workspace before doing anything.']
@@ -77,8 +81,7 @@ for (x in agents) {
                     // Note: there seems to be too many commands that could have been split into sub-stages,
                     //       but this would duplicate too many things and take too much time and resources.
 
-                    // Used by the auto-updater to bypass the need for an account
-                    env.FORCE_USE_LATEST_VERSION = '1'
+                    env.FORCE_USE_LATEST_VERSION = env.BYPASS_ACCOUNT ? 1 : 0
 
                     dir('sources') {
                         dir('build') {

--- a/tools/scripts/check_update_process.py
+++ b/tools/scripts/check_update_process.py
@@ -196,7 +196,7 @@ def launch_drive(executable, args=None):
         cmd = ["open", f"{Path.home()}/Applications/Nuxeo Drive.app"]
         if args:
             cmd.append("--args")
-            cmd.extend(*args)
+            cmd.extend(args)
     else:
         cmd = [
             expandvars(
@@ -206,12 +206,7 @@ def launch_drive(executable, args=None):
         ]
 
     print(">>> Command:", cmd, flush=True)
-    try:
-        subprocess.check_call(cmd)
-    except subprocess.CalledProcessError:
-        # Either this is bad and OK the process will handle the error later;
-        # either this is an error at the end of the app exit, and it is OK too.
-        pass
+    subprocess.check_call(cmd)
 
 
 def save_log(output, name):


### PR DESCRIPTION
…r update at startup

Also:

- Skip the user prompt asking to auto-update when the update state is "forced".
- Prevent concurrent auto-updates.
- When the channel is centralizedn auto-updates are disabled and a client_version is set, then auto-updates are still effective.

And other patches needed for testing:
- `FORCE_USE_LATEST_VERSION` can be set in the job parameters.
-  Write the `$HOME/.nuxeo-drive/VERSION` file only when frozen.
- Fixes in `check_update_process.py`
-- Fixed a `TypeError: extend() takes exactly one argument (5 given)`.
-- Do not silently skip errors in `launch_drive()`.

PLus some code clean-up.
