### PR TITLE
NXDRIVE-2023: Make the error title an URL to the remote document

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -35,6 +35,7 @@ Release date: `20xx-xx-xx`
 - [NXDRIVE-2010](https://jira.nuxeo.com/browse/NXDRIVE-2010): Restart the download on HTTP 416 error (range not satisfiable)
 - [NXDRIVE-2012](https://jira.nuxeo.com/browse/NXDRIVE-2012): Upgrade to sentry-sdk 0.14.1 to fix memory leaks
 - [NXDRIVE-2022](https://jira.nuxeo.com/browse/NXDRIVE-2022): Allow text selection into the errors/conflicts window
+- [NXDRIVE-2023](https://jira.nuxeo.com/browse/NXDRIVE-2023): Make the error title an URL to the remote document
 - [NXDRIVE-2027](https://jira.nuxeo.com/browse/NXDRIVE-2027): Allow Direct Edit on custom blob metadata values
 - [NXDRIVE-2040](https://jira.nuxeo.com/browse/NXDRIVE-2040): [Direct Transfer] Temporary disable folder uploads
 - [NXDRIVE-2047](https://jira.nuxeo.com/browse/NXDRIVE-2047): Unlock updates on the centralized channel when auto-update is disabled
@@ -142,6 +143,7 @@ Release date: `20xx-xx-xx`
 
 ## Technical Changes
 
+- Added `QMLDriveApi.open_document`
 - Added `Application.point_size`
 - Added `Application.display_warning()`
 - Added `Application.show_msgbox_restart_needed()`

--- a/nxdrive/data/qml/FileCard.qml
+++ b/nxdrive/data/qml/FileCard.qml
@@ -42,7 +42,7 @@ ShadowRectangle {
                 }
                 MouseArea {
                     anchors.fill: parent
-                    onClicked: api.open_local(engineUid, fileData.local_parent_path)
+                    onClicked: api.open_document(engineUid, fileData.id)
                     hoverEnabled: true
                     cursorShape: Qt.PointingHandCursor
                 }

--- a/nxdrive/gui/api.py
+++ b/nxdrive/gui/api.py
@@ -335,6 +335,25 @@ class QMLDriveApi(QObject):
         self.application.hide_systray()
         self._manager.open_help()
 
+    @pyqtSlot(str, int)
+    def open_document(self, engine_uid: str, doc_pair_id: int) -> None:
+        """Open the local or remote document depending on the pair state"""
+        engine = self._manager.engines.get(engine_uid)
+        if not engine:
+            return
+
+        doc_pair = engine.dao.get_state_from_id(doc_pair_id)
+        if not doc_pair:
+            return
+        if (
+            doc_pair.pair_state == "error"
+            and doc_pair.remote_ref
+            and doc_pair.remote_name
+        ):
+            self.open_remote(engine_uid, doc_pair.remote_ref, doc_pair.remote_name)
+        else:
+            self.open_local(engine_uid, str(doc_pair.local_parent_path))
+
     @pyqtSlot(str)
     def show_conflicts_resolution(self, uid: str) -> None:
         self.application.hide_systray()

--- a/tools/whitelist.py
+++ b/tools/whitelist.py
@@ -54,6 +54,7 @@ QMLDriveApi.get_update_version  # Used in QML
 QMLDriveApi.open_direct_transfer  # Used in QML
 QMLDriveApi.open_local  # Used in QML
 QMLDriveApi.open_remote_server  # Used in QML
+QMLDriveApi.open_document  # Used in QML
 QMLDriveApi.open_report  # Used in QML
 QMLDriveApi.set_proxy_settings  # Used in QML
 QMLDriveApi.set_server_ui  # Used in QML


### PR DESCRIPTION
Being able to click on the error title to open the document is an
intuitive action users often try.
The error title is now a link to the remote document.
Also changelog has been updated.