### PR TITLE
Add missing importlib-metadata and zipp modules following markdown up…

### DIFF
--- a/docs/changes/4.4.3.md
+++ b/docs/changes/4.4.3.md
@@ -35,6 +35,8 @@ Release date: `2020-xx-xx`
 
 ## Minor Changes
 
+- Added `importlib-metadata` 1.6.0
+- Added `zipp` 3.1.0
 - Upgraded `boto3` from 1.12.19 to 1.13.0
 - Upgraded `botocore` from 1.15.19 to 1.16.0
 - Upgraded `certifi` from 2019.11.28 to 2020.4.5.1

--- a/tools/deps/requirements-lint.txt
+++ b/tools/deps/requirements-lint.txt
@@ -4,6 +4,10 @@ entrypoints==0.3 \
 flake8==3.8.1 \
     --hash=sha256:6c1193b0c3f853ef763969238f6c81e9e63ace9d024518edc020d5f1d6d93195 \
     --hash=sha256:ea6623797bf9a52f4c9577d780da0bb17d65f870213f7b5bcc9fca82540c31d5
+importlib-metadata==1.6.0 \
+    --hash=sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f \
+    --hash=sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e
+    # via flake8
 mccabe==0.6.1 \
     --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42
     # via flake8
@@ -15,3 +19,7 @@ pyflakes==2.2.0 \
     --hash=sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92 \
     --hash=sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8
     # via flake8
+zipp==3.1.0 \
+    --hash=sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b \
+    --hash=sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96
+    # via importlib-metadata

--- a/tools/deps/requirements.txt
+++ b/tools/deps/requirements.txt
@@ -82,6 +82,10 @@ idna==2.9 \
     --hash=sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa \
     --hash=sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb
     # via requests
+importlib-metadata==1.6.0 \
+    --hash=sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f \
+    --hash=sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e
+    # via markdown
 jmespath==0.9.5 \
     --hash=sha256:695cb76fa78a10663425d5b73ddc5714eb711157e52704d69be03b1a02ba4fec \
     --hash=sha256:cca55c8d153173e21baa59983015ad0daf603f9cb799904ff057bfb8ff8dc2d9
@@ -250,3 +254,7 @@ xattr==0.9.7 ; sys_platform != "win32" \
     --hash=sha256:e2c72a3a501bac715489180ca2b646e48a1ca3a794c1103dd6f0f987d43f570c \
     --hash=sha256:1e11ba8ab86dfe74419704c53722ea9b5915833db07416e7c10db5dfb02218bb \
     --hash=sha256:b0bbca828e04ef2d484a6522ae7b3a7ccad5e43fa1c6f54d78e24bb870f49d44
+zipp==3.1.0 \
+    --hash=sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b \
+    --hash=sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96
+    # via importlib-metadata


### PR DESCRIPTION
…grade

Do the same for flake8 upgrade.