### PR TITLE
NXDRIVE-1970: get_tree_size() and get_tree_list() should be resilient to OS errors

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -4,6 +4,7 @@ Release date: `20xx-xx-xx`
 
 ## Core
 
+- [NXDRIVE-374](https://jira.nuxeo.com/browse/NXDRIVE-374): Use file system decorations on GNU/Linux
 - [NXDRIVE-1831](https://jira.nuxeo.com/browse/NXDRIVE-1831): [GNU/Linux] Set the root local folder icon
 - [NXDRIVE-1847](https://jira.nuxeo.com/browse/NXDRIVE-1847): [Windows] Fix endless synchronization on fast create-then-rename folder
 - [NXDRIVE-1893](https://jira.nuxeo.com/browse/NXDRIVE-1893): Remove hardcoded "Nuxeo Drive" strings
@@ -12,6 +13,7 @@ Release date: `20xx-xx-xx`
 - [NXDRIVE-1958](https://jira.nuxeo.com/browse/NXDRIVE-1958): [Direct Transfer] Create a remote subfolder when uploaing a folder
 - [NXDRIVE-1966](https://jira.nuxeo.com/browse/NXDRIVE-1966): Use a custom parent folder for downloads on different partition
 - [NXDRIVE-1969](https://jira.nuxeo.com/browse/NXDRIVE-1969): [Windows] Direct Edit should work when the sync folder is not on C:
+- [NXDRIVE-1970](https://jira.nuxeo.com/browse/NXDRIVE-1970): get_tree_size() and get_tree_list() should be resilient to OS errors
 - [NXDRIVE-1976](https://jira.nuxeo.com/browse/NXDRIVE-1976): [macOS] Do not fail the auto-update on unmountable volume
 - [NXDRIVE-1980](https://jira.nuxeo.com/browse/NXDRIVE-1980): Force apply of local configuration options that use the default value
 - [NXDRIVE-1981](https://jira.nuxeo.com/browse/NXDRIVE-1981): Better improvement patch for `safe_filename()`

--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -4,7 +4,6 @@ Release date: `20xx-xx-xx`
 
 ## Core
 
-- [NXDRIVE-374](https://jira.nuxeo.com/browse/NXDRIVE-374): Use file system decorations on GNU/Linux
 - [NXDRIVE-1831](https://jira.nuxeo.com/browse/NXDRIVE-1831): [GNU/Linux] Set the root local folder icon
 - [NXDRIVE-1847](https://jira.nuxeo.com/browse/NXDRIVE-1847): [Windows] Fix endless synchronization on fast create-then-rename folder
 - [NXDRIVE-1893](https://jira.nuxeo.com/browse/NXDRIVE-1893): Remove hardcoded "Nuxeo Drive" strings

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -322,6 +322,12 @@ def get_tree_list(
     yield remote_ref, path
     remote_ref += f"/{path.name}"
 
+    try:
+        path.is_dir()
+    except OSError:
+        log.warning(f"Error calling is_dir() on: {path!r}", exc_info=True)
+        return
+
     # Then, yield its children
     with os.scandir(path) as it:
         for entry in it:
@@ -342,6 +348,12 @@ def get_tree_size(path: Path) -> int:
     Note: this function cannot be decorated with lru_cache().
     """
     size = 0
+    try:
+        path.is_dir()
+    except OSError:
+        log.warning(f"Error calling is_dir() on: {path!r}", exc_info=True)
+        return size
+
     with os.scandir(path) as it:
         for entry in it:
             try:

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -320,7 +320,7 @@ def get_tree_list(
     """
     try:
         path.is_dir()
-    except (PermissionError, OSError):
+    except OSError:
         log.warning(f"Error calling is_dir() on: {path!r}", exc_info=True)
         return
 
@@ -333,7 +333,7 @@ def get_tree_list(
         for entry in it:
             try:
                 is_dir = entry.is_dir()
-            except (PermissionError, OSError):
+            except OSError:
                 log.warning(f"Error calling is_dir() on: {entry.path!r}", exc_info=True)
                 continue
             if is_dir:
@@ -350,7 +350,7 @@ def get_tree_size(path: Path) -> int:
     size = 0
     try:
         path.is_dir()
-    except (PermissionError, OSError):
+    except OSError:
         log.warning(f"Error calling is_dir() on: {path!r}", exc_info=True)
         return size
 
@@ -358,7 +358,7 @@ def get_tree_size(path: Path) -> int:
         for entry in it:
             try:
                 is_dir = entry.is_dir()
-            except (PermissionError, OSError):
+            except OSError:
                 log.warning(f"Error calling is_dir() on: {entry.path!r}", exc_info=True)
                 continue
             if is_dir:

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -328,7 +328,7 @@ def get_tree_list(
             try:
                 is_dir = entry.is_dir()
             except OSError:
-                log.warning(f"Error calling is_dir() on: {entry.path}")
+                log.warning(f"Error calling is_dir() on: {entry.path!r}", exc_info=True)
                 continue
             if is_dir:
                 yield from get_tree_list(Path(entry.path), remote_ref)
@@ -347,7 +347,7 @@ def get_tree_size(path: Path) -> int:
             try:
                 is_dir = entry.is_dir()
             except OSError:
-                log.warning(f"Error calling is_dir() on: {entry.path}")
+                log.warning(f"Error calling is_dir() on: {entry.path!r}", exc_info=True)
                 continue
             if is_dir:
                 size += get_tree_size(Path(entry.path))

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -318,15 +318,15 @@ def get_tree_list(
 
     Note: this function cannot be decorated with lru_cache().
     """
-    # First, yield the folder itself
-    yield remote_ref, path
-    remote_ref += f"/{path.name}"
-
     try:
         path.is_dir()
     except OSError:
         log.warning(f"Error calling is_dir() on: {path!r}", exc_info=True)
         return
+
+    # First, yield the folder itself
+    yield remote_ref, path
+    remote_ref += f"/{path.name}"
 
     # Then, yield its children
     with os.scandir(path) as it:

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -320,7 +320,7 @@ def get_tree_list(
     """
     try:
         path.is_dir()
-    except OSError:
+    except (PermissionError, OSError):
         log.warning(f"Error calling is_dir() on: {path!r}", exc_info=True)
         return
 
@@ -333,7 +333,7 @@ def get_tree_list(
         for entry in it:
             try:
                 is_dir = entry.is_dir()
-            except OSError:
+            except (PermissionError, OSError):
                 log.warning(f"Error calling is_dir() on: {entry.path!r}", exc_info=True)
                 continue
             if is_dir:
@@ -350,7 +350,7 @@ def get_tree_size(path: Path) -> int:
     size = 0
     try:
         path.is_dir()
-    except OSError:
+    except (PermissionError, OSError):
         log.warning(f"Error calling is_dir() on: {path!r}", exc_info=True)
         return size
 
@@ -358,7 +358,7 @@ def get_tree_size(path: Path) -> int:
         for entry in it:
             try:
                 is_dir = entry.is_dir()
-            except OSError:
+            except (PermissionError, OSError):
                 log.warning(f"Error calling is_dir() on: {entry.path!r}", exc_info=True)
                 continue
             if is_dir:

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -325,10 +325,15 @@ def get_tree_list(
     # Then, yield its children
     with os.scandir(path) as it:
         for entry in it:
-            if entry.is_file():
-                yield remote_ref, Path(entry.path)
-            elif entry.is_dir():
+            try:
+                is_dir = entry.is_dir()
+            except OSError:
+                log.warning(f"Error calling is_dir() on: {entry.path}")
+                continue
+            if is_dir:
                 yield from get_tree_list(Path(entry.path), remote_ref)
+            elif entry.is_file():
+                yield remote_ref, Path(entry.path)
 
 
 def get_tree_size(path: Path) -> int:
@@ -339,10 +344,15 @@ def get_tree_size(path: Path) -> int:
     size = 0
     with os.scandir(path) as it:
         for entry in it:
-            if entry.is_file():
-                size += entry.stat().st_size
-            elif entry.is_dir():
+            try:
+                is_dir = entry.is_dir()
+            except OSError:
+                log.warning(f"Error calling is_dir() on: {entry.path}")
+                continue
+            if is_dir:
                 size += get_tree_size(Path(entry.path))
+            elif entry.is_file():
+                size += entry.stat().st_size
     return size
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -503,6 +503,18 @@ def test_get_tree_list():
     assert guessed_rpaths == expected_rpaths
 
 
+@patch("os.scandir")
+def test_get_tree_list_os_error(mock_scandir):
+    remote_ref = f"{env.WS_DIR}/foo"
+    mock_scandir.return_value.__enter__.return_value = iter(
+        [FakeDirEntry(), FakeDirEntry(True), FakeDirEntry(True, True)]
+    )
+    tree = list(nxdrive.utils.get_tree_list(Path("/fake"), remote_ref))
+
+    # We did not go into the third FakeDir because of OSError
+    assert len(tree) == 3
+
+
 def test_get_tree_size():
     location = nxdrive.utils.normalized_path(__file__).parent.parent
     path = location / "resources"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -514,7 +514,7 @@ def test_get_tree_list():
 @patch("pathlib.Path.is_dir")
 def test_get_tree_list_dir_raise_os_error(mock_path):
     remote_ref = f"{env.WS_DIR}/foo"
-    mock_path.side_effect = OSError
+    mock_path.side_effect = OSError("Mock'ed OSError")
 
     tree = list(nxdrive.utils.get_tree_list(Path("/fake"), remote_ref))
 
@@ -567,8 +567,8 @@ def test_get_tree_size_subdir_raise_permission_error(mock_scandir):
 
 
 @patch("pathlib.Path.is_dir")
-def test_get_tree_size_dir_raise_os_error(mock_path):
-    mock_path.side_effect = OSError
+def test_get_tree_size_dir_raise_permission_error(mock_path):
+    mock_path.side_effect = PermissionError("Mock'ed PermissionError")
     assert nxdrive.utils.get_tree_size(Path("/fake/path")) == 0
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -510,8 +510,8 @@ def test_get_tree_list_dir_raise_os_error(mock_path):
 
     tree = list(nxdrive.utils.get_tree_list(Path("/fake"), remote_ref))
 
-    # We exit right after the first yield because of OSError
-    assert len(tree) == 1
+    # We exit before the first yield because of OSError
+    assert len(tree) == 0
 
 
 @patch("os.scandir")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -532,7 +532,7 @@ def test_get_tree_list_subdir_raise_os_error(mock_scandir):
             FakeDirEntry(
                 is_dir=True,
                 should_raise=True,
-                raised_exception=OSError("Too many levels of symbolic links"),
+                raised_exception=OSError("Mock'ed Too many levels of symbolic links"),
             ),
         ]
     )
@@ -558,7 +558,7 @@ def test_get_tree_size_subdir_raise_permission_error(mock_scandir):
             FakeDirEntry(
                 is_dir=True,
                 should_raise=True,
-                raised_exception=PermissionError("Permission denied"),
+                raised_exception=PermissionError("Mock'ed Permission denied"),
             ),
         ]
     )


### PR DESCRIPTION
'get_tree_size()' and 'get_tree_list()' methods have been updated to catch OSError.