### PR TITLE
NXDRIVE-2091: Wait for the server configuration before starting features

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -39,6 +39,7 @@ Release date: `20xx-xx-xx`
 - [NXDRIVE-2086](https://jira.nuxeo.com/browse/NXDRIVE-2086): Fix mypy issues following the update to mypy 0.770
 - [NXDRIVE-2088](https://jira.nuxeo.com/browse/NXDRIVE-2088): Make the synchronization_enabled option effective locally in certain conditions
 - [NXDRIVE-2090](https://jira.nuxeo.com/browse/NXDRIVE-2090): Ask for application restart on specific server config change
+- [NXDRIVE-2091](https://jira.nuxeo.com/browse/NXDRIVE-2091): Wait for the server configuration before starting features
 
 ## GUI
 
@@ -132,6 +133,7 @@ Release date: `20xx-xx-xx`
 - Added `Manager.restartNeeded` signal
 - Changed `Manager.is_paused()` from a function to an attribute
 - Removed `Manager.refresh_update_status()`. Use `.updater.refresh_status()` instead.
+- Changed `dao` argument of `ProcessAutoLockerWorker.__init__()` to `manager`
 - Added `Remote.personal_space()`
 - Changed `Upload.batch` from `str` to `nuxeo.models.Batch`
 - Removed `Upload.idx`. Use `Upload.batch["upload_idx"]` instead.

--- a/nxdrive/direct_edit.py
+++ b/nxdrive/direct_edit.py
@@ -95,6 +95,26 @@ class DirectEdit(Worker):
         self.autolock.orphanLocks.connect(self._autolock_orphans)
         self._manager.directEdit.connect(self.edit)
 
+        # Notification signals
+        self.directEditLockError.connect(
+            self._manager.notification_service._directEditLockError
+        )
+        self.directEditStarting.connect(
+            self._manager.notification_service._directEditStarting
+        )
+        self.directEditForbidden.connect(
+            self._manager.notification_service._directEditForbidden
+        )
+        self.directEditReadonly.connect(
+            self._manager.notification_service._directEditReadonly
+        )
+        self.directEditLocked.connect(
+            self._manager.notification_service._directEditLocked
+        )
+        self.directEditUploadCompleted.connect(
+            self._manager.notification_service._directEditUpdated
+        )
+
     @pyqtSlot(object)
     def _autolock_orphans(self, locks: List[Path]) -> None:
         log.debug(f"Orphans lock: {locks!r}")

--- a/nxdrive/notification.py
+++ b/nxdrive/notification.py
@@ -506,16 +506,6 @@ class DefaultNotificationService(NotificationService):
     def init_signals(self) -> None:
         self._manager.initEngine.connect(self._connect_engine)
         self._manager.newEngine.connect(self._connect_engine)
-        self._manager.direct_edit.directEditLockError.connect(self._directEditLockError)
-        self._manager.direct_edit.directEditStarting.connect(self._directEditStarting)
-        self._manager.direct_edit.directEditForbidden.connect(self._directEditForbidden)
-        self._manager.direct_edit.directEditReadonly.connect(self._directEditReadonly)
-        self._manager.direct_edit.directEditLocked.connect(self._directEditLocked)
-        self._manager.direct_edit.directEditUploadCompleted.connect(
-            self._directEditUpdated
-        )
-        self._manager.autolock_service.documentLocked.connect(self._lockDocument)
-        self._manager.autolock_service.documentUnlocked.connect(self._unlockDocument)
 
     def _connect_engine(self, engine: "Engine") -> None:
         engine.newConflict.connect(self._newConflict)

--- a/tests/old_functional/__init__.py
+++ b/tests/old_functional/__init__.py
@@ -28,14 +28,20 @@ def patch_nxdrive_objects():
 
     nxdrive.engine.dao.utils.save_backup = lambda *args: True
 
+    from nxdrive.poll_workers import ServerOptionsUpdater
+
+    @property
+    def enable(self) -> bool:
+        return False
+
+    ServerOptionsUpdater.enable = enable
+
     from nxdrive.gui.application import Application
 
     Application.init_nxdrive_listener = lambda *args: None
 
     from nxdrive.manager import Manager
     from nxdrive.engine.queue_manager import QueueManager
-
-    Manager._create_server_config_updater = lambda *args: None
 
     def dispose_all(self) -> None:
         for engine in self.engines.values():

--- a/tests/unit/test_autolock.py
+++ b/tests/unit/test_autolock.py
@@ -6,9 +6,8 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 from unittest.mock import Mock, patch
 
-import pytest
-
 import nxdrive.autolocker
+import pytest
 
 from .. import ensure_no_exception
 
@@ -32,8 +31,10 @@ class DAO:
 @pytest.fixture(scope="function")
 def autolock(tmpdir):
     check_interval = 5
+    manager = Mock()
+    manager.dao = DAO()
     autolocker = nxdrive.autolocker.ProcessAutoLockerWorker(
-        check_interval, DAO(), Path(tmpdir)
+        check_interval, manager, Path(tmpdir)
     )
     autolocker.direct_edit = Mock()
     return autolocker


### PR DESCRIPTION
A lot of code move, to better isolate some components' signals.
Engines, the Auto-Updater and Direct Edit (+ its Autolocker) are now started when the server's configuration has been fetched.