### PR TITLE
NXDRIVE-1991: Fix the tests "rerun" mechanism

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -58,6 +58,7 @@ Release date: `20xx-xx-xx`
 
 ## Tests
 
+- [NXDRIVE-1991](https://jira.nuxeo.com/browse/NXDRIVE-1991): Fix the tests "rerun" mechanism
 - [NXDRIVE-1994](https://jira.nuxeo.com/browse/NXDRIVE-1994): [Windows] Skip JUnit report when running a specific test
 - [NXDRIVE-1996](https://jira.nuxeo.com/browse/NXDRIVE-1996): Add a script to check translations files
 - [NXDRIVE-2004](https://jira.nuxeo.com/browse/NXDRIVE-2004): Allow to customize document types in tests

--- a/tools/check_pytest_lastfailed.py
+++ b/tools/check_pytest_lastfailed.py
@@ -1,0 +1,37 @@
+# coding: utf-8
+"""
+This script allows the user to check that the pytest cache folder contains
+a valid lastfailed file. Will return 1 if the cache file is not found or if
+no test failed. Else return 0.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+EXIT_SUCCESS = 0
+EXIT_FAILURE = 1
+
+
+def run_check() -> int:
+    """Open the lastfailed file and check its content."""
+
+    last_failed_file = Path(".pytest_cache/v/cache/lastfailed")
+
+    try:
+        data = json.loads(last_failed_file.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(">>> No lastfailed cache file.", flush=True)
+        return EXIT_FAILURE
+
+    for _, value in data.items():
+        if value:
+            print(">>> Failure found.", flush=True)
+            return EXIT_SUCCESS
+
+    print(">>> No failure found.", flush=True)
+    return EXIT_FAILURE
+
+
+if __name__ == "__main__":
+    sys.exit(run_check())

--- a/tools/posix/deploy_jenkins_slave.sh
+++ b/tools/posix/deploy_jenkins_slave.sh
@@ -217,6 +217,10 @@ launch_test() {
     ${cmd} ${pytest_args} `junit_arg ${path} 1` "${path}" && return
 
     if should_run "rerun"; then
+        # ${cmd} --cache-show
+        # Will return 0 if rerun is needed else 1
+        ${PYTHON} tools/check_pytest_lastfailed.py || return
+
         # Do not fail on error as all failures will be re-run another time at the end
         ${cmd} --last-failed --last-failed-no-failures none `junit_arg ${path} 2`  || true
     fi
@@ -225,6 +229,8 @@ launch_test() {
 launch_tests() {
     local ret=0
     local junit_folder="tools/jenkins/junit/xml"
+
+    rm -rf .pytest_cache
 
     # If a specific test is asked, just run it and bypass all over checks
     if [ "${SPECIFIC_TEST}" != "tests" ]; then
@@ -251,6 +257,8 @@ launch_tests() {
 
         if should_run "rerun"; then
             echo ">>> Re-rerun failed tests"
+            ${PYTHON} tools/check_pytest_lastfailed.py || return
+
             set +e
             ${PYTHON} -bb -Wall -m pytest --last-failed --last-failed-no-failures none `junit_arg "final"`
             # The above command will exit with error code 5 if there is no failure to rerun

--- a/tools/posix/deploy_jenkins_slave.sh
+++ b/tools/posix/deploy_jenkins_slave.sh
@@ -257,6 +257,8 @@ launch_tests() {
 
         if should_run "rerun"; then
             echo ">>> Re-rerun failed tests"
+
+            # Will return 0 if rerun is needed else 1
             ${PYTHON} tools/check_pytest_lastfailed.py || return
 
             set +e

--- a/tools/windows/deploy_jenkins_slave.ps1
+++ b/tools/windows/deploy_jenkins_slave.ps1
@@ -371,14 +371,14 @@ function launch_test($path, $pytest_args) {
 	}
 
 	if (-not ($Env:SKIP -match 'rerun' -or $Env:SKIP -match 'all')) {
-		# Do not fail on error as all failures will be re-run another time at the end
-		$junitxml = junit_arg $path 2
+		# Will return 0 if rerun is needed else 1
 		& $Env:STORAGE_DIR\Scripts\python.exe tools\check_pytest_lastfailed.py
-
 		if ($lastExitCode -eq 1) {
 			return
 		}
 
+		# Do not fail on error as all failures will be re-run another time at the end
+		$junitxml = junit_arg $path 2
 		& $Env:STORAGE_DIR\Scripts\python.exe $global:PYTHON_OPT -bb -Wall -m pytest `
 			--last-failed --last-failed-no-failures none $junitxml
 	}
@@ -419,6 +419,7 @@ function launch_tests {
 		if (-not ($Env:SKIP -match 'rerun' -or $Env:SKIP -match 'all')) {
 			Write-Output ">>> Re-rerun failed tests"
 
+			# Will return 0 if rerun is needed else 1
 			& $Env:STORAGE_DIR\Scripts\python.exe tools\check_pytest_lastfailed.py
 			if ($lastExitCode -eq 1) {
 				return

--- a/tools/windows/deploy_jenkins_slave.ps1
+++ b/tools/windows/deploy_jenkins_slave.ps1
@@ -373,6 +373,12 @@ function launch_test($path, $pytest_args) {
 	if (-not ($Env:SKIP -match 'rerun' -or $Env:SKIP -match 'all')) {
 		# Do not fail on error as all failures will be re-run another time at the end
 		$junitxml = junit_arg $path 2
+		& $Env:STORAGE_DIR\Scripts\python.exe tools\check_pytest_lastfailed.py
+
+		if ($lastExitCode -eq 1) {
+			return
+		}
+
 		& $Env:STORAGE_DIR\Scripts\python.exe $global:PYTHON_OPT -bb -Wall -m pytest `
 			--last-failed --last-failed-no-failures none $junitxml
 	}
@@ -380,6 +386,11 @@ function launch_test($path, $pytest_args) {
 
 function launch_tests {
 	$junit_folder = "tools\jenkins\junit\xml"
+
+	if (Test-Path ".pytest_cache") {
+		Remove-Item -Path ".pytest_cache" -Verbose
+	}
+
 	# If a specific test is asked, just run it and bypass all over checks
 	if ($Env:SPECIFIC_TEST -ne "tests") {
 		Write-Output ">>> Launching the tests suite"
@@ -407,6 +418,12 @@ function launch_tests {
 
 		if (-not ($Env:SKIP -match 'rerun' -or $Env:SKIP -match 'all')) {
 			Write-Output ">>> Re-rerun failed tests"
+
+			& $Env:STORAGE_DIR\Scripts\python.exe tools\check_pytest_lastfailed.py
+			if ($lastExitCode -eq 1) {
+				return
+			}
+
 			$junitxml = junit_arg "final"
 			& $Env:STORAGE_DIR\Scripts\python.exe $global:PYTHON_OPT -bb -Wall -m pytest `
 				--last-failed --last-failed-no-failures none $junitxml


### PR DESCRIPTION
When all tests pass, the "rerun" mecanism will still
be executed. And then all tests will be started, without
OS filtering.
The problem is caused by the pytest_cache that is used by the
command `pytest --last-failed --last-failed-no-failures`.
When all test pass, the lastfailed cache file will be empty,
in that case, the command will collect and rerun all the tests.
When this happen no test should be run at all.
The check_pytest_lastfailed.py file has been added to verify
verify the lastfailed cache file.
The script is called by the `deploy_jenkins_slave`(.sh|.ps1) files.
The .pytest_cache folder is now deleted before launching tests.
Also the changelog have been updated.

Signed-off-by: Romain Grasland <rgrasland@nuxeo.com>