### PR TITLE
NXDRIVE-2113: [Direct Edit] Add a warning on upload when server-side lock is disabled

### DIFF
--- a/docs/changes/4.4.3.md
+++ b/docs/changes/4.4.3.md
@@ -6,6 +6,7 @@ Release date: `2020-xx-xx`
 
 - [NXDRIVE-1786](https://jira.nuxeo.com/browse/NXDRIVE-1786): Handle corrupted downloads in Direct Edit
 - [NXDRIVE-2112](https://jira.nuxeo.com/browse/NXDRIVE-2112): Always start a fresh download on Direct Edit
+- [NXDRIVE-2113](https://jira.nuxeo.com/browse/NXDRIVE-2113): [Direct Edit] Add a warning on upload when server-side lock is disabled
 - [NXDRIVE-2116](https://jira.nuxeo.com/browse/NXDRIVE-2116): Direct Edit requests "Invalid byte range" multiple of total binary size Edit
 - [NXDRIVE-2124](https://jira.nuxeo.com/browse/NXDRIVE-2124): Uniformize the name: Direct Edit
 

--- a/nxdrive/direct_edit.py
+++ b/nxdrive/direct_edit.py
@@ -432,6 +432,11 @@ class DirectEdit(Worker):
         if not info:
             return None
 
+        if not self.use_autolock:
+            log.warning(
+                "Server-side document locking is disabled: you are not protected against concurrent updates."
+            )
+
         url = None
         url_info: Dict[str, str] = {}
         if download_url:


### PR DESCRIPTION
Uploading a new blob of an ongoing Direct Edit'ed document should be made only when the
user had already locked it.
The auto-locking of documents can be disabled on Drive throught an option, exposing
the user to possibles concurrent updates of the document.

A warning log has been added when a Direct Edit is done while this option is activated.