### PR TITLE
NXDRIVE-2127: Fixes for functional tests using tox

### DIFF
--- a/docs/changes/4.4.3.md
+++ b/docs/changes/4.4.3.md
@@ -17,7 +17,7 @@ Release date: `2020-xx-xx`
 
 ## Tests
 
-- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
+- [NXDRIVE-2127](https://jira.nuxeo.com/browse/NXDRIVE-2127): Fixes for functional tests using tox
 
 ## Docs
 

--- a/tests/old_functional/common.py
+++ b/tests/old_functional/common.py
@@ -278,7 +278,7 @@ class TwoUsersTest(TestCase):
 
         def kill_test():
             log.error(f"Killing {self.id()} after {timeout} seconds")
-            self.app.quit()
+            sys.exit(1)
 
         QTimer.singleShot(timeout * 1000, kill_test)
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envlist =
     # translations
     # integration
     # ft
+    # oft
     # clean
     # bench
 
@@ -94,7 +95,17 @@ deps =
     -r tools/deps/requirements.txt
     -r tools/deps/requirements-tests.txt
 commands =
-    python -m pytest {posargs} tests/functional tests/old_functional
+    python -m pytest {posargs} tests/functional
+
+[testenv:oft]
+description = (old) Fuctional tests
+passenv = {[base]passenv}
+deps =
+    {[base]deps}
+    -r tools/deps/requirements.txt
+    -r tools/deps/requirements-tests.txt
+commands =
+    python -m pytest {posargs} tests/old_functional
 
 [testenv:integration]
 description = Integration tests


### PR DESCRIPTION
- Run tests from "functional" when using the "ft" env.
- Run tests from "old_functional" when using the "oft" env.

Also use a hammer when a test ran out of time: `sys.exit(1)`.