### PR TITLE
NXDRIVE-2129:  [Direct Edit] Ensure unlocking of orphaned documents

### DIFF
--- a/nxdrive/direct_edit.py
+++ b/nxdrive/direct_edit.py
@@ -123,10 +123,6 @@ class DirectEdit(Worker):
         for lock in locks:
             if self._folder in lock.parents:
                 log.info(f"Should unlock {lock!r}")
-                if not lock.exists():
-                    self.autolock.orphan_unlocked(lock)
-                    continue
-
                 ref = self.local.get_path(lock)
                 self._lock_queue.put((ref, "unlock_orphan"))
 

--- a/tests/old_functional/__init__.py
+++ b/tests/old_functional/__init__.py
@@ -569,8 +569,7 @@ class DocRemote(RemoteTest):
         return self.execute(command="Blob.Remove", input_obj=f"doc:{ref}", xpath=xpath)
 
     def is_locked(self, ref: str) -> bool:
-        data = self.fetch(ref, headers={"fetch-document": "lock"})
-        return "lockCreated" in data
+        return bool(self.documents.fetch_lock_status(ref))
 
     def get_versions(self, ref: str):
         headers = {"fetch-document": "versionLabel"}


### PR DESCRIPTION
When the application is shut down during a direct edit, the edited file
stay locked on the remote server and the temporary file is not deleted.
When starting, the expected behaviour is to unlock the document on
the remote then remove the local orphan file.

This commit add a functionnal test on the direct edit system for
unlocking orphan files.
This is the last step of a three steps fix of the bug.