### PR TITLE
NXDRIVE-2079: Add behaviors flags

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -40,13 +40,13 @@ Release date: `20xx-xx-xx`
 - [NXDRIVE-2054](https://jira.nuxeo.com/browse/NXDRIVE-2054): Ask for a new batch in case of failed S3 upload resuming
 - [NXDRIVE-2055](https://jira.nuxeo.com/browse/NXDRIVE-2055): Process queued Qt events on CTRL+C
 - [NXDRIVE-2075](https://jira.nuxeo.com/browse/NXDRIVE-2075): [Windows] Use the long path prefix for Engine.download_dir
+- [NXDRIVE-2079](https://jira.nuxeo.com/browse/NXDRIVE-2079): Auto-enabling behaviors/features behind flags
 - [NXDRIVE-2086](https://jira.nuxeo.com/browse/NXDRIVE-2086): Fix mypy issues following the update to mypy 0.770
 - [NXDRIVE-2088](https://jira.nuxeo.com/browse/NXDRIVE-2088): Make the synchronization_enabled option effective locally in certain conditions
 - [NXDRIVE-2090](https://jira.nuxeo.com/browse/NXDRIVE-2090): Ask for application restart on specific server config change
 - [NXDRIVE-2091](https://jira.nuxeo.com/browse/NXDRIVE-2091): Wait for the server configuration before starting features
 - [NXDRIVE-2092](https://jira.nuxeo.com/browse/NXDRIVE-2092): Fix Downloads.path and Uploads.path database field type
 - [NXDRIVE-2100](https://jira.nuxeo.com/browse/NXDRIVE-2100): Clean-up code smells found by Sourcery
-
 
 ## GUI
 
@@ -150,6 +150,7 @@ Release date: `20xx-xx-xx`
 - Changed `Upload.batch` from `str` to `nuxeo.models.Batch`
 - Removed `Upload.idx`. Use `Upload.batch["upload_idx"]` instead.
 - Removed `idx` column from `Uploads` table
+- Added `behavior.py`
 - Removed constants.py::`FORBID_CHARS_ALL`
 - Removed constants.py::`FORBID_CHARS_UNIX`
 - Added updater/constants.py::`AutoUpdateState`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,12 +32,14 @@ Parameter values are taken as is, except for booleans. In that case, you can spe
 - bool: boolean
 - int: integer
 - list: list of strings (one item by line)
+- map: simple key/value map.
 - str: string
 
 ### Available Parameters
 
 | Parameter | Default Value | Type | Version Added | Description
 |---|---|---|---|---
+| `behavior` | [...](#behaviors) | map | 4.4.2 | Application behavior that can be turned on/off on-demand. That parameter cannot be set via the local configuration file: only the server has rights to define it.
 | `big-file` | 300 | int | 4.1.4 | File size in MiB. Files bigger than this limit are considered "big". This implies few tweaks in the synchronization engine like bypassing most of the expensive and time consuming digest computations. It is a tradeoff to handle large files as best effort.
 | `ca-bundle` | None | str | 4.0.2 | File or directory with certificates of trusted Certificate Authorities. If set, `ssl-no-verify` has no effect. See the `requests` [documentation](http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification) for more details.
 | `channel` | centralized | str | 4.0.2 | Update channel. Can be centralized, release, beta or alpha.
@@ -82,6 +84,27 @@ Parameter values are taken as is, except for booleans. In that case, you can spe
 Other changes:
 
 - `channel` was set to "release" in 4.0.2. It then changed to "centralized" in 4.2.0.
+
+## Behaviors
+
+The application can be tweaked using on-demand on/off options via the `behavior` parameter.
+As this is targeting server actions, this parameter cannot be set via the local configuration file but only via the server configuration one.
+
+Available behaviors:
+
+| Parameter | Default Value (bool) | Version Added | Description
+|---|---|---|---
+| `server_deletion` | true | 4.4.2 | Allow or disallow server deletions.
+
+Here is how to tweak behaviors via the server configuration file:
+
+```json
+{
+  "behavior": {
+    "server-deletion": true
+  }
+}
+```
 
 ## Command Line Arguments
 

--- a/docs/dep/2020-03 Features flags.md
+++ b/docs/dep/2020-03 Features flags.md
@@ -1,7 +1,7 @@
 # Features and Behaviors Flags
 
 - Created: 2020-03-03
-- Last-Modified: 2020-03-04
+- Last-Modified: 2020-03-06
 - Author: Mickaël Schoentgen <mschoentgen@nuxeo.com>,
           Patrick Abgrall <pabgrall@nuxeo.com>
 - Reviewer: Yannis Achour <yachour@nuxeo.com>
@@ -57,8 +57,8 @@ The file format is JSON, and the syntax would be like:
 
 ```json
 {
-    "behaviors": {
-        "server-deletions": true
+    "behavior": {
+        "server-deletion": true
     },
     "features": {
         "auto-updates"    : true,
@@ -95,7 +95,7 @@ At the time of that DEP, defaults are:
 - `direct-edit`: `true`
 - `direct-transfer`: `false`
 - `s3`: `true`
-- `server-deletions`: `true`
+- `server-deletion`: `true`
 
 ## Backward Compatibility
 

--- a/nxdrive/behavior.py
+++ b/nxdrive/behavior.py
@@ -1,0 +1,16 @@
+"""
+Application behavior that can be turned on/off on-demand.
+Parameters listed here cannot be set locally: only the server
+has rights to change values.
+
+Introduced in Nuxeo Drive 4.4.2.
+
+Available parameters and introduced version:
+
+- server_deletion (4.4.2)
+    Allow or disallow server deletions.
+
+"""
+from types import SimpleNamespace
+
+Behavior = SimpleNamespace(server_deletion=True)

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -20,6 +20,7 @@ from nuxeo.exceptions import (
 from PyQt5.QtCore import pyqtSignal
 from urllib3.exceptions import MaxRetryError
 
+from ..behavior import Behavior
 from ..client.local import FileInfo
 from ..constants import (
     CONNECTION_ERROR,
@@ -919,6 +920,15 @@ class Processor(EngineWorker):
             self.dao.remove_state(doc_pair)
             self._search_for_dedup(doc_pair)
             self.remove_void_transfers(doc_pair)
+            return
+
+        if not Behavior.server_deletion:
+            log.debug(
+                "Server deletions are forbidden, skipping the remote deletion"
+                f" and marking {doc_pair.local_path!r} as filtered"
+            )
+            self.dao.remove_state(doc_pair)
+            self.dao.add_filter(f"{doc_pair.remote_parent_path}/{doc_pair.remote_ref}")
             return
 
         if doc_pair.remote_can_delete:

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -30,6 +30,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
 )
 
+from ..behavior import Behavior
 from ..constants import (
     APP_NAME,
     BUNDLE_IDENTIFIER,
@@ -549,7 +550,12 @@ class Application(QApplication):
     @pyqtSlot(Path)
     def _doc_deleted(self, path: Path) -> None:
         engine: Engine = self.sender()
-        mode = self.confirm_deletion(path)
+
+        if not Behavior.server_deletion:
+            mode = DelAction.UNSYNC
+            log.debug(f"Server deletions behavior is False, mode set to {mode.value!r}")
+        else:
+            mode = self.confirm_deletion(path)
 
         if mode is DelAction.ROLLBACK:
             # Re-sync the document

--- a/nxdrive/poll_workers.py
+++ b/nxdrive/poll_workers.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from PyQt5.QtCore import pyqtSignal, pyqtSlot
 
+from .behavior import Behavior
 from .engine.workers import PollWorker
 from .options import Options
 from .updater.constants import UPDATE_STATUS_UPDATING
@@ -78,7 +79,7 @@ class ServerOptionsUpdater(PollWorker):
                 engine.set_ui("jsf", overwrite=False)
                 continue
 
-            engine.set_ui(conf.pop("ui"), overwrite=False)
+            engine.set_ui(conf.pop("ui", "web"), overwrite=False)
 
             # Compat with old servers
             beta = conf.pop("beta_channel", False)
@@ -88,6 +89,22 @@ class ServerOptionsUpdater(PollWorker):
             if "nxdrive_home" in conf:
                 # Expand eventuel envars like %userprofile% and co.
                 conf["nxdrive_home"] = normalize_and_expand_path(conf["nxdrive_home"])
+
+            # Behavior can only be set from the server config,
+            # so the following logic can be kept here only.
+            if "behavior" in conf:
+                for behavior, value in conf["behavior"].items():
+                    behavior = behavior.replace("-", "_").lower()
+                    if not hasattr(Behavior, behavior):
+                        log.warning(f"Invalid behavior: {behavior!r}")
+                    elif not isinstance(value, bool):
+                        log.warning(
+                            f"Invalid behavior value: {value!r} (a boolean is required)"
+                        )
+                    elif getattr(Behavior, behavior) is not value:
+                        log.warning(f"Updating behavior {behavior!r} to {value!r}")
+                        setattr(Behavior, behavior, value)
+                del conf["behavior"]
 
             # We cannot use fail_on_error=True because the server may
             # be outdated and still have obsolete options.

--- a/tests/functional/test_server_options.py
+++ b/tests/functional/test_server_options.py
@@ -1,0 +1,67 @@
+from unittest.mock import patch
+
+from nxdrive.behavior import Behavior
+from nxdrive.poll_workers import ServerOptionsUpdater
+
+
+def test_behavior(manager_factory):
+    """Check that behaviors are well handled."""
+    manager, engine = manager_factory()
+    updater = ServerOptionsUpdater(manager)
+
+    def enabled():
+        return {"behavior": {"server_deletion": True}}
+
+    def disabled():
+        return {"behavior": {"server_deletion": False}}
+
+    # Default value is True
+    assert Behavior.server_deletion is True
+
+    # Mimic the IT team disabling the behavior
+    with patch.object(engine.remote, "get_server_configuration", new=disabled):
+        updater._poll()
+        assert Behavior.server_deletion is False
+
+    # Mimic the IT team enabling back the behavior
+    with patch.object(engine.remote, "get_server_configuration", new=enabled):
+        updater._poll()
+        assert Behavior.server_deletion is True
+
+    # No-op check
+    updater._poll()
+    assert Behavior.server_deletion is True
+
+
+def test_behavior_not_good(caplog, manager_factory):
+    """Check that bad behaviors are skipped."""
+    manager, engine = manager_factory()
+    updater = ServerOptionsUpdater(manager)
+
+    def unknown():
+        return {"behavior": {"alien": True}}
+
+    def bad_value():
+        return {"behavior": {"server_deletion": "oui"}}
+
+    # Default value is True
+    assert Behavior.server_deletion is True
+
+    # Mimic the IT team setting an unknown behavior
+    with patch.object(engine.remote, "get_server_configuration", new=unknown):
+        caplog.clear()
+        updater._poll()
+
+        # Skip the first log: "wui preferences set to web"
+        record = caplog.records[1]
+        assert record.levelname == "WARNING"
+        assert record.message == "Invalid behavior: 'alien'"
+
+    # Mimic the IT team setting a bad value for a known behavior
+    with patch.object(engine.remote, "get_server_configuration", new=bad_value):
+        caplog.clear()
+        updater._poll()
+
+        record = caplog.records[0]
+        assert record.levelname == "WARNING"
+        assert record.message == "Invalid behavior value: 'oui' (a boolean is required)"

--- a/tests/old_functional/test_behavior.py
+++ b/tests/old_functional/test_behavior.py
@@ -1,0 +1,74 @@
+"""
+Test application Behavior.
+"""
+from nxdrive.behavior import Behavior
+
+from .. import ensure_no_exception
+from .common import OneUserTest
+
+
+class TestBehavior(OneUserTest):
+    def test_server_deletion(self):
+        """When server deletion is forbidden, then no remote deletion should be made."""
+
+        local = self.local_1
+        remote = self.remote_document_client_1
+        self.engine_1.start()
+
+        # Create a remote folder with 1 child, then sync
+        remote.make_folder("/", "folder")
+        remote.make_file("/folder", "file.bin", content=b"42")
+        self.wait_sync(wait_for_async=True)
+
+        # Check everything is synced
+        assert local.exists("/folder")
+        assert local.exists("/folder/file.bin")
+
+        # Update the server deletion behavior
+        Behavior.server_deletion = False
+
+        try:
+            # Locally delete the file, then sync
+            local.delete("/folder/file.bin")
+            self.wait_sync()
+            assert not local.exists("/folder/file.bin")
+
+            # The remote file should still be present
+            assert remote.exists("/folder")
+            assert remote.exists("/folder/file.bin")
+
+            # The file should be filtered
+            filters = self.engine_1.dao.get_filters()
+            assert len(filters) == 1
+
+            # Locally delete the folder, then sync
+            local.delete("/folder")
+            self.wait_sync()
+            assert not local.exists("/folder")
+
+            # The remote folder and its child should still be present
+            assert remote.exists("/folder")
+            assert remote.exists("/folder/file.bin")
+
+            # The folder should be filtered
+            # (there is still only 1 filter as file is a subfilter of folder)
+            filters = self.engine_1.dao.get_filters()
+            assert len(filters) == 1
+        finally:
+            # Restore the server deletion behavior
+            Behavior.server_deletion = True
+
+        # [Deeper test]
+
+        # Update the remote file
+        remote.update_content("/folder/file.bin", b"222")
+
+        # And see what happens
+        with ensure_no_exception():
+            self.wait_sync(wait_for_async=True)
+
+        # Nothing should be locally created
+        assert not local.exists("/folder")
+
+        # And the folder should still be filtered
+        assert len(self.engine_1.dao.get_filters()) == 1


### PR DESCRIPTION
There is only one at the time:

- `server_deletion`: Allow or disallow server deletions.