### PR TITLE
NXDRIVE-2127: Fixes

### DIFF
--- a/docs/changes/4.4.2.md
+++ b/docs/changes/4.4.2.md
@@ -7,7 +7,6 @@ Release date: `2020-04-15`
 - [NXDRIVE-374](https://jira.nuxeo.com/browse/NXDRIVE-374): [GNU/Linux] Use file system decorations
 - [NXDRIVE-382](https://jira.nuxeo.com/browse/NXDRIVE-382): Invalid conflict resolution when choosing the local file, if the remote file has been renamed before
 - [NXDRIVE-1640](https://jira.nuxeo.com/browse/NXDRIVE-1640): Refactor simple `QMessageBoxes`
-- [NXDRIVE-1690](https://jira.nuxeo.com/browse/NXDRIVE-1690): [GNU/Linux] File is not deleted on the server when the parent folder is renamed, while offline
 - [NXDRIVE-1831](https://jira.nuxeo.com/browse/NXDRIVE-1831): [GNU/Linux] Set the root local folder icon
 - [NXDRIVE-1847](https://jira.nuxeo.com/browse/NXDRIVE-1847): [Windows] Fix endless synchronization on fast create-then-rename folder
 - [NXDRIVE-1866](https://jira.nuxeo.com/browse/NXDRIVE-1866): Check spurious `ThreadInterrupt` in the conflict resolver

--- a/tests/old_functional/test_local_client.py
+++ b/tests/old_functional/test_local_client.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from time import sleep
 
 import pytest
-
 from nxdrive.constants import ROOT, WINDOWS
 from nxdrive.exceptions import DuplicationDisabledError, NotFound
 
@@ -119,10 +118,9 @@ class StubLocalClient:
         assert file_2.name == escaped_filename
         assert file_2.path == folder_1_info.path / escaped_filename
 
-    @pytest.mark.xfail(True, raises=NotFound, reason="Must fail.")
     def test_missing_file(self):
-        local = self.local_1
-        local.get_info("/Something Missing")
+        with pytest.raises(NotFound):
+            self.local_1.get_info("/Something Missing")
 
     @pytest.mark.timeout(30)
     def test_case_sensitivity(self):

--- a/tests/old_functional/test_synchronization_suspend.py
+++ b/tests/old_functional/test_synchronization_suspend.py
@@ -1,5 +1,6 @@
 # coding: utf-8
-from nxdrive.constants import WINDOWS
+import pytest
+from nxdrive.constants import LINUX, WINDOWS
 
 from .common import SYNC_ROOT_FAC_ID, OneUserTest
 
@@ -96,6 +97,7 @@ class TestSynchronizationSuspend(OneUserTest):
         self.wait_sync(wait_for_async=True)
         assert len(remote.get_children_info(self.workspace)) == 4
 
+    @pytest.mark.xfail(LINUX, reason="NXDRIVE-1690", strict=True)
     def test_folder_renaming_while_offline(self):
         """
         Scenario:


### PR DESCRIPTION
- Fixed `test_missing_file()`: it was not passing and was killed by the timeout. I do not know why, but the fix is simple and working.
- Reverted NXDRIVE-1690: as tests was screwed, it was passing even if it should have failed. Reverting the news also.

There are other failures to tackle, coming later.