### PR TITLE
NXDRIVE-2003: Skip inexistant group deletion in test_group_changes.py

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -74,7 +74,7 @@ Release date: `20xx-xx-xx`
 - [NXDRIVE-1991](https://jira.nuxeo.com/browse/NXDRIVE-1991): Fix the tests "rerun" mechanism
 - [NXDRIVE-1994](https://jira.nuxeo.com/browse/NXDRIVE-1994): [Windows] Skip JUnit report when running a specific test
 - [NXDRIVE-1996](https://jira.nuxeo.com/browse/NXDRIVE-1996): Add a script to check translations files
-- [NXDRIVE-2003](https://jira.nuxeo.com/browse/NXDRIVE-2003): Skip inexistant group deletion in test_group_changes.py
+- [NXDRIVE-2003](https://jira.nuxeo.com/browse/NXDRIVE-2003): Skip inexistent group deletion in test_group_changes.py
 - [NXDRIVE-2004](https://jira.nuxeo.com/browse/NXDRIVE-2004): Allow to customize document types in tests
 - [NXDRIVE-2013](https://jira.nuxeo.com/browse/NXDRIVE-2013): Create a script to convert NCO CSV log files to real log files
 - [NXDRIVE-2063](https://jira.nuxeo.com/browse/NXDRIVE-2063): Move tests logic to tox

--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -74,6 +74,7 @@ Release date: `20xx-xx-xx`
 - [NXDRIVE-1991](https://jira.nuxeo.com/browse/NXDRIVE-1991): Fix the tests "rerun" mechanism
 - [NXDRIVE-1994](https://jira.nuxeo.com/browse/NXDRIVE-1994): [Windows] Skip JUnit report when running a specific test
 - [NXDRIVE-1996](https://jira.nuxeo.com/browse/NXDRIVE-1996): Add a script to check translations files
+- [NXDRIVE-2003](https://jira.nuxeo.com/browse/NXDRIVE-2003): Skip inexistant group deletion in test_group_changes.py
 - [NXDRIVE-2004](https://jira.nuxeo.com/browse/NXDRIVE-2004): Allow to customize document types in tests
 - [NXDRIVE-2013](https://jira.nuxeo.com/browse/NXDRIVE-2013): Create a script to convert NCO CSV log files to real log files
 - [NXDRIVE-2063](https://jira.nuxeo.com/browse/NXDRIVE-2063): Move tests logic to tox

--- a/tests/old_functional/test_group_changes.py
+++ b/tests/old_functional/test_group_changes.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from logging import getLogger
 
+from nuxeo.exceptions import HTTPError
 from nuxeo.models import Document, Group
 
 from .. import env
@@ -49,7 +50,12 @@ class TestGroupChanges(OneUserTest):
     def tearDown(self):
         self.workspace_group.delete()
         for group in reversed(self.new_groups):
-            self.root_remote.groups.delete(group.groupname)
+            try:
+                self.root_remote.groups.delete(group.groupname)
+            except HTTPError as exc:
+                if exc.status == 404:
+                    continue
+                raise
 
     def set_ace(self, user, doc):
         log.info(f"Grant ReadWrite permission to  {user} on {doc}")


### PR DESCRIPTION
The line 'self.root_remote.groups.delete(group.groupname)' may
sometimes ends on a 404 error.
The test has been updated to now skip the error.
Also changelog has been updated.