### PR TITLE
NXDRIVE-2169: Enforce Python 32-bit on the CI

### DIFF
--- a/.github/workflows/dead_code.yml
+++ b/.github/workflows/dead_code.yml
@@ -14,6 +14,7 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7  # XXX_PYTHON
+        architecture: 'x86'
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,7 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7  # XXX_PYTHON
+        architecture: 'x86'
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pip

--- a/.github/workflows/spell.yml
+++ b/.github/workflows/spell.yml
@@ -17,6 +17,7 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7  # XXX_PYTHON
+        architecture: 'x86'
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pip

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -14,6 +14,7 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7  # XXX_PYTHON
+        architecture: 'x86'
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pip

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -14,6 +14,7 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7  # XXX_PYTHON
+        architecture: 'x86'
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pip

--- a/.github/workflows/types.yml
+++ b/.github/workflows/types.yml
@@ -14,6 +14,7 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7  # XXX_PYTHON
+        architecture: 'x86'
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pip

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -17,6 +17,7 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7  # XXX_PYTHON
+        architecture: 'x86'
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pip
@@ -40,6 +41,7 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7  # XXX_PYTHON
+        architecture: 'x86'
     - uses: actions/cache@v1
       with:
         path: ~/Library/Caches/pip
@@ -63,6 +65,7 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7  # XXX_PYTHON
+        architecture: 'x86'
     - uses: actions/cache@v1
       with:
         path: ~\AppData\Local\pip\Cache


### PR DESCRIPTION
This would have catch the Windows crash. Better late than never!