### PR TITLE
NXDRIVE-2131: [Direct Edit] Handle HTTP 413 error: Request Entity Too Large

### DIFF
--- a/docs/changes/4.4.3.md
+++ b/docs/changes/4.4.3.md
@@ -14,6 +14,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2113](https://jira.nuxeo.com/browse/NXDRIVE-2113): Add a warning on upload when server-side lock is disabled
 - [NXDRIVE-2116](https://jira.nuxeo.com/browse/NXDRIVE-2116): Requests `Invalid byte range` multiple of total binary size
 - [NXDRIVE-2124](https://jira.nuxeo.com/browse/NXDRIVE-2124): Uniformize the name: "Direct Edit"
+- [NXDRIVE-2131](https://jira.nuxeo.com/browse/NXDRIVE-2131): Handle HTTP 413 error: Request Entity Too Large
 - [NXDRIVE-2132](https://jira.nuxeo.com/browse/NXDRIVE-2132): Do not allow Direct Edit on proxies
 
 ## GUI

--- a/nxdrive/engine/blacklist_queue.py
+++ b/nxdrive/engine/blacklist_queue.py
@@ -49,6 +49,11 @@ class BlacklistQueue:
     def __str__(self) -> str:
         return repr(self)
 
+    def empty(self) -> bool:
+        """Return True if the queue is empty, False otherwise."""
+        with self._lock:
+            return not bool(self._queue)
+
     def push(self, path: Path) -> None:
         with self._lock:
             item = BlacklistItem(path, next_try=self._delay)


### PR DESCRIPTION
When trying to upload changes in Direct Edit, and if the target is a proxy then
the HTTPError 413 will be raised, filling server logs, client logs and
Sentry events. The error was already partially fixed by NXDRIVE-2132.

The error is now catched and the upload skipped when this error is raised.
The functional test test_direct_edit_413_error has been added.
Also changelog has been updated.