### PR TITLE
NXDRIVE-2204: Add notifications when release jobs fail

### DIFF
--- a/docs/changes/4.4.4.md
+++ b/docs/changes/4.4.4.md
@@ -48,6 +48,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2146](https://jira.nuxeo.com/browse/NXDRIVE-2146): Do not package `Qt5RemoteObjects` DLL and shared library
 - [NXDRIVE-2175](https://jira.nuxeo.com/browse/NXDRIVE-2175): Move Crowdin synchronization to GitHub Actions
 - [NXDRIVE-2203](https://jira.nuxeo.com/browse/NXDRIVE-2203): Use Python 3 in release scripts
+- [NXDRIVE-2204](https://jira.nuxeo.com/browse/NXDRIVE-2204): Add notifications when release jobs fail
 
 ## Tests
 

--- a/tools/jenkins/beta.groovy
+++ b/tools/jenkins/beta.groovy
@@ -20,6 +20,10 @@ properties([
     ]]
 ])
 
+def notifyFailure() {
+    slackSend(channel: 'drive-notifs', color: '#FF0000', message: "Release <" + currentBuild.absoluteUrl + "|failed>. Please investigate NOW.")
+}
+
 node('IT') {
     def credential_id = '4691426b-aa51-428b-901d-4e851ee37b01'
     def differ_commits = '0'
@@ -77,6 +81,7 @@ node('IT') {
             sh "tools/release.sh --cancel ${release_type}"
         }
         currentBuild.result = 'FAILURE'
+        notifyFailure()
         throw e
     }
 }


### PR DESCRIPTION
Notification will be sent to the public `#drive-notifs` channel.