### PR TITLE
NXDRIVE-2049: Skip malformed local configuration files

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -29,6 +29,7 @@ Release date: `20xx-xx-xx`
 - [NXDRIVE-2040](https://jira.nuxeo.com/browse/NXDRIVE-2040): [Direct Transfer] Temporary disable folder uploads
 - [NXDRIVE-2047](https://jira.nuxeo.com/browse/NXDRIVE-2047): Unlock updates on the centralized channel when auto-update is disabled
 - [NXDRIVE-2048](https://jira.nuxeo.com/browse/NXDRIVE-2048): Reduce the amount of Process information retrieved in the auto-locker
+- [NXDRIVE-2049](https://jira.nuxeo.com/browse/NXDRIVE-2049): Skip malformed local configuration files
 - [NXDRIVE-2052](https://jira.nuxeo.com/browse/NXDRIVE-2052): Optimize CPU consumption (and laptop batteries)
 - [NXDRIVE-2054](https://jira.nuxeo.com/browse/NXDRIVE-2054): Ask for a new batch in case of failed S3 upload resuming
 - [NXDRIVE-2055](https://jira.nuxeo.com/browse/NXDRIVE-2055): Process queued Qt events on CTRL+C


### PR DESCRIPTION
When reading a config file with an unhandled encoding the config parser will crash.
We want Drive to ignore those files.
Drive is now handling only UTF-8 encoding for the config file.
A new test have been added in the test_commandline.py file.
Also changelog have been updated.

Signed-off-by: Romain Grasland <rgrasland@nuxeo.com>