### PR TITLE
NXDRIVE-2190: Refactor Remote client uploads

### DIFF
--- a/docs/changes/4.4.4.md
+++ b/docs/changes/4.4.4.md
@@ -17,6 +17,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2185](https://jira.nuxeo.com/browse/NXDRIVE-2185): Be more specific on HTTP error handling when fetching the batch ID associated to an upload
 - [NXDRIVE-2187](https://jira.nuxeo.com/browse/NXDRIVE-2187): New language: Basque (eu)
 - [NXDRIVE-2188](https://jira.nuxeo.com/browse/NXDRIVE-2188): Remove the Hebrew language
+- [NXDRIVE-2190](https://jira.nuxeo.com/browse/NXDRIVE-2190): Refactored Remote client uploads
 
 ### Direct Edit
 
@@ -86,6 +87,10 @@ Release date: `2020-xx-xx`
 - Added `USER_AGENT` in `constants.py`
 - Added `EngineDAO.update_upload()`
 - Added `NuxeoDocumentInfo.is_proxy`
+- Removed `Remote.direct_transfer()`. Use `DirectTransferUploader.upload()` instead.
+- Removed `Remote.get_document_or_none()`. Use `DirectTransferUploader.get_document_or_none()` instead.
+- Removed `Remote.link_blob_to_doc()`. Use `BaseUploader.link_blob_to_doc()` instead.
+- Removed `Remote.upload_chunks()`. Use `BaseUploader.upload_chunks()` instead.
 - Added utils.py::`disk_space()`
 - Removed options.py::`handle_feat_direct_transfer()`
 - Removed options.py::`handle_feat_direct_edit()`
@@ -103,6 +108,7 @@ Release date: `2020-xx-xx`
 - Added `Manager.set_feature_state()`
 - Added `QMLDriveApi.get_features_list()`
 - Added features.py::`Beta`
+- Added client/uploader
 - Removed `conf_name` keyword argument to `CLIHandler.load_config()`
 - Removed engine/dao/sqlite.py::`str_to_path()`
 - Changed order of elements returned by utils.py::`get_tree_list()`

--- a/nxdrive/client/uploader/__init__.py
+++ b/nxdrive/client/uploader/__init__.py
@@ -1,0 +1,297 @@
+"""
+Uploader used by the Remote client for all upload stuff.
+"""
+from abc import abstractmethod
+from datetime import datetime, timedelta
+from logging import getLogger
+from pathlib import Path
+from time import monotonic_ns
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+from nuxeo.exceptions import HTTPError
+from nuxeo.models import Batch, FileBlob
+from PyQt5.QtWidgets import QApplication
+
+from ...constants import TX_TIMEOUT, TransferStatus
+from ...engine.activity import LinkingAction, UploadAction
+from ...exceptions import UploadPaused
+from ...feature import Feature
+from ...objects import Upload
+from ...options import Options
+
+if TYPE_CHECKING:
+    from .remote_client import Remote  # noqa
+    from ..engine.dao.sqlite import EngineDAO  # noqa
+
+log = getLogger(__name__)
+
+
+class BaseUploader:
+    """Upload capabilities for the Remove client."""
+
+    linking_action = LinkingAction
+    upload_action = UploadAction
+
+    def __init__(self, remote: "Remote") -> None:
+        self.remote = remote
+        self.dao = remote.dao
+
+    @abstractmethod
+    def get_upload(self, file_path: Path) -> Optional[Upload]:
+        """Retrieve the eventual transfer associated to the given *file_path*."""
+
+    @abstractmethod
+    def upload(
+        self,
+        file_path: Path,
+        command: str,
+        filename: str = None,
+        mime_type: str = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Upload a file with a batch."""
+
+    def upload_impl(
+        self,
+        file_path: Path,
+        command: str,
+        filename: str = None,
+        mime_type: str = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """
+        Upload flow implementation.
+        If command is not None, the operation is executed with the batch as an input.
+
+        If an exception happens at step 1 or 2, the upload will be continued the next
+        time the Processor handle the document (it will be postponed due to the error).
+
+        If the error was raised at step 1, the upload will not start from zero: it will
+        resume from the next chunk based on what previously chunks were sent.
+        This is dependent of the chunk TTL configured on the server (it must be large enough
+        to handle big files).
+
+        If the error was raised at step 2, the step 1 will be checked to ensure the blob
+        was successfully uploaded. But it most cases, nothing will be uploaded twice.
+        Also, if the error is one of HTTP 502 or 503, the Processor will check for
+        the file existence to bypass errors happening *after* the operation was successful.
+        If it exists, the error is skipped and the upload is seen as a success.
+        """
+        # Step 1: upload the blob
+        blob = self.upload_chunks(
+            file_path, filename=filename, mime_type=mime_type, **kwargs
+        )
+
+        # Step 2: link the uploaded blob to the document
+        kwargs["file_path"] = file_path
+        return self.link_blob_to_doc(command, blob, **kwargs)
+
+    def upload_chunks(
+        self,
+        file_path: Path,
+        filename: str = None,
+        mime_type: str = None,
+        **kwargs: Any,
+    ) -> FileBlob:
+        """Upload a blob by chunks or in one go."""
+
+        action = self.upload_action(file_path, reporter=QApplication.instance())
+        blob = FileBlob(str(file_path))
+        if filename:
+            blob.name = filename
+        if mime_type:
+            blob.mimetype = mime_type
+
+        batch: Optional[Batch] = None
+        chunk_size = None
+
+        # See if there is already a transfer for this file
+        transfer = self.get_upload(file_path)
+
+        try:
+            if transfer:
+                log.debug(f"Retrieved transfer for {file_path!r}: {transfer}")
+                if transfer.status not in (TransferStatus.ONGOING, TransferStatus.DONE):
+                    raise UploadPaused(transfer.uid or -1)
+
+                # When fetching for an eventual batch, specifying the file index
+                # is not possible for S3 as there is no blob at the current index
+                # until the S3 upload is done itself and the call to
+                # batch.complete() done.
+                file_idx = (
+                    None
+                    if transfer.batch.get("provider", "") == "s3"
+                    else transfer.batch["upload_idx"]
+                )
+
+                # Check if the associated batch still exists server-side
+                try:
+                    self.remote.uploads.get(
+                        transfer.batch["batchId"], file_idx=file_idx
+                    )
+                except HTTPError as exc:
+                    if exc.status != 404:
+                        raise
+                    log.debug("No associated batch found, restarting from zero")
+                else:
+                    log.debug("Associated batch found, resuming the upload")
+                    batch = Batch(service=self.remote.uploads, **transfer.batch)
+                    chunk_size = transfer.chunk_size
+
+            if not batch:
+                # .uploads.handlers() result is cached, so it is convenient to call it each time here
+                # in case the server did not answer correctly the previous time and thus S3 would
+                # be completely disabled because of a one-time server error.
+                handler = "s3" if Feature.s3 and self.remote.uploads.has_s3() else ""
+
+                # Create a new batch and save it in the DB
+                batch = self.remote.uploads.batch(handler=handler)
+
+                if batch.is_s3():
+                    self._aws_token_ttl(batch.extraInfo["expiration"] / 1000)
+
+            # By default, Options.chunk_size is 20, so chunks will be 20MiB.
+            # It can be set to a value between 1 and 20 through the config.ini
+            chunk_size = chunk_size or (Options.chunk_size * 1024 * 1024)
+
+            # For the upload to be chunked, the Options.chunk_upload must be True
+            # and the blob must be bigger than Options.chunk_limit, which by default
+            # is equal to Options.chunk_size.
+            chunked = (
+                Options.chunk_upload and blob.size > Options.chunk_limit * 1024 * 1024
+            )
+
+            engine_uid = kwargs.pop("engine_uid", None)
+            is_direct_edit = kwargs.pop("is_direct_edit", False)
+
+            # Set those attributes as FileBlob does not have them
+            # and they are required for the step 2 of .upload_impl()
+            blob.batch_id = batch.uid
+            blob.fileIdx = batch.upload_idx
+
+            uploader = batch.get_uploader(
+                blob,
+                chunked=chunked,
+                chunk_size=chunk_size,
+                callback=self.remote.upload_callback,
+            )
+            log.debug(f"Using {type(uploader).__name__!r} uploader")
+
+            if not transfer:
+                # Remove eventual obsolete upload (it happens when an upload using S3 has invalid metadatas)
+                self.dao.remove_transfer("upload", file_path)
+
+                # Add an upload entry in the database
+                transfer = Upload(
+                    None,
+                    file_path,
+                    TransferStatus.ONGOING,
+                    engine=engine_uid,
+                    is_direct_edit=is_direct_edit,
+                    batch=batch.as_dict(),
+                    chunk_size=chunk_size,
+                )
+                self.dao.save_upload(transfer)
+            elif transfer.batch["batchId"] != batch.uid:
+                # The upload was not a fresh one but its batch ID was perimed.
+                # Before NXDRIVE-2183, the batch ID was not updated and so the second step
+                # of the upload (attaching the blob to a document) was failing.
+                transfer.batch["batchId"] = batch.uid
+                self.dao.update_upload(transfer)
+
+            if uploader.chunked:
+                # Update the progress on chunked upload only as the first call to
+                # action.progress will set the action.uploaded attr to True for
+                # empty files. This is not what we want: empty files are legits.
+                action.progress = chunk_size * len(uploader.blob.uploadedChunkIds)
+
+                # Store the chunk size and start time for later transfer speed computation
+                action.chunk_size = chunk_size
+                action.chunk_transfer_start_time_ns = monotonic_ns()
+
+                # If there is an UploadError, we catch it from the processor
+                for _ in uploader.iter_upload():
+                    # Here 0 may happen when doing a single upload
+                    action.progress += uploader.chunk_size or 0
+
+                    # Save the progression
+                    # transfer.progress = action.get_percent()  # type: ignore
+                    # self.dao.set_transfer_progress("upload", transfer)
+
+                    # Handle status changes every time a chunk is sent
+                    transfer = self.dao.get_upload(path=file_path)
+                    if transfer and transfer.status not in (
+                        TransferStatus.ONGOING,
+                        TransferStatus.DONE,
+                    ):
+                        raise UploadPaused(transfer.uid or -1)
+            else:
+                uploader.upload()
+
+                # For empty files, this will set action.uploaded to True,
+                # telling us that the file was correctly sent to the server.
+                action.progress += blob.size
+
+                transfer.progress = action.get_percent()
+
+            if batch.is_s3():
+                if not batch.blobs:
+                    # This may happen when resuming an upload with all parts sent.
+                    # Trigger upload() that will complete the MPU and fill required
+                    # attributes like the Batch ETag, blob index, etc..
+                    uploader.upload()
+
+                # Complete the S3 upload
+                # (setting a big timeout to handle big files)
+                batch.complete(timeout=TX_TIMEOUT)
+
+            # Transfer is completed, update the status in the database
+            transfer.status = TransferStatus.DONE  # type: ignore
+            self.dao.set_transfer_status("upload", transfer)
+
+            return blob
+        finally:
+            # In case of error, log the progression to help debugging
+            percent = action.get_percent()
+            if percent < 100.0 and not action.uploaded:
+                log.debug(f"Upload progression stopped at {percent:.2f}%")
+
+                # Save the progression
+                if transfer:
+                    transfer.progress = percent
+                    self.dao.set_transfer_progress("upload", transfer)
+
+            action.finish_action()
+
+            if blob.fd:
+                blob.fd.close()
+
+    def link_blob_to_doc(
+        self, command: str, blob: FileBlob, **kwargs: Any
+    ) -> Dict[str, Any]:
+        """Link the given uploaded *blob* to the given document (refs are passed into *kwargs*)."""
+
+        # Remove additional parameters to prevent a BadQuery
+        kwargs.pop("engine_uid", None)
+        kwargs.pop("is_direct_edit", None)
+        file_path = kwargs.pop("file_path")
+
+        action = self.linking_action(file_path, reporter=QApplication.instance())
+        try:
+            res: Dict[str, Any] = self.remote.execute(
+                command=command,
+                input_obj=blob,
+                headers={"Nuxeo-Transaction-Timeout": str(TX_TIMEOUT)},
+                timeout=TX_TIMEOUT,
+                **kwargs,
+            )
+            return res
+        finally:
+            action.finish_action()
+
+    def _aws_token_ttl(self, timestamp: int) -> timedelta:
+        """Return the AWS token TTL for S3 uploads."""
+        expiration = datetime.utcfromtimestamp(timestamp)
+        ttl = expiration - datetime.utcnow()
+        log.debug(f"AWS token will expire in {ttl} [at {expiration} UTC exactly]")
+        return ttl

--- a/nxdrive/client/uploader/direct_transfer.py
+++ b/nxdrive/client/uploader/direct_transfer.py
@@ -1,0 +1,154 @@
+"""
+Uploader used by the Direct Transfer feature.
+"""
+from logging import getLogger
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from nuxeo.exceptions import HTTPError
+from nuxeo.models import Document
+
+from ...engine.activity import LinkingAction, UploadAction
+from ...exceptions import DirectTransferDuplicateFoundError
+from ...objects import Upload
+from ..local import LocalClient
+from . import BaseUploader
+
+log = getLogger(__name__)
+
+
+class DirectTransferUploader(BaseUploader):
+    """Upload capabilities for the Direct Transfer feature."""
+
+    linking_action = LinkingAction
+    upload_action = UploadAction
+
+    def get_document_or_none(self, uid: str = "", path: str = "") -> Optional[Document]:
+        """Fetch a document based on given criteria or return None if not found on the server."""
+        doc: Optional[Document] = None
+        try:
+            doc = self.remote.documents.get(uid=uid, path=path)
+        except HTTPError as exc:
+            if exc.status != 404:
+                raise
+        return doc
+
+    def get_upload(self, file_path: Path) -> Optional[Upload]:
+        """Retrieve the eventual transfer associated to the given *file_path*."""
+        ret: Optional[Upload] = self.dao.get_upload(path=file_path)
+        return ret
+
+    def upload(
+        self,
+        file_path: Path,
+        command: str = None,
+        filename: str = None,
+        mime_type: str = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Upload a given file to the given folderish document on the server.
+
+        Note about possible duplicate creation via a race condition client <-> server.
+        Given the local *file* with the path "$HOME/some-folder/subfolder/file.odt",
+        the file name is "file.odt".
+
+        Scenario:
+            - Step 1: local, check for a doc with the path name "file.odt" => nothing returned, continuing;
+            - Step 2: server, a document with a path name set to "file.odt" is created;
+            - Step 3: local, create the document with the path name "file.odt".
+
+        Even if the elapsed time between steps 1 and 3 is really short, it may happen.
+
+        What can be done to prevent such scenario is not on the Nuxeo Drive side but on the server one.
+        For now, 2 options are possible but not qualified to be done in a near future:
+            - https://jira.nuxeo.com/browse/NXP-22959;
+            - create a new operation `Document.GetOrCreate` that ensures atomicity.
+        """
+        parent_path = kwargs.pop("parent_path")
+        engine_uid = kwargs.pop("engine_uid")
+        replace_blob = kwargs.get("replace_blob", False)
+        log.info(f"Direct Transfer of {file_path!r} into {parent_path!r}")
+
+        # The remote file, when created, is stored in the file xattrs.
+        # So retrieve it and if it is defined, the document creation should
+        # be skipped to prevent duplicate creations.
+        remote_ref = LocalClient.get_path_remote_id(file_path, name="remote")
+
+        doc: Optional[Document] = None
+
+        if remote_ref:
+            # The remote ref is set, so it means either the file has already been uploaded,
+            # either a previous upload failed: the document was created, or not, and it has
+            # a blob attached, or not. In any cases, we need to ensure the user can upload
+            # without headhache.
+            doc = self.get_document_or_none(uid=remote_ref)
+
+        if not doc:
+            # We need to handle possbile duplicates based on the file name and
+            # the destination folder on the server.
+            # Note: using this way may still result in duplicates:
+            #  - the user created 2 documents with the same name on Web-UI or another way
+            #  - the user then deleted the 1st document
+            #  - the other document has a path like "name.TIMESTAMP"
+            # So then Drive will not see that document as a duplicate because it will check
+            # a path with "name" only.
+
+            # If we really want to avoid that situation, we should use that commented code:
+            """
+            # Note that it would be too much effort for the server, we do not want that!
+            for child in self.documents.get_children(path=parent_path):
+                # It is OK to have a folder and a file with the same name,
+                # but not 2 files or 2 folders with the same name
+                if child.title == file.name:
+                    local_is_dir = file.isdir()
+                    remote_is_dir = "Folderish" in child["facets"]
+                    if local_is_dir is remote_is_dir:
+                        # Duplicate found!
+                        doc = child
+                        remote_ref = doc.uid
+                        break
+            """
+
+            doc = self.get_document_or_none(path=f"{parent_path}/{file_path.name}")
+            if doc:
+                remote_ref = doc.uid
+
+        if not replace_blob and doc and doc.properties.get("file:content"):
+            # The document already exists and has a blob attached. Ask the user what to do.
+            raise DirectTransferDuplicateFoundError(file_path, doc)
+
+        if not doc:
+            # Create the document on the server
+            nature = "File" if file_path.is_file() else "Folder"
+            doc = self.remote.documents.create(
+                Document(
+                    name=file_path.name,
+                    type=nature,
+                    properties={"dc:title": file_path.name},
+                ),
+                parent_path=parent_path,
+            )
+            remote_ref = doc.uid
+
+        # If the path is a folder, there is no more work to do
+        if file_path.is_dir():
+            details: Dict[str, Any] = doc.as_dict()
+            return details
+
+        # Save the remote document's UID into the file xattrs, in case next steps fails
+        LocalClient.set_path_remote_id(file_path, remote_ref, name="remote")
+
+        # Upload the blob and attach it to the document
+        item = super().upload_impl(
+            file_path,
+            "Blob.AttachOnDocument",
+            xpath="file:content",
+            void_op=True,
+            document=remote_ref,
+            engine_uid=engine_uid,
+        )
+
+        # Transfer is completed, delete the upload from the database
+        self.dao.remove_transfer("upload", file_path)
+
+        return item

--- a/nxdrive/client/uploader/sync.py
+++ b/nxdrive/client/uploader/sync.py
@@ -1,0 +1,35 @@
+"""
+Uploader used by the synchronization engine.
+"""
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from ...objects import Upload
+from . import BaseUploader
+
+
+class SyncUploader(BaseUploader):
+    """Upload capabilities for the synchronization engine."""
+
+    def get_upload(self, file_path: Path) -> Optional[Upload]:
+        """Retrieve the eventual transfer associated to the given *file_path*."""
+        ret: Optional[Upload] = self.dao.get_upload(path=file_path)
+        return ret
+
+    def upload(
+        self,
+        file_path: Path,
+        command: str,
+        filename: str = None,
+        mime_type: str = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """See BaseUploader.upload_impl()."""
+        item = self.upload_impl(
+            file_path, command, filename=filename, mime_type=mime_type, **kwargs
+        )
+
+        # Transfer is completed, delete the upload from the database
+        self.dao.remove_transfer("upload", file_path)
+
+        return item

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -22,6 +22,7 @@ from urllib3.exceptions import MaxRetryError
 
 from ..behavior import Behavior
 from ..client.local import FileInfo
+from ..client.uploader.direct_transfer import DirectTransferUploader
 from ..constants import (
     CONNECTION_ERROR,
     LONG_FILE_ERRORS,
@@ -514,8 +515,12 @@ class Processor(EngineWorker):
             return
 
         # Do the upload
-        self.remote.direct_transfer(
-            file, parent_path, self.engine.uid, replace_blob=replace_blob
+        self.remote.upload(
+            file,
+            parent_path=parent_path,
+            engine_uid=self.engine.uid,
+            uploader=DirectTransferUploader,
+            replace_blob=replace_blob,
         )
 
         # Clean-up

--- a/tests/old_functional/common.py
+++ b/tests/old_functional/common.py
@@ -663,12 +663,14 @@ class TwoUsersTest(TestCase):
         """ Generate a report on failure. """
         # Track any exception that could happen, specially those we would not
         # see if the test succeed.
+        from _pytest.outcomes import Skipped, XFailed
+
         for n, exc in enumerate(exceptions, 1):
             error = exc.getrepr(
                 showlocals=True, style="long", funcargs=True, truncate_locals=False
             )
             log.warning(f"Error n°{n}\n{error}")
-            if exc.errisinstance(AssertionError):
+            if exc.errisinstance((AssertionError, Skipped, XFailed)):
                 break
             if "mock" not in str(exc.exconly()).lower():
                 break


### PR DESCRIPTION
Split the current implementation of the uploads to ease customizing the behavior.

This is a required step in order to keep unified upload flow with different features (the sync process and Direct Transfer for now) without code duplication.