### PR TITLE
NXDRIVE-2115: Fix flake8 issues following the update to pyflakes 2.2.0

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -54,6 +54,7 @@ Release date: `20xx-xx-xx`
 - [NXDRIVE-2092](https://jira.nuxeo.com/browse/NXDRIVE-2092): Fix Downloads.path and Uploads.path database field type
 - [NXDRIVE-2100](https://jira.nuxeo.com/browse/NXDRIVE-2100): Clean-up code smells found by Sourcery
 - [NXDRIVE-2103](https://jira.nuxeo.com/browse/NXDRIVE-2103): [S3] Disable the feature until it is fully usable
+- [NXDRIVE-2115](https://jira.nuxeo.com/browse/NXDRIVE-2115): Fix flake8 issues following the update to pyflakes 2.2.0
 
 ## GUI
 

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -489,7 +489,7 @@ class Remote(Nuxeo):
                         "No associated batch found, restarting from zero", exc_info=True
                     )
                 else:
-                    log.debug(f"Associated batch found, resuming the upload")
+                    log.debug("Associated batch found, resuming the upload")
                     batch = Batch(service=self.uploads, **upload.batch)
                     chunk_size = upload.chunk_size
 

--- a/nxdrive/engine/dao/sqlite.py
+++ b/nxdrive/engine/dao/sqlite.py
@@ -771,7 +771,7 @@ class EngineDAO(ConfigurationDAO):
                         # Clean-up the TMP file
                         with suppress(OSError):
                             shutil.rmtree(download.tmpname.parent)
-                    cursor.execute(f"DELETE FROM Downloads WHERE doc_pair = ?", (id,))
+                    cursor.execute("DELETE FROM Downloads WHERE doc_pair = ?", (id,))
 
                     self.remove_state(doc_pair)
                     log.debug(

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -448,7 +448,7 @@ class Processor(EngineWorker):
         except Exception:
             pass
         else:
-            log.debug(f"The document has already been uploaded to the server")
+            log.debug("The document has already been uploaded to the server")
 
             # Fetch the remote item to update the local pair details
             doc_pair.remote_ref = (

--- a/nxdrive/engine/watcher/local_watcher.py
+++ b/nxdrive/engine/watcher/local_watcher.py
@@ -930,11 +930,11 @@ class LocalWatcher(EngineWorker):
                 #  - a synced document can be modified and we need to handle it
                 #  - a conflicted file can be manually resolved using the local version and we need to handle it too
                 if doc_pair.pair_state not in ("synchronized", "locally_resolved"):
-                    log.debug(f"Size has changed (copy must still be running)")
+                    log.debug("Size has changed (copy must still be running)")
                     doc_pair.local_digest = UNACCESSIBLE_HASH
                     ongoing_copy = True
             elif doc_pair.local_digest == UNACCESSIBLE_HASH:
-                log.debug(f"Unaccessible hash (copy must still be running)")
+                log.debug("Unaccessible hash (copy must still be running)")
                 ongoing_copy = True
             if ongoing_copy:
                 if not local_info.remote_ref and doc_pair.remote_ref:

--- a/nxdrive/gui/folders_model.py
+++ b/nxdrive/gui/folders_model.py
@@ -243,7 +243,7 @@ class FoldersOnly:
                 if "Folderish" in doc.facets:
                     yield Doc(doc)
         except Exception:
-            log.warning(f"Error while retrieving documents on '/'", exc_info=True)
+            log.warning("Error while retrieving documents on '/'", exc_info=True)
             yield Doc(Document(title="/", contextParameters={"permissions": []}))
 
     def get_children(self, parent: "Documents") -> Iterator["Documents"]:

--- a/nxdrive/osi/windows/windows.py
+++ b/nxdrive/osi/windows/windows.py
@@ -7,10 +7,9 @@ from logging import getLogger
 from pathlib import Path
 from typing import Any, Dict
 
-from PyQt5.QtCore import pyqtSlot
-
 import win32api
 import win32file
+from PyQt5.QtCore import pyqtSlot
 from win32com.client import Dispatch
 from win32com.shell import shell, shellcon
 
@@ -97,7 +96,7 @@ class WindowsIntegration(AbstractOSIntegration):
         try:
             subprocess.run([str(installer)])
         except Exception:
-            log.exception(f"Unknown error while trying to install addons")
+            log.exception("Unknown error while trying to install addons")
         else:
             return bool(self.addons_installed())
         return False

--- a/nxdrive/updater/darwin.py
+++ b/nxdrive/updater/darwin.py
@@ -70,7 +70,7 @@ class Updater(BaseUpdater):
                 subprocess.check_call(["hdiutil", "unmount", mount_dir, "-force"])
             except subprocess.CalledProcessError:
                 log.warning(
-                    f"Unmount failed, you will have to do it manually (Catalina feature).",
+                    "Unmount failed, you will have to do it manually (Catalina feature).",
                     exc_info=True,
                 )
 

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -1176,7 +1176,7 @@ class PidLockFile:
                     self.pid_filepath.read_text(encoding="utf-8").strip()
                 )
             except ValueError:
-                log.warning(f"The PID file has invalid data", exc_info=True)
+                log.warning("The PID file has invalid data", exc_info=True)
                 pid = None
             else:
                 from contextlib import suppress

--- a/tests/integration/windows/test_cli_sub_command.py
+++ b/tests/integration/windows/test_cli_sub_command.py
@@ -164,18 +164,18 @@ def test_complete_scenario_synchronization_from_zero(nuxeo_url, exe, server, tmp
 
 def test_ctx_menu_access_online_inexistant(nuxeo_url, exe, server, tmp):
     """It should be a no-op, no fatal error."""
-    args = f'access-online --file="bla bla bla"'
+    args = 'access-online --file="bla bla bla"'
     assert launch(exe, args)
 
 
 def test_ctx_menu_copy_share_link_inexistant(nuxeo_url, exe, server, tmp):
-    args = f'copy-share-link --file="bla bla bla"'
+    args = 'copy-share-link --file="bla bla bla"'
     assert not launch(exe, args)
 
 
 def test_ctx_menu_edit_metadata_inexistant(nuxeo_url, exe, server, tmp):
     """It should be a no-op, no fatal error."""
-    args = f'edit-metadata --file="bla bla bla"'
+    args = 'edit-metadata --file="bla bla bla"'
     assert launch(exe, args)
 
 

--- a/tests/integration/windows/utils.py
+++ b/tests/integration/windows/utils.py
@@ -32,7 +32,7 @@ def fatal_error_dlg(app, with_details: bool = True) -> bool:
             sleep(1)
             log.warning(f"Fatal error screen detected! Details:\n{cb_get()}")
         else:
-            log.warning(f"Fatal error screen detected!")
+            log.warning("Fatal error screen detected!")
 
         dlg.close()
         return True

--- a/tests/old_functional/test_synchronization_dedup.py
+++ b/tests/old_functional/test_synchronization_dedup.py
@@ -113,7 +113,7 @@ class TestSynchronizationDedupCaseSensitive(OneUserTest):
         assert len(get("/")) == count_root
         assert len(get("/fruits")) == count_folder
         if count_fixed_folder > -1:
-            assert len(get(f"/fruits-renamed")) == count_fixed_folder
+            assert len(get("/fruits-renamed")) == count_fixed_folder
 
         # Ensure there is no postponed nor documents in error
         assert not self.engine_1.dao.get_error_count(threshold=0)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -448,7 +448,7 @@ def test_get_date_from_sqlite():
 
 def test_get_default_local_folder():
     if WINDOWS:
-        path = os.path.expandvars(f"C:\\Users\\%username%\\Documents")
+        path = os.path.expandvars("C:\\Users\\%username%\\Documents")
         good_folder = Path(path) / APP_NAME
     else:
         good_folder = Path.home() / APP_NAME
@@ -768,7 +768,7 @@ def test_parse_protocol_url_cmd(cmd):
 
 def test_parse_protocol_url_cmd_unknown():
     """Parse an unknown command, it must fail."""
-    url = f"nxdrive://unknown/00000000-0000-0000-0000/On%20call%20Schedule.docx"
+    url = "nxdrive://unknown/00000000-0000-0000-0000/On%20call%20Schedule.docx"
     with pytest.raises(ValueError):
         nxdrive.utils.parse_protocol_url(url)
 

--- a/tests/unit/test_windows_registry.py
+++ b/tests/unit/test_windows_registry.py
@@ -7,7 +7,7 @@ except ImportError:
 
 
 def test_registry_create():
-    k = f"Software\\Classes\\directory\\shell\\MockedApplicationName"
+    k = "Software\\Classes\\directory\\shell\\MockedApplicationName"
     try:
         registry.create(k)
         assert registry.exists(k)
@@ -16,18 +16,18 @@ def test_registry_create():
 
 
 def test_registry_delete():
-    k = f"Software\\Classes\\directory\\shell\\MockedApplicationNameUnknown"
+    k = "Software\\Classes\\directory\\shell\\MockedApplicationNameUnknown"
     assert registry.delete(k)
 
 
 def test_registry_delete_value():
-    k = f"Software\\Classes\\directory\\shell\\MockedApplicationNameUnknown"
+    k = "Software\\Classes\\directory\\shell\\MockedApplicationNameUnknown"
     v = "nonSenseValue"
     assert registry.delete_value(k, v)
 
 
 def test_registry_exists():
-    k = f"Software\\Classes\\directory\\shell\\MockedApplicationNameUnknown"
+    k = "Software\\Classes\\directory\\shell\\MockedApplicationNameUnknown"
     assert not registry.exists(k)
 
 

--- a/tools/scripts/check_update_process.py
+++ b/tools/scripts/check_update_process.py
@@ -257,9 +257,9 @@ def set_options():
 
     print(">>> Setting options:", options, flush=True)
     with open(file, "w") as f:
-        f.write(f"[DEFAULT]\n")
-        f.write(f"env = automatic\n")
-        f.write(f"[automatic]\n")
+        f.write("[DEFAULT]\n")
+        f.write("env = automatic\n")
+        f.write("[automatic]\n")
         f.write("\n".join(options))
         f.write("\n")
 


### PR DESCRIPTION
This was only one kind of error:

    F999 f-string is missing placeholders