### PR TITLE
NXDRIVE-2105: Fix a random bug in test_move_parent_while_syncing_a_lo…

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -88,6 +88,7 @@ Release date: `20xx-xx-xx`
 - [NXDRIVE-2069](https://jira.nuxeo.com/browse/NXDRIVE-2069): Don't use dots in custom HTTP headers in tests
 - [NXDRIVE-2080](https://jira.nuxeo.com/browse/NXDRIVE-2080): Fix SonarCube coverage report path
 - [NXDRIVE-2096](https://jira.nuxeo.com/browse/NXDRIVE-2096): Make the JUnit merge script universal
+- [NXDRIVE-2105](https://jira.nuxeo.com/browse/NXDRIVE-2105): Fix a random bug in `test_move_parent_while_syncing_a_lot_of_files()`
 
 ## Docs
 

--- a/tests/functional/test_engine.py
+++ b/tests/functional/test_engine.py
@@ -80,6 +80,7 @@ def test_delete_doc(manager_factory, tmp):
                         "parentId": "parent-uid",
                         "path": "/some/path",
                         "name": name,
+                        "digest": "0" * 32,
                     }
                 )
                 doc_pair.remote_parent_path = "remote-aprent-path"

--- a/tests/old_functional/test_local_move_folders.py
+++ b/tests/old_functional/test_local_move_folders.py
@@ -58,7 +58,7 @@ class TestLocalMoveFolders(OneUserTest):
                 assert set(children) == names
 
     def tearDown(self):
-        with suppress(TypeError):
+        with suppress(TypeError, AttributeError):
             self.engine_1._local_watcher.localScanFinished.disconnect(
                 self.app.local_scan_finished
             )


### PR DESCRIPTION
…t_of_files()

Also a small fix:

- NXDRIVE-1973: Fix `test_delete_doc()`