### PR TITLE
NXDRIVE-2121: Lower logging level of "Icon folder cannot be set"

### DIFF
--- a/docs/changes/4.4.3.md
+++ b/docs/changes/4.4.3.md
@@ -4,6 +4,7 @@ Release date: `2020-xx-xx`
 
 ## Core
 
+- [NXDRIVE-2121](https://jira.nuxeo.com/browse/NXDRIVE-2121): Lower logging level of "Icon folder cannot be set"
 - [NXDRIVE-2139](https://jira.nuxeo.com/browse/NXDRIVE-2139): Make the custom user agent effective
 
 ### Direct Edit

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -1099,7 +1099,7 @@ class Engine(QObject):
         try:
             self.local.set_folder_icon(ROOT, icon)
         except Exception:
-            log.exception("Icon folder cannot be set")
+            log.warning("Icon folder cannot be set", exc_info=True)
         finally:
             self.local.lock_ref(ROOT, locker)
 


### PR DESCRIPTION
The logging level from exception "Icon folder cannot be set"
has been lowered to warning because it is filling Sentry with
useless informations.