### PR TITLE
NXDRIVE-2201: Restore the 4 hours kill timeout for test_volume.py

### DIFF
--- a/tests/old_functional/common.py
+++ b/tests/old_functional/common.py
@@ -271,7 +271,7 @@ class TwoUsersTest(TestCase):
             "test_nxdrive_903": 60 * 4,  # 4 minutes
             "test_nxdrive_947": 60 * 15,  # 15 minutes
             "test_nxdrive_1033": 60 * 6,  # 6 minutes
-            "test_volume": 60 * 60,  # 1 hour
+            "test_volume": 60 * 60 * 4,  # 4 hours
         }
         test_file = self.id().replace("tests.old_functional.", "").split(".")[0]
         timeout = timeouts.get(test_file, default_timeout)


### PR DESCRIPTION
It was changed mistakenly with 47ba4437fe170bd618bb19dcc672e4dd5c542868.