### PR TITLE
NXDRIVE-2092: Downloads.path and Uploads.path database field type

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -43,6 +43,8 @@ Release date: `20xx-xx-xx`
 - [NXDRIVE-2088](https://jira.nuxeo.com/browse/NXDRIVE-2088): Make the synchronization_enabled option effective locally in certain conditions
 - [NXDRIVE-2090](https://jira.nuxeo.com/browse/NXDRIVE-2090): Ask for application restart on specific server config change
 - [NXDRIVE-2091](https://jira.nuxeo.com/browse/NXDRIVE-2091): Wait for the server configuration before starting features
+- [NXDRIVE-2092](https://jira.nuxeo.com/browse/NXDRIVE-2092): Fix Downloads.path and Uploads.path database field type
+
 
 ## GUI
 

--- a/nxdrive/engine/dao/sqlite.py
+++ b/nxdrive/engine/dao/sqlite.py
@@ -763,38 +763,6 @@ class EngineDAO(ConfigurationDAO):
         cursor.execute(
             "CREATE TABLE if not exists Downloads ("
             "    uid            INTEGER     NOT NULL,"
-            "    path           INTEGER     UNIQUE,"
-            "    status         INTEGER,"
-            "    engine         VARCHAR     DEFAULT NULL,"
-            "    is_direct_edit INTEGER     DEFAULT 0,"
-            "    progress       REAL,"
-            "    filesize       INTEGER     DEFAULT 0,"
-            "    doc_pair       INTEGER     UNIQUE,"
-            "    tmpname        VARCHAR,"
-            "    url            VARCHAR,"
-            "    PRIMARY KEY (uid)"
-            ")"
-        )
-        cursor.execute(
-            "CREATE TABLE if not exists Uploads ("
-            "    uid            INTEGER     NOT NULL,"
-            "    path           INTEGER     UNIQUE,"
-            "    status         INTEGER,"
-            "    engine         VARCHAR     DEFAULT NULL,"
-            "    is_direct_edit INTEGER     DEFAULT 0,"
-            "    progress       REAL,"
-            "    doc_pair       INTEGER     UNIQUE,"
-            "    batch          VARCHAR,"
-            "    chunk_size     INTEGER,"
-            "    PRIMARY KEY (uid)"
-            ")"
-        )
-
-    @staticmethod
-    def _create_transfer_tables_v2(cursor: Cursor) -> None:
-        cursor.execute(
-            "CREATE TABLE if not exists Downloads ("
-            "    uid            INTEGER     NOT NULL,"
             "    path           VARCHAR     UNIQUE,"
             "    status         INTEGER,"
             "    engine         VARCHAR     DEFAULT NULL,"

--- a/nxdrive/engine/dao/sqlite.py
+++ b/nxdrive/engine/dao/sqlite.py
@@ -740,7 +740,7 @@ class EngineDAO(ConfigurationDAO):
             cursor.execute("ALTER TABLE Downloads RENAME TO Downloads_backup;")
 
             # Create again the tables, with up-to-date columns
-            self._create_transfer_tables_v2(cursor)
+            self._create_transfer_tables(cursor)
 
             # Insert back old datas with up-to-date fields types
             cursor.execute("INSERT INTO Uploads SELECT * FROM Uploads_backup;")

--- a/nxdrive/gui/view.py
+++ b/nxdrive/gui/view.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-import os.path
 from functools import partial
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Tuple
 
@@ -201,7 +200,7 @@ class TransferModel(QAbstractListModel):
             size = row["filesize"]
         else:
             try:
-                size = os.path.getsize(row["path"])
+                size = row["path"].stat().st_size
             except FileNotFoundError:
                 size = 0
             progress = size * (row["progress"] or 0.0) / 100

--- a/tests/unit/test_engine_dao.py
+++ b/tests/unit/test_engine_dao.py
@@ -302,6 +302,13 @@ def test_migration_db_v8(engine_dao):
             assert str(download.tmpname).startswith("\\\\?\\")
 
 
+def test_migration_db_v9(engine_dao):
+    """Verify Downloads.path and Uploads.path types after migration."""
+    with engine_dao("test_engine_migration_8.db") as dao:
+        downloads = list(dao.get_downloads())
+        assert len(downloads) == 1
+
+
 def test_migration_db_v1_with_duplicates(engine_dao):
     """ Test a non empty DB. """
     with engine_dao("test_engine_migration_duplicate.db") as dao:


### PR DESCRIPTION
In Downloads and Uploads tables of the Engine database, path fields
are wrongly defined as INTEGER.
A new migration have been added to change path fields to VARCHAR.
A test have been added.
Also changelog have been updated.