### PR TITLE
NXDRIVE-2112: Always start a fresh download on Direct Edit

### DIFF
--- a/docs/changes/4.4.3.md
+++ b/docs/changes/4.4.3.md
@@ -5,6 +5,8 @@ Release date: `2020-xx-xx`
 ## Core
 
 - [NXDRIVE-1786](https://jira.nuxeo.com/browse/NXDRIVE-1786): Handle corrupted downloads in Direct Edit
+- [NXDRIVE-2112](https://jira.nuxeo.com/browse/NXDRIVE-2112): Always start a fresh download on Direct Edit
+- [NXDRIVE-2116](https://jira.nuxeo.com/browse/NXDRIVE-2116): Direct Edit requests "Invalid byte range" multiple of total binary size Edit
 - [NXDRIVE-2124](https://jira.nuxeo.com/browse/NXDRIVE-2124): Uniformize the name: Direct Edit
 
 ## GUI


### PR DESCRIPTION
It seems that there are more and more issues because of a previous
Direct Edit download failure. Doing another Direct Edit on the same
document will resume the download. Sometimes it will work, and
most of the time not.

A fresh download is now started everytime to prevent this issues.
The test test_resumed_download has benn added.
Also changelog has been updated.