### PR TITLE
NXDRIVE-2128: Allow only one Direct Edit'ion per document

### DIFF
--- a/docs/changes/4.4.3.md
+++ b/docs/changes/4.4.3.md
@@ -13,6 +13,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2113](https://jira.nuxeo.com/browse/NXDRIVE-2113): Add a warning on upload when server-side lock is disabled
 - [NXDRIVE-2116](https://jira.nuxeo.com/browse/NXDRIVE-2116): Requests `Invalid byte range` multiple of total binary size
 - [NXDRIVE-2124](https://jira.nuxeo.com/browse/NXDRIVE-2124): Uniformize the name: "Direct Edit"
+- [NXDRIVE-2128](https://jira.nuxeo.com/browse/NXDRIVE-2128): Allow only one Direct Edit'ion per document
 
 ## GUI
 


### PR DESCRIPTION
When a document is opened, one should not be able to open it again.