### PR TITLE
NXDRIVE-2074: Always raise the Conflicts/Errors window

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -55,6 +55,7 @@ Release date: `20xx-xx-xx`
 - [NXDRIVE-1990](https://jira.nuxeo.com/browse/NXDRIVE-1990): [Direct Transfer] Disable the OK button when no local path selected
 - [NXDRIVE-2021](https://jira.nuxeo.com/browse/NXDRIVE-2021): Use a more appropriate "open remote URL" icon
 - [NXDRIVE-2042](https://jira.nuxeo.com/browse/NXDRIVE-2042): Display the disk free space at different places
+- [NXDRIVE-2074](https://jira.nuxeo.com/browse/NXDRIVE-2074): Always raise the Conflicts/Errors window
 - [NXDRIVE-2081](https://jira.nuxeo.com/browse/NXDRIVE-2081): Several small UX improvements
 
 ## Packaging / Build

--- a/nxdrive/gui/api.py
+++ b/nxdrive/gui/api.py
@@ -338,7 +338,6 @@ class QMLDriveApi(QObject):
     @pyqtSlot(str)
     def show_conflicts_resolution(self, uid: str) -> None:
         self.application.hide_systray()
-
         engine = self._manager.engines.get(uid)
         if engine:
             self.application.show_conflicts_resolution(engine)

--- a/nxdrive/gui/api.py
+++ b/nxdrive/gui/api.py
@@ -338,6 +338,10 @@ class QMLDriveApi(QObject):
     @pyqtSlot(str)
     def show_conflicts_resolution(self, uid: str) -> None:
         self.application.hide_systray()
+
+        # Arise the conflicts window to let the user know the error
+        self.application._show_window(self.application.conflicts_window)
+
         engine = self._manager.engines.get(uid)
         if engine:
             self.application.show_conflicts_resolution(engine)

--- a/nxdrive/gui/api.py
+++ b/nxdrive/gui/api.py
@@ -339,9 +339,6 @@ class QMLDriveApi(QObject):
     def show_conflicts_resolution(self, uid: str) -> None:
         self.application.hide_systray()
 
-        # Arise the conflicts window to let the user know the error
-        self.application._show_window(self.application.conflicts_window)
-
         engine = self._manager.engines.get(uid)
         if engine:
             self.application.show_conflicts_resolution(engine)

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -667,6 +667,7 @@ class Application(QApplication):
         self.refresh_conflicts(engine.uid)
         self._window_root(self.conflicts_window).setEngine.emit(engine.uid)
         self.conflicts_window.show()
+        self.conflicts_window.raise_()
         self.conflicts_window.requestActivate()
 
     @pyqtSlot()  # From systray.py

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -666,9 +666,7 @@ class Application(QApplication):
         """ Display the conflicts/errors window. """
         self.refresh_conflicts(engine.uid)
         self._window_root(self.conflicts_window).setEngine.emit(engine.uid)
-        self.conflicts_window.show()
-        self.conflicts_window.raise_()
-        self.conflicts_window.requestActivate()
+        self._show_window(self.conflicts_window)
 
     @pyqtSlot()  # From systray.py
     @pyqtSlot(str)  # All other calls


### PR DESCRIPTION
When clicking on "Open window" link in the Account settings, the window
may not appear if is already shown and hidden by another application.
A fix has been added in api.py file to always arise the conflict
windows when clicking on the link.
Also changelog has been updated.