### PR TITLE
NXDRIVE-2129: [Direct Edit] Orphaned documents should first be remotely unlocked before being cleaned up

### DIFF
--- a/docs/changes/4.4.4.md
+++ b/docs/changes/4.4.4.md
@@ -19,6 +19,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2113](https://jira.nuxeo.com/browse/NXDRIVE-2113): Add a warning on upload when server-side lock is disabled
 - [NXDRIVE-2116](https://jira.nuxeo.com/browse/NXDRIVE-2116): Requests `Invalid byte range` multiple of total binary size
 - [NXDRIVE-2124](https://jira.nuxeo.com/browse/NXDRIVE-2124): Uniformize the name: "Direct Edit"
+- [NXDRIVE-2129](https://jira.nuxeo.com/browse/NXDRIVE-2129): Orphaned documents should first be remotely unlocked before being cleaned up
 - [NXDRIVE-2131](https://jira.nuxeo.com/browse/NXDRIVE-2131): Handle HTTP 413 error: Request Entity Too Large
 - [NXDRIVE-2132](https://jira.nuxeo.com/browse/NXDRIVE-2132): Do not allow Direct Edit on proxies
 - [NXDRIVE-2155](https://jira.nuxeo.com/browse/NXDRIVE-2155): Improvements on the main popup

--- a/nxdrive/direct_edit.py
+++ b/nxdrive/direct_edit.py
@@ -224,6 +224,12 @@ class DirectEdit(Worker):
                 continue
 
             # Place for handle reopened of interrupted Direct Edit
+            # Orphans locked files are ignored here as they are deleted later after being unlocked
+            locks = self._manager.dao.get_locked_paths()
+            if any(child.filepath for lock in locks if child.filepath in lock.parents):
+                continue
+
+            # Finally
             purge(child.path)
 
     def __get_engine(self, url: str, user: str = None) -> Optional["Engine"]:


### PR DESCRIPTION
When the application is shut down during a direct edit, the edited file
stay locked on the remote server and the temporary file is not deleted.
When starting, the expected behaviour is to unlock the document on
the remote then remove the local orphan file.