### PR TITLE
NXDRIVE-2183: Fix chunked upload using an obsolete batch ID in certain circumstances

### DIFF
--- a/docs/changes/4.4.4.md
+++ b/docs/changes/4.4.4.md
@@ -11,6 +11,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2160](https://jira.nuxeo.com/browse/NXDRIVE-2160): Lower logging level of "Error while stopping FinderSync"
 - [NXDRIVE-2162](https://jira.nuxeo.com/browse/NXDRIVE-2162): Enforce disk space retrieval robustness
 - [NXDRIVE-2170](https://jira.nuxeo.com/browse/NXDRIVE-2170): Fix new errors found by codespell 1.17.0
+- [NXDRIVE-2183](https://jira.nuxeo.com/browse/NXDRIVE-2183): Fix chunked upload using an obsolete batch ID in certain circumstances
 
 ### Direct Edit
 
@@ -75,6 +76,7 @@ Release date: `2020-xx-xx`
 ## Technical Changes
 
 - Added `USER_AGENT` in `constants.py`
+- Added `EngineDAO.update_upload()`
 - Added `NuxeoDocumentInfo.is_proxy`
 - Added utils.py::`disk_space()`
 - Removed options.py::`handle_feat_direct_transfer()`

--- a/docs/changes/4.4.4.md
+++ b/docs/changes/4.4.4.md
@@ -13,6 +13,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2170](https://jira.nuxeo.com/browse/NXDRIVE-2170): Fix new errors found by codespell 1.17.0
 - [NXDRIVE-2183](https://jira.nuxeo.com/browse/NXDRIVE-2183): Fix chunked upload using an obsolete batch ID in certain circumstances
 - [NXDRIVE-2184](https://jira.nuxeo.com/browse/NXDRIVE-2184): Fix mypy issues following the update to mypy 0.780
+- [NXDRIVE-2185](https://jira.nuxeo.com/browse/NXDRIVE-2185): Be more specific on HTTP error handling when fetching the batch ID associated to an upload
 
 ### Direct Edit
 

--- a/docs/changes/4.4.4.md
+++ b/docs/changes/4.4.4.md
@@ -12,6 +12,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2162](https://jira.nuxeo.com/browse/NXDRIVE-2162): Enforce disk space retrieval robustness
 - [NXDRIVE-2170](https://jira.nuxeo.com/browse/NXDRIVE-2170): Fix new errors found by codespell 1.17.0
 - [NXDRIVE-2183](https://jira.nuxeo.com/browse/NXDRIVE-2183): Fix chunked upload using an obsolete batch ID in certain circumstances
+- [NXDRIVE-2184](https://jira.nuxeo.com/browse/NXDRIVE-2184): Fix mypy issues following the update to mypy 0.780
 
 ### Direct Edit
 

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -484,10 +484,10 @@ class Remote(Nuxeo):
                 # Check if the associated batch still exists server-side
                 try:
                     self.uploads.get(upload.batch["batchId"], file_idx=file_idx)
-                except Exception:
-                    log.debug(
-                        "No associated batch found, restarting from zero", exc_info=True
-                    )
+                except HTTPError as exc:
+                    if exc.status != 404:
+                        raise
+                    log.debug("No associated batch found, restarting from zero")
                 else:
                     log.debug("Associated batch found, resuming the upload")
                     batch = Batch(service=self.uploads, **upload.batch)

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -556,6 +556,12 @@ class Remote(Nuxeo):
                     chunk_size=chunk_size,
                 )
                 self.dao.save_upload(upload)
+            elif upload.batch["batchId"] != batch.uid:
+                # The upload was not a fresh one but its batch ID was perimed.
+                # Before NXDRIVE-2183, the batch ID was not updated and so the second step
+                # of the upload (attaching the blob to a document) was failing.
+                upload.batch["batchId"] = batch.uid
+                self.dao.update_upload(upload)
 
             # Update the progress on chunked upload only as the first call to
             # action.progress will set the action.uploaded attr to True for

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -493,15 +493,6 @@ class Remote(Nuxeo):
                     batch = Batch(service=self.uploads, **upload.batch)
                     chunk_size = upload.chunk_size
 
-                    if batch.is_s3():
-                        token_ttl = self._aws_token_ttl(
-                            batch.extraInfo["expiration"] / 1000
-                        )
-                        if token_ttl.total_seconds() < 1:
-                            batch = None
-                            upload = None
-                            log.warning("AWS token has expired, restarting from zero")
-
             if not batch:
                 # .uploads.handlers() result is cached, so it is convenient to call it each time here
                 # in case the server did not answer correctly the previous time and thus S3 would

--- a/nxdrive/engine/dao/sqlite.py
+++ b/nxdrive/engine/dao/sqlite.py
@@ -2197,6 +2197,16 @@ class EngineDAO(ConfigurationDAO):
 
             self.transferUpdated.emit()
 
+    def update_upload(self, upload: Upload) -> None:
+        """Update a upload."""
+        with self.lock:
+            # Remove non-serializable data, never used elsewhere
+            batch = {k: v for k, v in upload.batch.items() if k != "blobs"}
+
+            c = self._get_write_connection().cursor()
+            sql = "UPDATE Uploads SET batch = ? WHERE uid = ?"
+            c.execute(sql, (json.dumps(batch), upload.uid))
+
     def pause_transfer(self, nature: str, uid: int, progress: float) -> None:
         with self.lock:
             c = self._get_write_connection().cursor()

--- a/nxdrive/engine/dao/utils.py
+++ b/nxdrive/engine/dao/utils.py
@@ -35,8 +35,7 @@ def dump(database: Path, dump_file: Path) -> None:
     with sqlite3.connect(str(database)) as con, dump_file.open(
         mode="w", encoding="utf-8"
     ) as f:
-        # TODO: Remove the next comment when mypy > 0.770 is out
-        for line in con.iterdump():  # type: ignore
+        for line in con.iterdump():
             f.write(f"{line}\n")
 
         # Force write of file to disk

--- a/nxdrive/osi/linux/linux.py
+++ b/nxdrive/osi/linux/linux.py
@@ -167,8 +167,7 @@ MimeType=x-scheme-handler/{NXDRIVE_SCHEME};
             emblem = shared_icons / f"emblem-nuxeo_{status}.svg"
 
             try:
-                # See https://github.com/python/typeshed/issues/3858
-                identical = filecmp.cmp(icon, emblem, shallow=False)  # type: ignore
+                identical = filecmp.cmp(icon, emblem, shallow=False)
             except OSError:
                 # Most likely the *icon* doest not exist yet
                 pass


### PR DESCRIPTION
Also:
- NXDRIVE-2183: Removed code useless now that NXPY-163 is done
- NXDRIVE-2184: Fix mypy issues following the update to mypy 0.780
- NXDRIVE-2185: Be more specific on HTTP error handling when fetching the batch ID associated to an upload