### PR TITLE
NXDRIVE-2064: Use the latest VM image available for GitHub Actions

### DIFF
--- a/.github/workflows/dead_code.yml
+++ b/.github/workflows/dead_code.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   job:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   job:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.github/workflows/spell.yml
+++ b/.github/workflows/spell.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   job:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   job:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   job:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.github/workflows/types.yml
+++ b/.github/workflows/types.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   job:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ut_linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -31,7 +31,7 @@ jobs:
       run: tox -e unit
 
   ut_macos:
-    runs-on: macos-10.15
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -54,7 +54,7 @@ jobs:
       run: tox -e unit
 
   ut_windows:
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -3,7 +3,9 @@ name: Unit tests
 on:
   pull_request:
     paths:
-    - '**/*.py'
+    - 'nxdrive/**/*.py'
+    - 'tests/*.py'
+    - 'tests/unit/*.py'
     - 'tools/deps/*.txt'
 
 jobs:

--- a/tools/deps/requirements-clean.txt
+++ b/tools/deps/requirements-clean.txt
@@ -1,0 +1,23 @@
+certifi==2019.11.28 \
+    --hash=sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3 \
+    --hash=sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f
+    # via requests
+chardet==3.0.4 \
+    --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
+    --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
+    # via requests
+idna==2.9 \
+    --hash=sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa \
+    --hash=sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb
+    # via requests
+nuxeo==2.4.4 \
+    --hash=sha256:3a5be3dfc86068d26d18f79c4cd2a7a18dc460b1ecd02f17406f6379e140f9a2 \
+    --hash=sha256:300bfdcecf5fbedd2175c3933885597f534e8d892086488e098250b4051304f0
+requests==2.23.0 \
+    --hash=sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee \
+    --hash=sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6
+    # via nuxeo
+urllib3==1.25.8 \
+    --hash=sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc \
+    --hash=sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc
+    # via requests

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envlist =
     # translations
     # integration
     # ft
+    # clean
     # bench
 
 [base]
@@ -117,3 +118,11 @@ commands = python -m pytest -c tests/benchmarks/empty.ini \
     --benchmark-sort=stddev \
     --benchmark-columns=min,max,mean,stddev \
     tests/benchmarks
+
+[testenv:clean]
+description = Clean-up tests data
+passenv = {[base]passenv}
+deps =
+    {[base]deps}
+    -r tools/deps/requirements-clean.txt
+commands = python tests/cleanup.py


### PR DESCRIPTION
And other small improvements:
- NXDRIVE-2064: Use more specific paths for unit tests detection
- NXDRIVE-2064: Add the 'clean' tox env to remove tests data