### PR TITLE
NXDRIVE-2129: Fix behaviour of get_locked_paths()

### DIFF
--- a/docs/changes/4.4.4.md
+++ b/docs/changes/4.4.4.md
@@ -102,3 +102,4 @@ Release date: `2020-xx-xx`
 - Added `QMLDriveApi.get_features_list()`
 - Added features.py::`Beta`
 - Removed `conf_name` keyword argument to `CLIHandler.load_config()`
+- Removed engine/dao/sqlite.py::`str_to_path()`

--- a/nxdrive/engine/dao/sqlite.py
+++ b/nxdrive/engine/dao/sqlite.py
@@ -135,11 +135,6 @@ def prepare_args(data: Tuple[Union[Path, str], ...]) -> Tuple[str, ...]:
     return tuple(data)  # type: ignore
 
 
-def str_to_path(data: str) -> Optional[Path]:
-    """ Convert str to Path after querying the database. """
-    return None if data == "" else Path(data.lstrip("/"))
-
-
 class AutoRetryCursor(Cursor):
     def execute(self, *args: str, **kwargs: Any) -> Cursor:
         if len(args) > 1:
@@ -493,12 +488,7 @@ class ManagerDAO(ConfigurationDAO):
         return c.execute("SELECT * FROM AutoLock").fetchall()
 
     def get_locked_paths(self) -> List[Path]:
-        paths = []
-        for lock in self.get_locks():
-            path = str_to_path(lock["path"])
-            if path:
-                paths.append(path)
-        return paths
+        return [Path(lock["path"]) for lock in self.get_locks()]
 
     def lock_path(self, path: Path, process: int, doc_id: str) -> None:
         with self.lock:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,3 +153,21 @@ def server(nuxeo_url):
         nuxeo.client.NuxeoClient._server_info = SERVER_INFO
 
     return server
+
+
+@pytest.fixture
+def app():
+    """
+    Fixture required to be able to process Qt events and quit smoothly the application.
+    To use in "functional" and "unit" tests only.
+    """
+    from PyQt5.QtCore import QCoreApplication, QTimer
+
+    app = QCoreApplication([])
+
+    # Little trick here! See Application.__init__() for details.
+    timer = QTimer()
+    timer.timeout.connect(lambda: None)
+    timer.start(100)
+
+    yield app

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -17,21 +17,6 @@ log = getLogger(__name__)
 
 
 @pytest.fixture(scope="session")
-def app():
-    """Fixture required to be able to process events and quit smoothly the application."""
-    from PyQt5.QtCore import QCoreApplication, QTimer
-
-    app = QCoreApplication([])
-
-    # Little trick here! See Application.__init__() for details.
-    timer = QTimer()
-    timer.timeout.connect(lambda: None)
-    timer.start(100)
-
-    yield app
-
-
-@pytest.fixture(scope="session")
 def faker() -> Callable[[], Faker]:
     """
     Get a Faker object to simplify other object creation.

--- a/tests/unit/test_autolock.py
+++ b/tests/unit/test_autolock.py
@@ -3,67 +3,60 @@
 Test the Auto-Lock feature used heavily by Direct Edit.
 """
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import List, Tuple
 from unittest.mock import Mock, patch
 
 import nxdrive.autolocker
 import pytest
+from nxdrive.engine.dao.sqlite import ManagerDAO
 
 from .. import ensure_no_exception
-
-
-class DAO:
-    """Minimal ManagerDAO for a working Auto-Lock."""
-
-    # {path: (process, doc_id)}
-    paths: Dict[str, Tuple[int, str]] = {}
-
-    def get_locked_paths(self) -> List[str]:
-        return list(self.paths.keys())
-
-    def lock_path(self, path: str, process: int, doc_id: str) -> None:
-        self.paths[path] = (process, doc_id)
-
-    def unlock_path(self, path: str) -> None:
-        self.paths.pop(path, None)
 
 
 @pytest.fixture(scope="function")
 def autolock(tmpdir):
     check_interval = 5
+    folder = Path(tmpdir / "edit")
+    folder.mkdir(parents=True)
+    db = folder.parent / "engine.db"
     manager = Mock()
-    manager.dao = DAO()
+    manager.dao = ManagerDAO(db)
     autolocker = nxdrive.autolocker.ProcessAutoLockerWorker(
-        check_interval, manager, Path(tmpdir)
+        check_interval, manager, folder
     )
     autolocker.direct_edit = Mock()
     return autolocker
 
 
-def test_autolock(autolock, tmpdir):
+def test_autolock(app, autolock, tmpdir):
     """Start the worker and simulate files to (un)lock."""
     # Unlock an orphaned document
-    autolock.orphan_unlocked("foo.txt")
+    autolock.orphan_unlocked(autolock._folder / "foo.txt")
 
     # Simulate watched files
-    autolock.set_autolock("already_locked.ods", Mock())
-    autolock.set_autolock("abc こん ツリー/2.ods", Mock())
+    file1 = autolock._folder / "already_locked.ods"
+    file1.touch()
+    autolock.set_autolock(file1, Mock())
+    autolock.set_autolock(autolock._folder / "abc こん ツリー.ods", Mock())
+
+    # Another file, not yet watched
+    file2 = autolock._folder / "myfile.doc"
 
     def tmp_file(name: str) -> Path:
-        path = autolock._folder / name
-        path.mkdir()
-        return path
+        file = autolock._folder / name
+        file.touch()
+        return file
 
     def files() -> List[Tuple[int, Path]]:
         # Watched file to unlock
-        file1 = tmp_file("already_locked.ods")
         yield 4, file1  # 1
 
         # Check if the next command does nothing as the file is already watched
-        autolock.set_autolock(file1.name, Mock())
+        autolock.set_autolock(file1, Mock())
 
         # New watched file
-        yield 42, tmp_file("myfile.doc")  # 2
+        file2.touch()
+        yield 42, file2  # 2
         # Its temporary sibling should be ignored
         yield 42, tmp_file("~$myfile.doc")
 
@@ -71,12 +64,18 @@ def test_autolock(autolock, tmpdir):
         yield 42, tmp_file("fichier.lock")
 
         # File not monitored, e.g. not in the watched folder
-        yield 7071, Path("He-Who-Must-Not-Be-Named.lock")
+        not_watched = autolock._folder.parent / "He-Who-Must-Not-Be-Named.lock"
+        not_watched.touch()
+        yield 7071, not_watched
 
     with patch.object(nxdrive.autolocker, "get_open_files", new=files):
         with ensure_no_exception():
-            autolock._poll()
+            # Proceed for the file1 locking, file2 locking is planned
+            autolock._process()
+            # Proceed for the file2 locking
+            autolock._process()
         assert len(autolock._autolocked) == 2
+        assert autolock.dao.get_locked_paths() == [file1, file2]
 
 
 def test_get_open_files():


### PR DESCRIPTION
When the application is shut down during a direct edit, the edited file
stay locked on the remote server and the temporary file is not deleted.
When starting, the expected behaviour is to unlock the document on
the remote then remove the local orphan file.

This commit fix the current behaviour in which Drive fails to retrieve
correctly the informations about the locked files from the database.
This prevent Drive to recognize orphan local files as locked.
This is the second step of a three steps fix of the bug.
Also changes has been updated.