### PR TITLE
NXDRIVE-1869: Handle pair state resolved-modified as conflicted

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -8,6 +8,7 @@ Release date: `20xx-xx-xx`
 - [NXDRIVE-1831](https://jira.nuxeo.com/browse/NXDRIVE-1831): [GNU/Linux] Set the root local folder icon
 - [NXDRIVE-1847](https://jira.nuxeo.com/browse/NXDRIVE-1847): [Windows] Fix endless synchronization on fast create-then-rename folder
 - [NXDRIVE-1866](https://jira.nuxeo.com/browse/NXDRIVE-1866): Check spurious ThreadInterrupt in the conflict resolver
+- [NXDRIVE-1869](https://jira.nuxeo.com/browse/NXDRIVE-1869): Handle pair state resolved-modified as conflicted
 - [NXDRIVE-1893](https://jira.nuxeo.com/browse/NXDRIVE-1893): Remove hardcoded "Nuxeo Drive" strings
 - [NXDRIVE-1901](https://jira.nuxeo.com/browse/NXDRIVE-1901): Fix regression introduced in 4.2.0 about invalid TransferStatus value
 - [NXDRIVE-1918](https://jira.nuxeo.com/browse/NXDRIVE-1918): Use Amazon S3 Direct Upload when available

--- a/nxdrive/engine/dao/sqlite.py
+++ b/nxdrive/engine/dao/sqlite.py
@@ -97,6 +97,7 @@ PAIR_STATES: Dict[Tuple[str, str], str] = {
     ("moved", "unknown"): "conflicted",
     ("moved", "moved"): "conflicted",
     ("moved", "created"): "conflicted",
+    ("resolved", "modified"): "conflicted",
     # conflict cases that have been manually resolved
     ("resolved", "unknown"): "locally_resolved",
     ("resolved", "synchronized"): "synchronized",


### PR DESCRIPTION
It seems that when a conflicted document was manually resolved by the user, and that same document was modified on the server at the same time (or almost), the error pops-up as that state was previously undefined. It is now a new conflict.