### PR TITLE
NXDRIVE-382: Invalid conflict resolution when choosing the Local file, if the Remote file has been renamed before

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -5,6 +5,7 @@ Release date: `20xx-xx-xx`
 ## Core
 
 - [NXDRIVE-374](https://jira.nuxeo.com/browse/NXDRIVE-374): [GNU/Linux] Use file system decorations
+- [NXDRIVE-382](https://jira.nuxeo.com/browse/NXDRIVE-382): Invalid conflict resolution when choosing the Local file, if the Remote file has been renamed before
 - [NXDRIVE-1831](https://jira.nuxeo.com/browse/NXDRIVE-1831): [GNU/Linux] Set the root local folder icon
 - [NXDRIVE-1847](https://jira.nuxeo.com/browse/NXDRIVE-1847): [Windows] Fix endless synchronization on fast create-then-rename folder
 - [NXDRIVE-1866](https://jira.nuxeo.com/browse/NXDRIVE-1866): Check spurious ThreadInterrupt in the conflict resolver


### PR DESCRIPTION
Nuxeo Drive has an incorrect way to resolve the conflict when choosing to keep
the local changes.
The remote file name is now updated before the changes upload.
Also changelog has been updated.