### PR TITLE
NXDRIVE-2018: Change order of elements returned by get_tree_list()

### DIFF
--- a/docs/changes/4.4.4.md
+++ b/docs/changes/4.4.4.md
@@ -105,3 +105,4 @@ Release date: `2020-xx-xx`
 - Added features.py::`Beta`
 - Removed `conf_name` keyword argument to `CLIHandler.load_config()`
 - Removed engine/dao/sqlite.py::`str_to_path()`
+- Changed order of elements returned by utils.py::`get_tree_list()`

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -426,7 +426,7 @@ class Engine(QObject):
                 plan(local_path, remote_ref)
             else:
                 tree = sorted(get_tree_list(local_path, remote_ref))
-                for remote_path, path in tree:
+                for path, remote_path in tree:
                     plan(path, remote_path)
 
     def direct_transfer_cancel(self, file: Path) -> None:

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -313,7 +313,7 @@ def get_default_local_folder() -> Path:
 
 def get_tree_list(
     path: Path, remote_ref: str
-) -> Generator[Tuple[str, Path], None, None]:
+) -> Generator[Tuple[Path, str], None, None]:
     """Compute remote paths based on *remote_ref* from a given *path*.
     This is used in the Direct Transfer feature to upload a folder
     and all its contents.
@@ -330,7 +330,7 @@ def get_tree_list(
         return
 
     # First, yield the folder itself
-    yield remote_ref, path
+    yield path, remote_ref
     remote_ref += f"/{path.name}"
 
     # Then, yield its children
@@ -344,7 +344,7 @@ def get_tree_list(
             if is_dir:
                 yield from get_tree_list(Path(entry.path), remote_ref)
             elif entry.is_file():
-                yield remote_ref, Path(entry.path)
+                yield Path(entry.path), remote_ref
 
 
 def get_tree_size(path: Path) -> int:

--- a/tests/old_functional/test_direct_transfer.py
+++ b/tests/old_functional/test_direct_transfer.py
@@ -510,7 +510,7 @@ class DirectTransferFolder:
 
         # Get folders and files tests will handle
         self.tree = {
-            path: rpath for rpath, path in get_tree_list(self.folder, self.ws.path)
+            path: rpath for path, rpath in get_tree_list(self.folder, self.ws.path)
         }
         paths = self.tree.keys()
         self.files = [path for path in paths if path.is_file()]

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -495,7 +495,7 @@ def test_get_tree_list():
 
     # Check we got all paths
     expected_paths = [path] + sorted(path.glob("**/*"))
-    guessed_paths = sorted(p for _, p in tree)
+    guessed_paths = sorted(p for p, _ in tree)
     assert guessed_paths == expected_paths
 
     # Check we got correct remote paths
@@ -508,7 +508,7 @@ def test_get_tree_list():
         else:
             expected_rpaths.append(rpath)
     expected_rpaths = sorted(expected_rpaths)
-    guessed_rpaths = sorted(p for p, _ in tree)
+    guessed_rpaths = sorted(p for _, p in tree)
     assert guessed_rpaths == expected_rpaths
 
 


### PR DESCRIPTION
This is only to keep the API homogenous and futures PRs will need that.