### PR TITLE
NXDRIVE-2132: Do not allow Direct Edit on proxies

### DIFF
--- a/docs/changes/4.4.3.md
+++ b/docs/changes/4.4.3.md
@@ -14,6 +14,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2113](https://jira.nuxeo.com/browse/NXDRIVE-2113): Add a warning on upload when server-side lock is disabled
 - [NXDRIVE-2116](https://jira.nuxeo.com/browse/NXDRIVE-2116): Requests `Invalid byte range` multiple of total binary size
 - [NXDRIVE-2124](https://jira.nuxeo.com/browse/NXDRIVE-2124): Uniformize the name: "Direct Edit"
+- [NXDRIVE-2132](https://jira.nuxeo.com/browse/NXDRIVE-2132): Do not allow Direct Edit on proxies
 
 ## GUI
 
@@ -49,3 +50,4 @@ Release date: `2020-xx-xx`
 ## Technical Changes
 
 - Added `USER_AGENT` in `constants.py`
+- Added `NuxeoDocumentInfo.is_proxy`

--- a/nxdrive/data/i18n/i18n.json
+++ b/nxdrive/data/i18n/i18n.json
@@ -77,6 +77,7 @@
     "DIRECT_EDIT_LOCK_ERROR_DESCRIPTION": "The document „%1“ was not locked",
     "DIRECT_EDIT_NOT_FOUND": "Document „%1“ not found on %2",
     "DIRECT_EDIT_NOT_ENABLED": "The Direct Edit feature is not enabled.",
+    "DIRECT_EDIT_PROXY": "You are trying to perform a Direct Edit on „%1“. This is a proxy so it cannot be edited.",
     "DIRECT_EDIT_READONLY_FILE": "Cannot edit „%1“ as it is read-only",
     "DIRECT_EDIT_STARTING_TITLE": "Opening from %1",
     "DIRECT_EDIT_STARTING_MSG": "„%1“ is being opened locally …",

--- a/nxdrive/direct_edit.py
+++ b/nxdrive/direct_edit.py
@@ -392,6 +392,9 @@ class DirectEdit(Worker):
                 "DIRECT_EDIT_VERSION", [info.version, info.name, info.uid]
             )
             return None
+        if info.is_proxy:
+            self.directEditError.emit("DIRECT_EDIT_PROXY", [info.name])
+            return None
 
         if info.lock_owner and info.lock_owner != engine.remote_user:
             # Retrieve the user full name, will be cached
@@ -740,6 +743,12 @@ class DirectEdit(Worker):
                         log.warning(
                             f"Unable to process Direct Edit on {remote_info.name} "
                             f"({details.uid}) because it is a version."
+                        )
+                        continue
+                    if remote_info.is_proxy:
+                        log.warning(
+                            f"Unable to process Direct Edit on {remote_info.name} "
+                            f"({details.uid}) because it is a proxy."
                         )
                         continue
                     remote_blob = remote_info.get_blob(xpath) if remote_info else None

--- a/nxdrive/objects.py
+++ b/nxdrive/objects.py
@@ -184,6 +184,7 @@ class NuxeoDocumentInfo:
     version: Optional[str]  # Nuxeo version
     state: Optional[str]  # Nuxeo lifecycle state
     is_trashed: bool  # Nuxeo trashed status
+    is_proxy: bool  # Is a proxy of a document
     is_version: bool  # is it a version of a document
     lock_owner: Optional[str]  # lock owner
     lock_created: Optional[datetime]  # lock creation time
@@ -221,6 +222,9 @@ class NuxeoDocumentInfo:
         # Is version of document
         is_version = doc.get("isVersion", False)
 
+        # Is a proxy
+        is_proxy = doc.get("isProxy", False)
+
         # XXX: we need another roundtrip just to fetch the parent uid...
 
         # Normalize using NFC to make the tests more intuitive
@@ -243,6 +247,7 @@ class NuxeoDocumentInfo:
             version,
             doc.get("state"),
             is_trashed,
+            is_proxy,
             is_version,
             lock_owner,
             lock_created,

--- a/tests/old_functional/__init__.py
+++ b/tests/old_functional/__init__.py
@@ -543,6 +543,12 @@ class DocRemote(RemoteTest):
             name=name,
         )
 
+    def create_proxy(self, ref: str, output_ref: str):
+        kwargs = {"Destination Path": output_ref}
+        return self.execute(
+            command="Document.CreateLiveProxy", input_obj=self.check_ref(ref), **kwargs,
+        )
+
     def update(self, ref: str, properties=None):
         return self.execute(
             command="Document.Update", input_obj=f"doc:{ref}", properties=properties


### PR DESCRIPTION
Direct Edit on proxies should be forbidden as it causes
many errors that fills the logs.

The document download is now aborted and a graphical error
is displayed when the user try to use Direct Edit on a proxy.
The translation file has been updated with the new error message.
A functionnal test has been added.
Also changelog has been updated.