### PR TITLE
NXDRIVE-382: Invalid conflict resolution when choosing the Local file, if the Remote file has been renamed before

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -5,6 +5,7 @@ Release date: `20xx-xx-xx`
 ## Core
 
 - [NXDRIVE-374](https://jira.nuxeo.com/browse/NXDRIVE-374): [GNU/Linux] Use file system decorations
+- [NXDRIVE-382](https://jira.nuxeo.com/browse/NXDRIVE-382): Invalid conflict resolution when choosing the Local file, if the Remote file has been renamed before
 - [NXDRIVE-1640](https://jira.nuxeo.com/browse/NXDRIVE-1640): Refactor simple QMessageBoxes
 - [NXDRIVE-1831](https://jira.nuxeo.com/browse/NXDRIVE-1831): [GNU/Linux] Set the root local folder icon
 - [NXDRIVE-1847](https://jira.nuxeo.com/browse/NXDRIVE-1847): [Windows] Fix endless synchronization on fast create-then-rename folder

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -801,6 +801,39 @@ class Processor(EngineWorker):
                         )
                     self.dao.synchronize_state(doc_pair)
                     return
+                # Document exists on the server but is different
+                elif (
+                    parent_pair.remote_ref
+                    and parent_pair.remote_ref == fs_item_info.parent_uid
+                    and not self.local.is_equal_digests(
+                        doc_pair.local_digest, fs_item_info.digest, doc_pair.local_path
+                    )
+                    and (
+                        doc_pair.local_name == info.name
+                        or doc_pair.local_state == "resolved"
+                    )
+                ):
+                    if doc_pair.pair_state == "locally_resolved":
+                        if fs_item_info.name != doc_pair.local_name:
+                            fs_item_info = self.remote.rename(
+                                fs_item_info.uid, doc_pair.local_name
+                            )
+                        remote_parent_path = (
+                            parent_pair.remote_parent_path
+                            + "/"
+                            + parent_pair.remote_ref
+                        )
+                        self.dao.update_remote_state(
+                            doc_pair,
+                            fs_item_info,
+                            remote_parent_path=remote_parent_path,
+                            versioned=False,
+                        )
+                        # Handle document modification - update the doc_pair
+                        refreshed = self.dao.get_state_from_id(doc_pair.id)
+                        if refreshed and overwrite:
+                            self._synchronize_locally_modified(refreshed)
+                    return
             except HTTPError as e:
                 # undelete will fail if you don't have the rights
                 if e.status not in {401, 403}:

--- a/tests/old_functional/test_conflicts.py
+++ b/tests/old_functional/test_conflicts.py
@@ -54,6 +54,38 @@ class TestConflicts(TwoUsersTest):
         assert remote.get_content(remote_children[0].uid) == b"Remote update 2"
         assert self.get_remote_state(self.file_id).pair_state == "conflicted"
 
+    def test_conflict_renamed_modified(self):
+        local = self.local_1
+        remote = self.remote_2
+
+        # Update content on both sides by different users, remote last
+        time.sleep(OS_STAT_MTIME_RESOLUTION)
+        # Race condition is still possible
+        remote.update_content(self.file_id, b"Remote update")
+        remote.rename(self.file_id, "plop.txt")
+        local.update_content("/test.txt", b"Local update")
+        self.wait_sync(wait_for_async=True)
+
+        assert remote.get_content(self.file_id) == b"Remote update"
+        assert local.get_content("/test.txt") == b"Local update"
+        assert self.get_remote_state(self.file_id).pair_state == "conflicted"
+
+    def test_resolve_local_renamed_modified(self):
+        remote = self.remote_2
+
+        self.test_conflict_renamed_modified()
+        # Resolve to local file
+        pair = self.get_remote_state(self.file_id)
+        assert pair
+        self.engine_1.resolve_with_local(pair.id)
+        self.wait_sync(wait_for_async=True)
+
+        remote_children = remote.get_fs_children(self.workspace_id)
+        assert len(remote_children) == 1
+        assert remote_children[0].uid == self.file_id
+        assert remote_children[0].name == "test.txt"
+        assert remote.get_content(remote_children[0].uid) == b"Local update"
+
     def test_real_conflict(self):
         local = self.local_1
         remote = self.remote_2


### PR DESCRIPTION
Nuxeo Drive has an incorrect way to resolve the conflict when choosing to keep
the local changes.
The remote file name is now updated before the changes upload.
Added new functional tests.
Also changelog has been updated.