### PR TITLE
NXDRIVE-374: Fix error handling

### DIFF
--- a/nxdrive/client/local/linux.py
+++ b/nxdrive/client/local/linux.py
@@ -38,8 +38,8 @@ class LocalClient(LocalClientMixin):
         cmd = ["gio", "info", "-a", "metadata", str(folder)]
         try:
             output = subprocess.check_output(cmd, encoding="utf-8")
-        except subprocess.CalledProcessError:
-            log.warning(f"Could not check the metadata of {folder!r}")
+        except Exception:
+            log.warning(f"Could not check the metadata of {folder!r}", exc_info=True)
             return False
 
         matcher = re.compile(r"metadata::emblems: \[.*emblem-nuxeo.*\]")
@@ -97,8 +97,8 @@ class LocalClient(LocalClientMixin):
         ]
         try:
             subprocess.check_call(cmd)
-        except subprocess.CalledProcessError:
-            log.warning(f"Could not set the folder emblem on {folder!r}")
+        except Exception:
+            log.warning(f"Could not set the folder emblem on {folder!r}", exc_info=True)
 
     @staticmethod
     def set_path_remote_id(

--- a/nxdrive/osi/linux/linux.py
+++ b/nxdrive/osi/linux/linux.py
@@ -5,15 +5,13 @@ import shutil
 import subprocess
 from logging import getLogger
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Dict
+from typing import TYPE_CHECKING, Dict, Optional
 
 from ...constants import APP_NAME, NXDRIVE_SCHEME
 from ...objects import DocPair
-from ...utils import find_icon
-from ...utils import if_frozen
-from ..extension import get_formatted_status
-from ..extension import icon_status, Status
+from ...utils import find_icon, if_frozen
 from .. import AbstractOSIntegration
+from ..extension import Status, get_formatted_status, icon_status
 
 __all__ = ("LinuxIntegration",)
 
@@ -150,8 +148,8 @@ MimeType=x-scheme-handler/{NXDRIVE_SCHEME};
         ]
         try:
             subprocess.check_call(cmd)
-        except subprocess.CalledProcessError:
-            log.warning(f"Could not set the {emblem} emblem on {path!r}")
+        except Exception:
+            log.warning(f"Could not set the {emblem} emblem on {path!r}", exc_info=True)
 
     def _icons_to_emblems(self) -> None:
         """


### PR DESCRIPTION
Instead of catching too specific exceptions, let's catch them all.

Here it was done to bypass:

    FileNotFoundError: [Errno 2] No such file or directory: 'gio': 'gio'