### PR TITLE
NXDRIVE-2208: [Direct Transfer] Enable to cancel one or more transfer

### DIFF
--- a/docs/changes/4.4.4.md
+++ b/docs/changes/4.4.4.md
@@ -35,6 +35,7 @@ Release date: `2020-xx-xx`
 
 - [NXDRIVE-1926](https://jira.nuxeo.com/browse/NXDRIVE-1926): Display global transfer metrics
 - [NXDRIVE-2065](https://jira.nuxeo.com/browse/NXDRIVE-2065): Leverage the `FileManager`
+- [NXDRIVE-2208](https://jira.nuxeo.com/browse/NXDRIVE-2208): Enable to cancel one or more transfer
 - [NXDRIVE-2155](https://jira.nuxeo.com/browse/NXDRIVE-2155): Improvements on the main popup
 - [NXDRIVE-2158](https://jira.nuxeo.com/browse/NXDRIVE-2158): Review the warning message on conflict popup
 
@@ -151,3 +152,6 @@ Release date: `2020-xx-xx`
 - Added `State.dt_remote_link`
 - Added `Upload.is_direct_transfer`
 - Added view.py::`DirectTransferModel`
+- Added `Engine.cancel_upload()`
+- Added `Remote.cancel_batch()`
+- Added `Application.confirm_cancel_transfer()`

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -13,7 +13,7 @@ from nuxeo.auth import TokenAuth
 from nuxeo.client import Nuxeo
 from nuxeo.compat import get_text
 from nuxeo.exceptions import CorruptedFile, HTTPError
-from nuxeo.models import Document
+from nuxeo.models import Batch, Document
 from nuxeo.utils import get_digest_algorithm, version_lt
 from PyQt5.QtWidgets import QApplication
 
@@ -382,6 +382,12 @@ class Remote(Nuxeo):
     ) -> Dict[str, Any]:
         """Upload a file with a batch."""
         return uploader(self).upload(*args, **kwargs)
+
+    def cancel_batch(self, batch_details: Dict[str, Any]) -> None:
+        """Cancel an uploaded Batch."""
+        batch = Batch(service=self.uploads, **batch_details)
+        with suppress(Exception):
+            batch.cancel()
 
     def get_fs_info(
         self, fs_item_id: str, parent_fs_item_id: str = None

--- a/nxdrive/data/i18n/i18n.json
+++ b/nxdrive/data/i18n/i18n.json
@@ -86,6 +86,7 @@
     "DIRECT_EDIT_UNLOCK_ERROR_DESCRIPTION": "The document „%1“ was not unlocked",
     "DIRECT_EDIT_UPDATED_FILE": "The file „%1“ has been updated",
     "DIRECT_EDIT_VERSION": "You are trying to perform a Direct Edit on version %1 of „%2“. It is not the current version of the document, so it is readonly and cannot be edited.",
+    "DIRECT_TRANSFER_CANCEL": "Confirm the cancellation the transfer of „%1“?",
     "DIRECT_TRANSFER_DETAILS": "[%1%] %2 of %3",
     "DIRECT_TRANSFER_END": "Transfer done: „%1“",
     "DIRECT_TRANSFER_ERROR": "Transfer error: „%1“",

--- a/nxdrive/data/qml/TransferItem.qml
+++ b/nxdrive/data/qml/TransferItem.qml
@@ -28,7 +28,7 @@ Rectangle {
 
         GridLayout {
             id: item_control
-            columns: 2
+            columns: 3
             Layout.fillWidth: true
             Layout.fillHeight: true
             Layout.rightMargin: 10
@@ -70,6 +70,17 @@ Rectangle {
                     } else {
                         api.pause_transfer("upload", engine, uid, progress)
                     }
+                }
+            }
+
+            // Stop icon
+            IconLabel {
+                enabled: paused
+                icon: MdiFont.Icon.close
+                tooltip: qsTr("CANCEL") + tl.tr
+                iconColor: "red"
+                onClicked: {
+                    application.confirm_cancel_transfer(engine, uid, name)
                 }
             }
         }

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -617,6 +617,20 @@ class Engine(QObject):
                 self.dao.remove_transfer(nature, transfer.path)
                 log.info(f"Removed staled {transfer}")
 
+    def cancel_upload(self, transfer_uid: int) -> None:
+        """Cancel an ongoing upload and clean the database."""
+        log.debug(f"Canceling transfer {transfer_uid}")
+        upload = self.dao.get_upload(uid=transfer_uid)
+        if not upload:
+            return
+        self.remote.cancel_batch(upload.batch)
+        self.dao.remove_transfer("upload", upload.path)
+
+        doc_pair = self.dao.get_state_from_local(upload.path)
+        if not doc_pair:
+            return
+        self.dao.remove_state(doc_pair)
+
     def suspend(self) -> None:
         if self._pause:
             return

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -804,6 +804,35 @@ class Application(QApplication):
         """Close the Direct Transfer window."""
         self.direct_transfer_window.close()
 
+    @pyqtSlot(str, int, str)
+    def confirm_cancel_transfer(
+        self, engine_uid: str, transfer_uid: int, name: str
+    ) -> None:
+        """
+        Show a dialog to confirm the given transfer cancel.
+        Cancel transfer on validation.
+        """
+        msgbox = QMessageBox(
+            QMessageBox.Question,
+            APP_NAME,
+            Translator.get("DIRECT_TRANSFER_CANCEL", [name]),
+            QMessageBox.NoButton,
+        )
+        continued = msgbox.addButton("OK", QMessageBox.AcceptRole)
+        cancel = msgbox.addButton(Translator.get("CANCEL"), QMessageBox.RejectRole)
+        msgbox.setDefaultButton(cancel)
+        msgbox.setIcon(QMessageBox.Question)
+        msgbox.exec_()
+        if msgbox.clickedButton() == continued:
+            engine = self.manager.engines.get(engine_uid)
+            if not engine:
+                return
+            engine.cancel_upload(transfer_uid)
+        elif msgbox.clickedButton() == cancel:
+            log.debug(
+                f"Aborted the cancellation of the transfer {transfer_uid}: {name!r}"
+            )
+
     @pyqtSlot(str, object)
     def open_authentication_dialog(
         self, url: str, callback_params: Dict[str, str]

--- a/tools/whitelist.py
+++ b/tools/whitelist.py
@@ -2,6 +2,7 @@
 
 Application.about_to_quit  # Used in QML
 Application.close_direct_transfer_window  # Used in QML
+Application.confirm_cancel_transfer  # Used in QML
 Application._nxdrive_url_env  # Used in QML
 Application.action_progressing  # Used by FileAction.processing signal
 BlacklistQueue.repush  # Used in tests


### PR DESCRIPTION
A new button was needed to have a way to cancel a transfer.
This button has been implemented using an icon next to the
pause/resume one.
Also changelog has been updated.