### PR TITLE
NXDRIVE-2010: Restart the download on HTTP 416 error (range not satis…

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -23,6 +23,7 @@ Release date: `20xx-xx-xx`
 - [NXDRIVE-2002](https://jira.nuxeo.com/browse/NXDRIVE-2002): Use a stricter mypy configuration
 - [NXDRIVE-2005](https://jira.nuxeo.com/browse/NXDRIVE-2005): Use stricter flake8 plugins in pre-commit
 - [NXDRIVE-2008](https://jira.nuxeo.com/browse/NXDRIVE-2008): Run codespell on the entire code base
+- [NXDRIVE-2010](https://jira.nuxeo.com/browse/NXDRIVE-2010): Restart the download on HTTP 416 error (range not satisfiable)
 - [NXDRIVE-2012](https://jira.nuxeo.com/browse/NXDRIVE-2012): Upgrade to sentry-sdk 0.14.1 to fix memory leaks
 - [NXDRIVE-2027](https://jira.nuxeo.com/browse/NXDRIVE-2027): Allow Direct Edit on custom blob metadata values
 - [NXDRIVE-2040](https://jira.nuxeo.com/browse/NXDRIVE-2040): [Direct Transfer] Temporary disable folder uploads

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -327,6 +327,14 @@ class Processor(EngineWorker):
                     # starting with identical characters.
                     log.warning(f"Delaying conflicted document: {doc_pair!r}")
                     self._postpone_pair(doc_pair, "Conflict")
+                elif exc.status == 416:
+                    log.warning(f"Invalid downloaded temporary file: {doc_pair!r}")
+                    tmp_folder = (
+                        self.engine.download_dir / doc_pair.remote_ref.split("#")[-1]
+                    )
+                    with suppress(FileNotFoundError):
+                        shutil.rmtree(tmp_folder)
+                    self._postpone_pair(doc_pair, "Requested Range Not Satisfiable")
                 elif exc.status == 500:
                     self.increase_error(doc_pair, "SERVER_ERROR", exception=exc)
                 elif exc.status in (502, 503):

--- a/tests/old_functional/test_synchronization.py
+++ b/tests/old_functional/test_synchronization.py
@@ -819,7 +819,7 @@ class TestSynchronization(OneUserTest):
 
         # Checks
         assert not engine.dao.get_errors()
-        assert self.local_1.exists("/test.bin")
+        assert local.exists("/test.bin")
 
     def test_local_modify_offline(self):
         local = self.local_1

--- a/tests/old_functional/test_synchronization.py
+++ b/tests/old_functional/test_synchronization.py
@@ -4,14 +4,12 @@ from pathlib import Path
 from unittest.mock import patch
 
 from requests import ConnectionError
-
 from nuxeo.exceptions import HTTPError, Unauthorized
 from nxdrive.constants import ROOT, WINDOWS
 from nxdrive.utils import safe_filename
-
 from .. import ensure_no_exception
-from . import LocalTest
 from .common import OS_STAT_MTIME_RESOLUTION, OneUserNoSync, OneUserTest, TwoUsersTest
+from . import LocalTest
 
 
 class TestSynchronizationDisabled(OneUserNoSync):
@@ -790,6 +788,38 @@ class TestSynchronization(OneUserTest):
         assert len(children) == 2
         assert children[0].name == file1
         assert children[1].name == file2
+
+    def test_416_range_past_eof(self):
+        """
+        Test wrong bytes range during download.
+        """
+
+        remote = self.remote_document_client_1
+        local = self.local_1
+        engine = self.engine_1
+
+        engine.start()
+        self.wait_sync(wait_for_async=True)
+        assert local.exists("/")
+
+        remote.make_file("/", "test.bin", content=b"42")
+
+        # Simulate a requested range not satisfiable on file download
+        bad_remote = self.get_bad_remote()
+        error = HTTPError(status=416, message="Mock Requested Range Not Satisfiable")
+        bad_remote.make_download_raise(error)
+
+        with patch.object(self.engine_1, "remote", new=bad_remote):
+            self.wait_sync(fail_if_timeout=False)
+            # Checks
+            assert engine.dao.queue_manager.get_errors_count() == 1
+
+        # Starting here, default behavior is restored
+        self.wait_sync()
+
+        # Checks
+        assert not engine.dao.get_errors()
+        assert self.local_1.exists("/test.bin")
 
     def test_local_modify_offline(self):
         local = self.local_1


### PR DESCRIPTION
…fiable)

When a download is paused, it may happen that the file size on the server
is modified. In this particular case, an HTTP 416 error will be raised.
We want the local temporary file to be deleted and the download to be
restarted.
The processor.py file have been updated to catch and process the error.
A new test have been added in the test_synchronization.py file.
Also the changelog have been updated.