### PR TITLE
NXDRIVE-2068: Use any macOS agent for releases

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -49,6 +49,8 @@ Release date: `20xx-xx-xx`
 - [NXDRIVE-2001](https://jira.nuxeo.com/browse/NXDRIVE-2001): Pin the Pip version to ease reproductible builds
 - [NXDRIVE-2050](https://jira.nuxeo.com/browse/NXDRIVE-2050): Provide auto-update scripts for wide deployment
 - [NXDRIVE-2056](https://jira.nuxeo.com/browse/NXDRIVE-2056): [GNU/Linux] PyInstaller 3.6 broke AppImage builds
+- [NXDRIVE-2062](https://jira.nuxeo.com/browse/NXDRIVE-2062): Upgrade mac-drive-2 to 10.13.6 (High Sierra)
+- [NXDRIVE-2068](https://jira.nuxeo.com/browse/NXDRIVE-2068): Upgrade mac-drive-1 to 10.13.6 (High Sierra)
 
 ## Tests
 

--- a/tools/jenkins/packages.groovy
+++ b/tools/jenkins/packages.groovy
@@ -25,12 +25,10 @@ properties([
 ])
 
 // Jenkins agents we will build on
-// agents = ['SLAVEPRIV', 'OSXSLAVE-DRIVE', 'WINSLAVE']
-agents = ['SLAVEPRIV', 'MAC-DRIVE-2', 'WINSLAVE']
+agents = ['SLAVEPRIV', 'OSXSLAVE-DRIVE', 'WINSLAVE']
 labels = [
     'SLAVEPRIV': 'GNU/Linux',
-    // 'OSXSLAVE-DRIVE': 'macOS',
-    'MAC-DRIVE-2': 'macOS',
+    'OSXSLAVE-DRIVE': 'macOS',
     'WINSLAVE': 'Windows'
 ]
 builders = [:]


### PR DESCRIPTION
The mac-drive-1 agent has been upgraded to 10.13.6 too, so it can be used for releases too.