### PR TITLE
NXDRIVE-2092: Make the JUnit merge script universal

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -77,6 +77,7 @@ Release date: `20xx-xx-xx`
 - [NXDRIVE-2063](https://jira.nuxeo.com/browse/NXDRIVE-2063): Move tests logic to tox
 - [NXDRIVE-2069](https://jira.nuxeo.com/browse/NXDRIVE-2069): Don't use dots in custom HTTP headers in tests
 - [NXDRIVE-2080](https://jira.nuxeo.com/browse/NXDRIVE-2080): Fix SonarCube coverage report path
+- [NXDRIVE-2096](https://jira.nuxeo.com/browse/NXDRIVE-2096): Make the JUnit merge script universal
 
 ## Docs
 

--- a/tools/posix/deploy_jenkins_slave.sh
+++ b/tools/posix/deploy_jenkins_slave.sh
@@ -269,7 +269,8 @@ launch_tests() {
         fi
 
         # Do not fail on junit merge
-        python tools/jenkins/junit/merge.py || true
+        export TEST_SUITE="Drive"
+        python tools/jenkins/junit/merge.py "tools/jenkins/junit/xml" || true
 
         if [ $ret -ne 0 ] && [ $ret -ne 5 ]; then
             exit 1

--- a/tools/windows/deploy_jenkins_slave.ps1
+++ b/tools/windows/deploy_jenkins_slave.ps1
@@ -432,7 +432,10 @@ function launch_tests {
 			}
 		}
 
-		& $Env:STORAGE_DIR\Scripts\python.exe $global:PYTHON_OPT tools\jenkins\junit\merge.py
+		$Env:TEST_SUITE = "Drive"
+		& $Env:STORAGE_DIR\Scripts\python.exe $global:PYTHON_OPT `
+			tools\jenkins\junit\merge.py `
+			tools\jenkins\junit\xml
 
 		if ($ret -ne 0 -and $ret -ne 5) {
 			ExitWithCode $ret


### PR DESCRIPTION
Usage: `python merge.py FOLDER [FILE]`

Merge JUnit reports from `FOLDER` into `FILE`.
`FILE` is optional and defaults to `junit.xml`.

The final report will be saved into `FOLDER/FILE`.

It is possible to custom the test suite final report name using the `TEST_SUITE` envar (default is `Project`), examples:

    export TEST_SUITE=Drive
    export TEST_SUITE=nxPyML