### PR TITLE
NXDRIVE-2048: Reduce the amount of Process informations retrieved in the auto-locker

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -25,6 +25,7 @@ Release date: `20xx-xx-xx`
 - [NXDRIVE-2012](https://jira.nuxeo.com/browse/NXDRIVE-2012): Upgrade to sentry-sdk 0.14.1 to fix memory leaks
 - [NXDRIVE-2027](https://jira.nuxeo.com/browse/NXDRIVE-2027): Allow Direct Edit on custom blob metadata values
 - [NXDRIVE-2047](https://jira.nuxeo.com/browse/NXDRIVE-2047): Unlock updates on the centralized channel when auto-update is disabled
+- [NXDRIVE-2048](https://jira.nuxeo.com/browse/NXDRIVE-2048): Reduce the amount of Process informations retrieved in the auto-locker
 - [NXDRIVE-2052](https://jira.nuxeo.com/browse/NXDRIVE-2052): Optimize CPU consumption (and laptop batteries)
 - [NXDRIVE-2054](https://jira.nuxeo.com/browse/NXDRIVE-2054): Ask for a new batch in case of failed S3 upload resuming
 - [NXDRIVE-2055](https://jira.nuxeo.com/browse/NXDRIVE-2055): Process queued Qt events on CTRL+C

--- a/nxdrive/autolocker.py
+++ b/nxdrive/autolocker.py
@@ -5,9 +5,8 @@ from logging import getLogger
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Iterable, Iterator
 
-from PyQt5.QtCore import QTimer, pyqtSignal
-
 import psutil
+from PyQt5.QtCore import QTimer, pyqtSignal
 
 from .constants import LINUX, MAC, WINDOWS
 from .engine.workers import PollWorker
@@ -166,7 +165,7 @@ def get_open_files() -> Iterator[Item]:
     # It would be an endless fight to catch specific errors only.
     # Here, it is typically MemoryError's.
     try:
-        for proc in psutil.process_iter():
+        for proc in psutil.process_iter(attrs=["pid"]):
             # But we also want to filter out errors by processor to be able to retrieve some data from others
             with suppress(Exception):
                 for handler in proc.open_files():


### PR DESCRIPTION
 - Updated psutil.process_iter() call to retrieve only the process pid.
 - Fixed imports.

Signed-off-by: Romain Grasland <rgrasland@nuxeo.com>