### PR TITLE
NXDRIVE-2004: Allow to customize document types in tests

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -58,6 +58,7 @@ Release date: `20xx-xx-xx`
 
 - [NXDRIVE-1994](https://jira.nuxeo.com/browse/NXDRIVE-1994): [Windows] Skip JUnit report when running a specific test
 - [NXDRIVE-1996](https://jira.nuxeo.com/browse/NXDRIVE-1996): Add a script to check translations files
+- [NXDRIVE-2004](https://jira.nuxeo.com/browse/NXDRIVE-2004): Allow to customize document types in tests
 - [NXDRIVE-2013](https://jira.nuxeo.com/browse/NXDRIVE-2013): Create a script to convert NCO CSV log files to real log files
 - [NXDRIVE-2063](https://jira.nuxeo.com/browse/NXDRIVE-2063): Move tests logic to tox
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -34,6 +34,8 @@ The other part of tests is managed by the deploy script. Check the [documentatio
 
 You can customize several things using environment variables (see also [env.py](env.py)):
 
+- `DOCTYPE_FILE`: Document type for file creation (default is `File`).
+- `DOCTYPE_FOLDERISH`: Document type for non-file creations (default is `Folder`).
 - `REPORT_PATH`: If set to an existing local folder, a ZIP'ed report will be created when a test failed.
 - `SKIP_SENTRY`: Set to `1` to disable Sentry reports (enabled by default).
 - `SENTRY_DSN`: The Sentry DSN.

--- a/tests/env.py
+++ b/tests/env.py
@@ -14,3 +14,7 @@ WS_DIR = getenv("NXDRIVE_TEST_PATH", "/default-domain/workspaces")
 
 # On Windows, this is used to define the drive letter of a second NTFS partition
 SECOND_PARTITION = getenv("SECOND_PARTITION", "Q:\\")
+
+# Custom document types
+DOCTYPE_FILE = getenv("DOCTYPE_FILE", "File")
+DOCTYPE_FOLDERISH = getenv("DOCTYPE_FOLDERISH", "Folder")

--- a/tests/old_functional/__init__.py
+++ b/tests/old_functional/__init__.py
@@ -15,6 +15,8 @@ from nxdrive.objects import NuxeoDocumentInfo, RemoteFileInfo
 from nxdrive.options import Options
 from nxdrive.utils import force_encode, safe_filename
 
+from .. import env
+
 
 def patch_nxdrive_objects():
     """Some feature are not needed or are better disabled when testing."""
@@ -207,7 +209,13 @@ class RemoteBase(Remote):
 
     def get_children_info(self, ref: str, limit: int = 1000) -> List[NuxeoDocumentInfo]:
         ref = self._escape(self.check_ref(ref))
-        types = {"File", "Note", "Workspace", "Folder", "Picture"}
+        types = {
+            "Note",
+            "Workspace",
+            "Picture",
+            env.DOCTYPE_FILE,
+            env.DOCTYPE_FOLDERISH,
+        }
 
         query = (
             "SELECT * FROM Document"
@@ -439,7 +447,11 @@ class DocRemote(RemoteTest):
         return doc["uid"]
 
     def make_file(
-        self, parent: str, name: str, content: bytes = None, doc_type: str = "File"
+        self,
+        parent: str,
+        name: str,
+        content: bytes = None,
+        doc_type: str = env.DOCTYPE_FILE,
     ) -> str:
         """Create a document of the given type with the given name and content
 
@@ -474,7 +486,7 @@ class DocRemote(RemoteTest):
         file_path: str,
         filename: str = None,
         mime_type: str = None,
-        doc_type: str = "File",
+        doc_type: str = env.DOCTYPE_FILE,
     ) -> str:
         """Create a document by streaming the file with the given path"""
         ref = self.make_file(parent, name, doc_type=doc_type)

--- a/tools/jenkins/test_volume_specific.groovy
+++ b/tools/jenkins/test_volume_specific.groovy
@@ -15,6 +15,8 @@ properties([
         string(name: 'NXDRIVE_TEST_USERNAME', defaultValue: 'Administrator', description: 'The user having administrator rights.', trim: true),
         string(name: 'NXDRIVE_TEST_PASSWORD', defaultValue: 'Administrator', description: 'The password associated to the username.', trim: true),
         string(name: 'NXDRIVE_TEST_PATH', defaultValue: '/default-domain/workspaces', description: 'The remote path where to store data. Must exist.', trim: true),
+        string(name: 'DOCTYPE_FILE', defaultValue: 'File', description: 'Document type for file creations.', trim: true),
+        string(name: 'DOCTYPE_FOLDERISH', defaultValue: 'Folder', description: 'Document type for non-file creations.', trim: true),
         string(name: 'TEST_VOLUME', defaultValue: '3,200,3', description: '<ul><li>number of folders</li><li>number of files to create inside each folder</li><li>depth: the tree will be replicated into itself <i>depth</i> times</li><li>Total is <code>...</code> (here 309,858)</ul>', trim: true),
         string(name: 'TEST_REMOTE_SCAN_VOLUME', defaultValue: '200000', description: 'Minimum number of documents to randomly import (here > 200,000).', trim: true),
         booleanParam(name: 'USE_MAC_DRIVE_1', defaultValue: true, description: 'macOS client n° 1.'),


### PR DESCRIPTION
Introduced 2 envars to control document types:

- `DOCTYPE_FILE` for file creations;
- `DOCTYPE_FOLDERISH` for non-files creations.