### PR TITLE
NXDRIVE-1786: Handle corrupted downloads in Direct Edit

### DIFF
--- a/docs/changes/4.4.3.md
+++ b/docs/changes/4.4.3.md
@@ -4,7 +4,7 @@ Release date: `2020-xx-xx`
 
 ## Core
 
-- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
+- [NXDRIVE-1786](https://jira.nuxeo.com/browse/NXDRIVE-1786): Handle corrupted downloads in Direct Edit
 
 ## GUI
 

--- a/nxdrive/data/i18n/i18n.json
+++ b/nxdrive/data/i18n/i18n.json
@@ -67,6 +67,8 @@
     "DIRECT_EDIT_CANT_FIND_ENGINE": "User <b>%1</b> on server <a href=\"%2\">%2</a> is not signed in %3 on this computer.",
     "DIRECT_EDIT_CONFLICT_MESSAGE": "The document „%1“ was modified remotely and is now in conflict. What do you want to do?",
     "DIRECT_EDIT_CONFLICT_OVERWRITE": "Overwrite",
+    "DIRECT_EDIT_CORRUPTED_DOWNLOAD_FAILURE": "DirectEdit failed because of corrupted content, please contact your administrator",
+    "DIRECT_EDIT_CORRUPTED_DOWNLOAD_RETRY": "File corruption detected, retrying…",
     "DIRECT_EDIT_AUTH_EXPIRED": "Authentication expired for the user <b>%1</b> on the server <a href=\"%2\">%2</a>.<br><br>Open the system tray menu or the settings to log back in.",
     "DIRECT_EDIT_FORBIDDEN_MSG": "Access to the document „%1“ on %2 is forbidden for user %3.",
     "DIRECT_EDIT_FORBIDDEN_TITLE": "Forbidden DirectEdit",


### PR DESCRIPTION
The downloaded file can be corrupted during a DirectEdit.
In this case We should display a notification and restart the download.

The CorruptedFile exception is now catched and the download restarted.
Notifications are now sent when this error happen.
Also changelog has been updated.