### PR TITLE
NXDRIVE-2139: Make the custom user agent effective

### DIFF
--- a/docs/changes/4.4.3.md
+++ b/docs/changes/4.4.3.md
@@ -4,7 +4,7 @@ Release date: `2020-xx-xx`
 
 ## Core
 
-- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
+- [NXDRIVE-2139](https://jira.nuxeo.com/browse/NXDRIVE-2139): Make the custom user agent effective
 
 ### Direct Edit
 
@@ -44,4 +44,4 @@ Release date: `2020-xx-xx`
 
 ## Technical Changes
 
--
+- Added `USER_AGENT` in `constants.py`

--- a/nxdrive/client/proxy.py
+++ b/nxdrive/client/proxy.py
@@ -6,6 +6,7 @@ import requests
 from pypac import get_pac
 from pypac.resolver import ProxyResolver
 
+from ..constants import USER_AGENT
 from ..options import Options
 from ..utils import decrypt, encrypt, force_decode
 
@@ -179,8 +180,11 @@ def save_proxy(proxy: Proxy, dao: "EngineDAO", token: str = None) -> None:
 
 def validate_proxy(proxy: Proxy, url: str) -> bool:
     verify = Options.ca_bundle or not Options.ssl_no_verify
+    headers = {"User-Agent": USER_AGENT}
     try:
-        with requests.get(url, proxies=proxy.settings(url=url), verify=verify):
+        with requests.get(
+            url, headers=headers, proxies=proxy.settings(url=url), verify=verify
+        ):
             return True
     except OSError as exc:
         # OSError: Could not find a suitable TLS CA certificate bundle, invalid path: ...

--- a/nxdrive/constants.py
+++ b/nxdrive/constants.py
@@ -6,6 +6,8 @@ from sys import platform
 
 from requests.exceptions import ChunkedEncodingError, ConnectionError, Timeout
 
+from . import __version__
+
 LINUX = platform == "linux"
 MAC = platform == "darwin"
 WINDOWS = platform == "win32"
@@ -16,6 +18,7 @@ NXDRIVE_SCHEME = "nxdrive"
 BUNDLE_IDENTIFIER = "org.nuxeo.drive"
 APP_NAME = "Nuxeo Drive"
 COMPANY = "Nuxeo"
+USER_AGENT = f"{APP_NAME}/{__version__}".lower().replace(" ", "-")
 
 TIMEOUT = 20  # Seconds
 STARTUP_PAGE_CONNECTION_TIMEOUT = 30  # Seconds

--- a/nxdrive/engine/tracker.py
+++ b/nxdrive/engine/tracker.py
@@ -104,7 +104,7 @@ class Tracker(PollWorker):
         """ Format a custom user agent. """
 
         return (
-            f"{APP_NAME.replace(' ', '')}/{self._manager.version} ({ga_user_agent()})"
+            f"{APP_NAME.replace(' ', '-')}/{self._manager.version} ({ga_user_agent()})"
         )
 
     def send_event(self, category: str, action: str, label: str, value: int) -> None:

--- a/nxdrive/manager.py
+++ b/nxdrive/manager.py
@@ -24,6 +24,7 @@ from .constants import (
     DEFAULT_SERVER_TYPE,
     NO_SPACE_ERRORS,
     STARTUP_PAGE_CONNECTION_TIMEOUT,
+    USER_AGENT,
     DelAction,
 )
 from .direct_edit import DirectEdit
@@ -613,7 +614,7 @@ class Manager(QObject):
             "X-Application-Name": APP_NAME,
             "X-Device-Id": self.device_id,
             "X-Client-Version": self.version,
-            "User-Agent": f"{APP_NAME}/{self.version}",
+            "User-Agent": USER_AGENT,
         }
 
         log.info(f"Proxy configuration for startup page connection: {self.proxy}")

--- a/nxdrive/updater/base.py
+++ b/nxdrive/updater/base.py
@@ -11,7 +11,7 @@ import yaml
 from PyQt5.QtCore import pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import QApplication
 
-from ..constants import APP_NAME, CONNECTION_ERROR, NO_SPACE_ERRORS
+from ..constants import APP_NAME, CONNECTION_ERROR, NO_SPACE_ERRORS, USER_AGENT
 from ..engine.workers import PollWorker
 from ..feature import Feature
 from ..options import Options
@@ -177,6 +177,7 @@ class BaseUpdater(PollWorker):
         name = self.release_file.format(version=version)
         url = "/".join([self.update_site, self.versions[version]["type"], name])
         path = os.path.join(gettempdir(), uuid.uuid4().hex + "_" + name)
+        headers = {"User-Agent": USER_AGENT}
 
         log.info(
             f"Fetching version {version!r} from update site {self.update_site!r} "
@@ -185,7 +186,7 @@ class BaseUpdater(PollWorker):
         try:
             # Note: I do not think we should pass the `verify` kwarg here
             # because updates are critical and must be stored on a secured server.
-            req = requests.get(url, stream=True)
+            req = requests.get(url, headers=headers, stream=True)
             size = int(req.headers["content-length"])
 
             with open(path, "wb") as tmp:
@@ -213,10 +214,11 @@ class BaseUpdater(PollWorker):
         """ Fetch available versions. It sets `self.versions` on success. """
 
         url = f"{self.update_site}/versions.yml"
+        headers = {"User-Agent": USER_AGENT}
         try:
             # Note: I do not think we should pass the `verify` kwarg here
             # because updates are critical and must be stored on a secured server.
-            with requests.get(url) as resp:
+            with requests.get(url, headers=headers) as resp:
                 resp.raise_for_status()
                 content = resp.text
         except Exception as exc:

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -38,6 +38,7 @@ from .constants import (
     FILE_BUFFER_SIZE,
     MAC,
     UNACCESSIBLE_HASH,
+    USER_AGENT,
     WINDOWS,
 )
 from .exceptions import InvalidSSLCertificate, UnknownDigest
@@ -911,6 +912,7 @@ def guess_server_url(
     kwargs: Dict[str, Any] = {
         "timeout": timeout,
         "verify": Options.ca_bundle or not Options.ssl_no_verify,
+        "headers": {"User-Agent": USER_AGENT},
     }
     for new_url in compute_urls(url):
         try:

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -181,10 +181,11 @@ def get_issue_infos(issue, raw=False):
     debug(">>> Fetching information of {}".format(issue))
     base_url = "https://jira.nuxeo.com"
     url = base_url + "/rest/api/2/issue/{}".format(issue)
+    headers = {"User-Agent": "changelog/{}".format(__version__)}
 
     for _ in range(5):
         try:
-            with requests.get(url) as content:
+            with requests.get(url, headers=headers) as content:
                 data = content.json()
                 break
         except (requests.HTTPError, ValueError):

--- a/tools/scripts/check_update_process.py
+++ b/tools/scripts/check_update_process.py
@@ -91,9 +91,10 @@ def download_last_ga_release(output_dir, version):
     file += "-x86_64.AppImage" if EXT == "appimage" else f".{EXT}"
     url = f"https://community.nuxeo.com/static/drive-updates/release/{file}"
     output = os.path.join(output_dir, "alpha", file)
+    headers = {"User-Agent": f"check-updater/{__version__}"}
     print(">>> Downloading", url, "->", output, flush=True)
 
-    with requests.get(url) as req, open(output, "wb") as dst:
+    with requests.get(url, headers=headers) as req, open(output, "wb") as dst:
         dst.write(req.content)
 
     # Adjust execution rights
@@ -127,8 +128,9 @@ def get_last_version_number():
     from nxdrive.updater.utils import get_latest_version
 
     url = "https://community.nuxeo.com/static/drive-updates/versions.yml"
+    headers = {"User-Agent": f"check-updater/{__version__}"}
     print(">>> Downloading", url, flush=True)
-    with requests.get(url) as req:
+    with requests.get(url, headers=headers) as req:
         data = req.content
 
     versions = yaml.safe_load(data)


### PR DESCRIPTION
For calls made outside the Python client.

Now, when looking at Apache logs, we will see more interesting data (before/after):

    IP - - [27/Apr/2020:14:03:07 +0000] "GET /static/drive-updates/versions.yml HTTP/1.1" 200 22268 "-" "python-requests/2.23.0"
    IP - - [27/Apr/2020:15:00:28 +0000] "GET /static/drive-updates/versions.yml HTTP/1.1" 200 22255 "-" "nuxeo-drive/4.4.3"