### PR TITLE
Upgraded PyObjC from 6.1 to 6.2

### DIFF
--- a/tools/deps/requirements.txt
+++ b/tools/deps/requirements.txt
@@ -144,38 +144,32 @@ pycryptodomex==3.9.7 \
     --hash=sha256:bf391b377413a197000b43ef2b74359974d8927d329a897c9f5ba7b63dca7b9c \
     --hash=sha256:1ecc9db7409db67765eb008e558879d298406642d33ade43a6488224d23e8081 \
     --hash=sha256:50163324834edd0c9ce3e4512ded3e221c969086e10fdd5d3fdcaadac5e24a78
-pyobjc-core==6.1 ; sys_platform == "darwin" \
-    --hash=sha256:470ccd754efb468a59426942673dfc3c5c59f33a5b8cae8a7fc1be975c2d4128 \
-    --hash=sha256:751cdeb436cb181af2e2413015b072075590577c410c7f345080a38dd028b8ec \
-    --hash=sha256:8ccf44511cbe438fa6562c423c0c5f1dad7cfc0eadd6d8f112840f8845b44fda \
-    --hash=sha256:1a0fbf012fb575e0adf8c18cfd4453e657cc2c0deb2660c529bf524ba4c9149a
+pyobjc-core==6.2 ; sys_platform == "darwin" \
+    --hash=sha256:cb130c953c79cb2df4eb3976b7fe28c336b0de0dc550b0574eca8856c76cd147 \
+    --hash=sha256:ccfad6cba29652b005bc41e819ad70d203cc3e57a16e75e27bc4e6979034c7c0 \
+    --hash=sha256:6af32dc491c575346400c29649fffe6e0a1911553b9218529deafc56fa357bdd \
+    --hash=sha256:8dd816c03fcbcbd8da8beb30dffe3aaaf8077d852cca4d636e3d7dd0ab48d39d \
+    --hash=sha256:843b175e6bd6309c4457090ca52ca8e20cb1e6be19df1bc74d1ed1889f52149c
     # via pyobjc-framework-Cocoa
-pyobjc-framework-Cocoa==6.1 ; sys_platform == "darwin" \
-    --hash=sha256:32ba4d0ce811e2088bf0fc360c9545c06586934e895f7133655b8f2182e7019a \
-    --hash=sha256:245e19156739f8068db474ad9561079cc698f08ef525e299b8eedc5531e02801 \
-    --hash=sha256:1dc428f867d35007ddf9de5b24eff5bfdf65c58b1d610abcb08bebd94c343312 \
-    --hash=sha256:c4077d2e6f96e4f3fd9780d66778cf51d27f414822498b24410e9df7a6a4d531
-pyobjc-framework-CoreServices==6.1 ; sys_platform == "darwin" \
-    --hash=sha256:0e28004a6fcc3d8928d7c8ddac2059651847851e2bad7fe2d1ed7fd12615065c \
-    --hash=sha256:a2977e948027677fca574a6c3fc4654f6644700bf9d2afa87c64afa2acf4b66e \
-    --hash=sha256:416c47d12640ddcdb773eee6a99e09d26326dadb15056d0f7734eff913d4ce7b \
-    --hash=sha256:665f979403ebae16b4d9945d24829c12c2aeccc0338cd04a268a324b6cc654a2
-pyobjc-framework-FSEvents==6.1 ; sys_platform == "darwin" \
-    --hash=sha256:94c6953774b6d69e59d9781951f05ef57e352b3c530d4c236f463444852c3a88 \
-    --hash=sha256:3a403ce5997cc01f23f1a70f8b4c919311b9a6b1fdd3c3d02d19079d711f954c \
-    --hash=sha256:d2ae8748d1791dc9e3d19b41d3873283ac34ed17ff8fca70f1a199336a0477b5 \
-    --hash=sha256:7a635c86af744a1d17f0c6c3913bef87b5fd146e0311c03229eba9e512b81520
+pyobjc-framework-Cocoa==6.2 ; sys_platform == "darwin" \
+    --hash=sha256:04b994a26bc30c912f2f5165d57a987f35889a36dd9c104674bc449c53649629 \
+    --hash=sha256:09612dd81fafb6e1a8eb597b5e523c9de103a50af79e95afbf13b8a5937e3cfa \
+    --hash=sha256:cbe4f1917aa5def4a77fd4199a9697f3b4224acf59acf4e01fe9a7c73d49b08c \
+    --hash=sha256:ef3c21a8b37519e3a3880fc0c5539fe27afd3e0235c8ebc9c87b3d0354cbb4ea \
+    --hash=sha256:e15bbf82bfe3a14dfd29c7465cc5d8edab16d546410239b7e1a4db62ded4a5b2
+pyobjc-framework-CoreServices==6.2 ; sys_platform == "darwin" \
+    --hash=sha256:9eda26223108190415cd528470a35d9633be215b32e50995d6c00c6e6a452272 \
+    --hash=sha256:c347b716af946221b83ba67f9e7cdb2e220ae2f11a267d03e99acf81e17e8551
+pyobjc-framework-FSEvents==6.2 ; sys_platform == "darwin" \
+    --hash=sha256:dbe66ac66e6425af20b5790c630e31d630320fb201c6b81800635ff1143efc9b \
+    --hash=sha256:e61f7f31bdc8cb4857d379d03dfc7eb8077b5b66e19bddae94ab53202a87f27e
     # via watchdog
-pyobjc-framework-ScriptingBridge==6.1 ; sys_platform == "darwin" \
-    --hash=sha256:219ff637ff937866c5b2d979ffc88231b88a0a0c29591251cee6652454a6cc92 \
-    --hash=sha256:affff06c35551a7cac5fb8bb5363b50eca0dc189df78fa343356e1eeda0492cd \
-    --hash=sha256:b3f9342733697f81b6e54e052648ac89beb234057502aa43c1861a243b0f0f61 \
-    --hash=sha256:5f4b2f62fe99cbb3feaa4afe55fef686b6ef3be2abaa5f55ed3a8fef40dc6046
-pyobjc-framework-SystemConfiguration==6.1 ; sys_platform == "darwin" \
-    --hash=sha256:07f1cf37ad1af293fc6f91da59796df5cb5f1584ff6c40f93ede10ae6aafb51a \
-    --hash=sha256:feb3d11f4a011e492cd00468791707aea65941cd5076f8c765bc1f3ad46b6cec \
-    --hash=sha256:801a1d7802b019c05cdf452245f830bfa3b2a8782fa2e334fc12d9fbff9f6f49 \
-    --hash=sha256:2d5da94f569fd0cdea981035b343a18275378c433e998a92926b788534320cbf
+pyobjc-framework-ScriptingBridge==6.2 ; sys_platform == "darwin" \
+    --hash=sha256:b5798691be4f876354b0da6e60974d65245f216f2f30edf58e874f59a02fd3d9 \
+    --hash=sha256:30262d16390af4c15647473966d1cd20480e83dca337a55f474076c991dce009
+pyobjc-framework-SystemConfiguration==6.2 ; sys_platform == "darwin" \
+    --hash=sha256:3d6b293a159d6a73d6393b01a5d6c7e646e120c1c3b821c051527048058c66c3 \
+    --hash=sha256:99a4b127925ed99958b28ad6fae95f764fe821be62e033b48d7b2d71c28fe58b
     # via pypac
 pypac==0.13.0 \
     --hash=sha256:a1eac0e3224939fcc691c8ad815f9cd24d737c8e0cf9c9905a01821bbe8f1414


### PR DESCRIPTION
PRs made by Dependabot are bad (#1498, #1499, #1500, #1501, #1502 and #1506).