### PR TITLE
NXDRIVE-2010: Restart the download on HTTP 416 error (range not satisfiable)

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -23,6 +23,7 @@ Release date: `20xx-xx-xx`
 - [NXDRIVE-2002](https://jira.nuxeo.com/browse/NXDRIVE-2002): Use a stricter mypy configuration
 - [NXDRIVE-2005](https://jira.nuxeo.com/browse/NXDRIVE-2005): Use stricter flake8 plugins in pre-commit
 - [NXDRIVE-2008](https://jira.nuxeo.com/browse/NXDRIVE-2008): Run codespell on the entire code base
+- [NXDRIVE-2010](https://jira.nuxeo.com/browse/NXDRIVE-2010): Restart the download on HTTP 416 error (range not satisfiable)
 - [NXDRIVE-2012](https://jira.nuxeo.com/browse/NXDRIVE-2012): Upgrade to sentry-sdk 0.14.1 to fix memory leaks
 - [NXDRIVE-2027](https://jira.nuxeo.com/browse/NXDRIVE-2027): Allow Direct Edit on custom blob metadata values
 - [NXDRIVE-2040](https://jira.nuxeo.com/browse/NXDRIVE-2040): [Direct Transfer] Temporary disable folder uploads

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -327,6 +327,14 @@ class Processor(EngineWorker):
                     # starting with identical characters.
                     log.warning(f"Delaying conflicted document: {doc_pair!r}")
                     self._postpone_pair(doc_pair, "Conflict")
+                elif exc.status == 416:
+                    log.warning(f"Invalid downloaded temporary file: {doc_pair!r}")
+                    tmp_folder = (
+                        self.engine.download_dir / doc_pair.remote_ref.split("#")[-1]
+                    )
+                    with suppress(FileNotFoundError):
+                        shutil.rmtree(tmp_folder)
+                    self._postpone_pair(doc_pair, "Requested Range Not Satisfiable")
                 elif exc.status == 500:
                     self.increase_error(doc_pair, "SERVER_ERROR", exception=exc)
                 elif exc.status in (502, 503):


### PR DESCRIPTION
When a download is paused, it may happen that the file size on the server
is modified. In this particular case, an HTTP 416 error will be raised.
We want the local temporary file to be deleted and the download to be
restarted.
The processor.py file have been updated to catch and process the error.
A new test have been added in the test_synchronization.py file.
Also the changelog have been updated.