### PR TITLE
NXDRIVE-1690: [GNU/Linux] File is not deleted on the server when the …

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -7,6 +7,7 @@ Release date: `20xx-xx-xx`
 - [NXDRIVE-374](https://jira.nuxeo.com/browse/NXDRIVE-374): [GNU/Linux] Use file system decorations
 - [NXDRIVE-382](https://jira.nuxeo.com/browse/NXDRIVE-382): Invalid conflict resolution when choosing the Local file, if the Remote file has been renamed before
 - [NXDRIVE-1640](https://jira.nuxeo.com/browse/NXDRIVE-1640): Refactor simple QMessageBoxes
+- [NXDRIVE-1690](https://jira.nuxeo.com/browse/NXDRIVE-1690): [GNU/Linux] File is not deleted on the server when the parent folder is renamed, while offline
 - [NXDRIVE-1831](https://jira.nuxeo.com/browse/NXDRIVE-1831): [GNU/Linux] Set the root local folder icon
 - [NXDRIVE-1847](https://jira.nuxeo.com/browse/NXDRIVE-1847): [Windows] Fix endless synchronization on fast create-then-rename folder
 - [NXDRIVE-1866](https://jira.nuxeo.com/browse/NXDRIVE-1866): Check spurious ThreadInterrupt in the conflict resolver

--- a/tests/old_functional/test_synchronization_suspend.py
+++ b/tests/old_functional/test_synchronization_suspend.py
@@ -1,7 +1,5 @@
 # coding: utf-8
-import pytest
-
-from nxdrive.constants import LINUX, WINDOWS
+from nxdrive.constants import WINDOWS
 
 from .common import SYNC_ROOT_FAC_ID, OneUserTest
 
@@ -98,7 +96,6 @@ class TestSynchronizationSuspend(OneUserTest):
         self.wait_sync(wait_for_async=True)
         assert len(remote.get_children_info(self.workspace)) == 4
 
-    @pytest.mark.xfail(LINUX, reason="NXDRIVE-1690", strict=True)
     def test_folder_renaming_while_offline(self):
         """
         Scenario:


### PR DESCRIPTION
…parent folder is renamed, while offline

The test does no fail anymore.