### PR TITLE
NXDRIVE-2127: Shadow (again) errors at closing

### DIFF
--- a/tests/old_functional/common.py
+++ b/tests/old_functional/common.py
@@ -262,7 +262,12 @@ class TwoUsersTest(TestCase):
         def launch_test(app=self.app):
             # Note: we cannot use super().run(result) here
             super(TwoUsersTest, self).run(result)
-            app.quit()
+
+            try:
+                app.quit()
+            except AttributeError:
+                # Too many missing attributes while closing the application if the test is not completed
+                pass
 
         # Ensure to kill the app if it is taking too long.
         # We need to do that because sometimes a thread get blocked and so the test suite.
@@ -441,6 +446,7 @@ class TwoUsersTest(TestCase):
             folder, self.nuxeo_url, user, password, start_engine=start_engine
         )
 
+        self.app.aboutToQuit.connect(manager.stop)
         engine.syncCompleted.connect(self.app.sync_completed)
         engine._remote_watcher.remoteScanFinished.connect(
             self.app.remote_scan_completed

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,6 @@ deps = {[base]deps}
 commands =
     {[base]commands}
     python -m pytest {posargs} tests/functional
-    python -m pytest {posargs} tests/old_functional
 
 [testenv:integration]
 description = Integration tests
@@ -107,6 +106,7 @@ passenv = {[base]passenv}
 deps = {[base]deps}
 commands =
     {[base]commands}
+    python -m pytest {posargs} tests/old_functional
 
 [testenv:spell]
 description = Grammar check


### PR DESCRIPTION
Just restoring the old behavior as there are too many useless errors reported to Sentry.