### PR TITLE
NXDRIVE-2137: Bump the version to 4.4.4

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -17,7 +17,8 @@
 - [4.4.0](changes/4.4.0.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-4.4.0...release-4.3.0))
 - [4.4.1](changes/4.4.1.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-4.4.0...release-4.4.1))
 - [4.4.2](changes/4.4.2.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-4.4.1...release-4.4.2))
-- [4.4.3](changes/4.4.3.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-4.4.2...master))
+- [4.4.3](changes/4.4.3.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-4.4.2...release-4.4.3))
+- [4.4.4](changes/4.4.4.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-4.4.3...master))
 
 ## 3.x
 

--- a/docs/changes/4.4.3.md
+++ b/docs/changes/4.4.3.md
@@ -1,65 +1,11 @@
 # 4.4.3
 
-Release date: `2020-xx-xx`
-
-## Core
-
-- [NXDRIVE-1848](https://jira.nuxeo.com/browse/NXDRIVE-1848): Remove dependency on `rfc3987` for URL parsing
-- [NXDRIVE-2121](https://jira.nuxeo.com/browse/NXDRIVE-2121): Lower logging level of "Icon folder cannot be set"
-- [NXDRIVE-2133](https://jira.nuxeo.com/browse/NXDRIVE-2133): [macOS] Skip errors on file creation time modification
-- [NXDRIVE-2139](https://jira.nuxeo.com/browse/NXDRIVE-2139): Make the custom user agent effective
-
-### Direct Edit
-
-- [NXDRIVE-1786](https://jira.nuxeo.com/browse/NXDRIVE-1786): Handle corrupted downloads
-- [NXDRIVE-2112](https://jira.nuxeo.com/browse/NXDRIVE-2112): Always start a fresh download
-- [NXDRIVE-2113](https://jira.nuxeo.com/browse/NXDRIVE-2113): Add a warning on upload when server-side lock is disabled
-- [NXDRIVE-2116](https://jira.nuxeo.com/browse/NXDRIVE-2116): Requests `Invalid byte range` multiple of total binary size
-- [NXDRIVE-2124](https://jira.nuxeo.com/browse/NXDRIVE-2124): Uniformize the name: "Direct Edit"
-- [NXDRIVE-2131](https://jira.nuxeo.com/browse/NXDRIVE-2131): Handle HTTP 413 error: Request Entity Too Large
-- [NXDRIVE-2132](https://jira.nuxeo.com/browse/NXDRIVE-2132): Do not allow Direct Edit on proxies
-
-## GUI
-
-- [NXDRIVE-2150](https://jira.nuxeo.com/browse/NXDRIVE-2150): Change the disk space usage border color
+Release date: `2020-05-19`
 
 ## Packaging / Build
 
-- [NXDRIVE-2016](https://jira.nuxeo.com/browse/NXDRIVE-2016): Upgrade Python from 3.7.4 to 3.7.7
-- [NXDRIVE-2146](https://jira.nuxeo.com/browse/NXDRIVE-2146): Do not package `Qt5RemoteObjects` DLL and shared library
 - [NXDRIVE-2169](https://jira.nuxeo.com/browse/NXDRIVE-2169): [Windows] `psutil` is crashing the application
-
-## Tests
-
-- [NXDRIVE-2127](https://jira.nuxeo.com/browse/NXDRIVE-2127): Fixes for functional tests using tox
-
-## Docs
-
-- [NXDRIVE-2130](https://jira.nuxeo.com/browse/NXDRIVE-2130): Add Direct Edit and Direct Transfer sections in the changelog
 
 ## Minor Changes
 
-- Added `importlib-metadata` 1.6.0
-- Added `zipp` 3.1.0
 - Downgraded `psutil` from 5.7.0 to 5.6.7
-- Upgraded `boto3` from 1.12.19 to 1.13.0
-- Upgraded `botocore` from 1.15.19 to 1.16.0
-- Upgraded `certifi` from 2019.11.28 to 2020.4.5.1
-- Upgraded `jmespath` from 0.9.5 to 0.10.0
-- Upgraded `markdown` from 3.2.1 to 3.2.2
-- Upgraded `pip` from 20.0.2 to 20.1
-- Upgraded `pyobjc-core` from 6.1 to 6.2
-- Upgraded `pyobjc-framework-Cocoa` from 6.1 to 6.2
-- Upgraded `pyobjc-framework-CoreServices` from 6.1 to 6.2
-- Upgraded `pyobjc-framework-FSEvents` from 6.1 to 6.2
-- Upgraded `pyobjc-framework-ScriptingBridge` from 6.1 to 6.2
-- Upgraded `pyobjc-framework-SystemConfiguration` from 6.1 to 6.2
-- Upgraded `sentry-sdk` from 0.14.3 to 0.14.4
-- Upgraded `tld` from 0.11.9 to 0.12.1
-- Upgraded `urllib3` from 1.25.8 to 1.25.9
-- Removed `rfc3987`
-
-## Technical Changes
-
-- Added `USER_AGENT` in `constants.py`
-- Added `NuxeoDocumentInfo.is_proxy`

--- a/docs/changes/4.4.4.md
+++ b/docs/changes/4.4.4.md
@@ -1,0 +1,63 @@
+# 4.4.4
+
+Release date: `2020-xx-xx`
+
+## Core
+
+- [NXDRIVE-1848](https://jira.nuxeo.com/browse/NXDRIVE-1848): Remove dependency on `rfc3987` for URL parsing
+- [NXDRIVE-2121](https://jira.nuxeo.com/browse/NXDRIVE-2121): Lower logging level of "Icon folder cannot be set"
+- [NXDRIVE-2133](https://jira.nuxeo.com/browse/NXDRIVE-2133): [macOS] Skip errors on file creation time modification
+- [NXDRIVE-2139](https://jira.nuxeo.com/browse/NXDRIVE-2139): Make the custom user agent effective
+
+### Direct Edit
+
+- [NXDRIVE-1786](https://jira.nuxeo.com/browse/NXDRIVE-1786): Handle corrupted downloads
+- [NXDRIVE-2112](https://jira.nuxeo.com/browse/NXDRIVE-2112): Always start a fresh download
+- [NXDRIVE-2113](https://jira.nuxeo.com/browse/NXDRIVE-2113): Add a warning on upload when server-side lock is disabled
+- [NXDRIVE-2116](https://jira.nuxeo.com/browse/NXDRIVE-2116): Requests `Invalid byte range` multiple of total binary size
+- [NXDRIVE-2124](https://jira.nuxeo.com/browse/NXDRIVE-2124): Uniformize the name: "Direct Edit"
+- [NXDRIVE-2131](https://jira.nuxeo.com/browse/NXDRIVE-2131): Handle HTTP 413 error: Request Entity Too Large
+- [NXDRIVE-2132](https://jira.nuxeo.com/browse/NXDRIVE-2132): Do not allow Direct Edit on proxies
+
+## GUI
+
+- [NXDRIVE-2150](https://jira.nuxeo.com/browse/NXDRIVE-2150): Change the disk space usage border color
+
+## Packaging / Build
+
+- [NXDRIVE-2016](https://jira.nuxeo.com/browse/NXDRIVE-2016): Upgrade Python from 3.7.4 to 3.7.7
+- [NXDRIVE-2146](https://jira.nuxeo.com/browse/NXDRIVE-2146): Do not package `Qt5RemoteObjects` DLL and shared library
+
+## Tests
+
+- [NXDRIVE-2127](https://jira.nuxeo.com/browse/NXDRIVE-2127): Fixes for functional tests using tox
+
+## Docs
+
+- [NXDRIVE-2130](https://jira.nuxeo.com/browse/NXDRIVE-2130): Add Direct Edit and Direct Transfer sections in the changelog
+
+## Minor Changes
+
+- Added `importlib-metadata` 1.6.0
+- Added `zipp` 3.1.0
+- Upgraded `boto3` from 1.12.19 to 1.13.0
+- Upgraded `botocore` from 1.15.19 to 1.16.0
+- Upgraded `certifi` from 2019.11.28 to 2020.4.5.1
+- Upgraded `jmespath` from 0.9.5 to 0.10.0
+- Upgraded `markdown` from 3.2.1 to 3.2.2
+- Upgraded `pip` from 20.0.2 to 20.1
+- Upgraded `pyobjc-core` from 6.1 to 6.2
+- Upgraded `pyobjc-framework-Cocoa` from 6.1 to 6.2
+- Upgraded `pyobjc-framework-CoreServices` from 6.1 to 6.2
+- Upgraded `pyobjc-framework-FSEvents` from 6.1 to 6.2
+- Upgraded `pyobjc-framework-ScriptingBridge` from 6.1 to 6.2
+- Upgraded `pyobjc-framework-SystemConfiguration` from 6.1 to 6.2
+- Upgraded `sentry-sdk` from 0.14.3 to 0.14.4
+- Upgraded `tld` from 0.11.9 to 0.12.1
+- Upgraded `urllib3` from 1.25.8 to 1.25.9
+- Removed `rfc3987`
+
+## Technical Changes
+
+- Added `USER_AGENT` in `constants.py`
+- Added `NuxeoDocumentInfo.is_proxy`

--- a/nxdrive/__init__.py
+++ b/nxdrive/__init__.py
@@ -27,7 +27,7 @@ To declare a beta, use this schema:
 """
 
 __author__ = "Nuxeo"
-__version__ = "4.4.3"
+__version__ = "4.4.4"
 __copyright__ = """
     Copyright Nuxeo (https://www.nuxeo.com) and others.
 


### PR DESCRIPTION
The history is weird because we urgently released 4.4.3 from a divergent branch. I tried to retrieve important data to keep aligned and doing thins right.