### PR TITLE
NXDRIVE-1926: Improve the Direct Transfer window

### DIFF
--- a/nxdrive/data/i18n/i18n.json
+++ b/nxdrive/data/i18n/i18n.json
@@ -1,6 +1,7 @@
 {
     "ABOUT": "About",
     "ACCOUNT_NAME": "Account name",
+    "ACTIVE": "Active",
     "ADD": "Add",
     "ADD_FILES": "Add files",
     "ADD_FOLDER": "Add a folder",
@@ -24,6 +25,7 @@
     "CHANNEL": "Channel",
     "CHANNEL_CHANGE_SETTINGS": "Change channel update settings",
     "CHANNEL_CONFIRM_DANGEROUS": "Confirm development channel?",
+    "COMPLETED": "Completed",
     "CONFIRM_DISCONNECT": "Confirm deletion?",
     "CONFIRM_UPDATE_MESSAGE": "About to update to %1 version %2",
     "CONFLICT": "Conflict",

--- a/nxdrive/data/qml/DirectTransfer.qml
+++ b/nxdrive/data/qml/DirectTransfer.qml
@@ -8,9 +8,6 @@ import "icon-font/Icon.js" as MdiFont
 Rectangle {
     id: directTransfer
     anchors.fill: parent
-    anchors.topMargin: 40
-    anchors.bottomMargin: 40
-    anchors.leftMargin: 20
 
     property string engineUid: ""
 
@@ -23,73 +20,101 @@ Rectangle {
         onNoItems: application.close_direct_transfer_window()
     }
 
-    Flickable {
-        id: fileList
-        anchors.fill: parent
+    TabBar {
+        id: bar
+        width: parent.width
+        height: 50
+        spacing: 0
 
-        // Grab the focus to allow scrolling using the keyboard
-        focus: true
+        anchors.top: parent.top
 
-        // UP and DOWN keys to scroll
-        Keys.onUpPressed: scrollBar.decrease()
-        Keys.onDownPressed: scrollBar.increase()
-
-        // The scrollbar
-        ScrollBar.vertical: ScrollBar {
-            id: scrollBar
+        SettingsTab {
+            text: qsTr("ACTIVE") + tl.tr
+            barIndex: bar.currentIndex;
+            index: 0
+            anchors.top: parent.top
         }
+        SettingsTab {
+            text: qsTr("COMPLETED") + tl.tr
+            barIndex: bar.currentIndex;
+            index: 1
+            anchors.top: parent.top
+            enabled: false
+        }
+    }
 
-        contentHeight: transfers.height
-        ListView {
-            id: transfers
-            visible: DirectTransferModel.count > 0
+    StackLayout {
+        currentIndex: bar.currentIndex
+        width: parent.width
+        height: parent.height - bar.height
+        anchors.bottom: parent.bottom
 
-            width: parent.width
-            height: contentHeight
-            spacing: 15
+        // The overall rect
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
 
-            // TODO: Not yet effective
-            highlight: Rectangle {
-                color: lighterGray
-            }
-
-            // The test before items being transferred
-            header: RowLayout {
+            // The "header" rect
+            Rectangle {
+                id: headerRect
                 width: parent.width
-                Rectangle {
-                    Layout.fillWidth: true
-                    height: 40
+                height: 60
+                anchors.top: parent.top
 
-                    ScaledText {
-                        elide: Text.ElideMiddle
-                        width: parent.width - 20
-                        property var destination_link: DirectTransferModel.destination_link
-                        text: qsTr("DIRECT_TRANSFER_SEND").arg(destination_link) + tl.tr
-                        font.pointSize: point_size * 1.2
-                        linkColor: nuxeoBlue
-                        onLinkActivated: Qt.openUrlExternally(link)
+                // The text above items
+                ScaledText {
+                    id: textIntro
+                    anchors.fill: parent
+                    anchors.margins: 20
+                    elide: Text.ElideMiddle
+                    text: qsTr("DIRECT_TRANSFER_SEND").arg(DirectTransferModel.destination_link) + tl.tr
+                    font.pointSize: point_size * 1.2
+                    linkColor: nuxeoBlue
+                    onLinkActivated: Qt.openUrlExternally(link)
 
-                        MouseArea {
-                            id: mouseArea
-                            anchors.fill: parent
-                            hoverEnabled: true
-                            cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
-                            // In order to only set a mouse cursor shape for a region without reacting to mouse
-                            // events set the acceptedButtons to none. This is important to being able to click
-                            // on the remote path and let Qt opening the browser at the good URL.
-                            acceptedButtons: Qt.NoButton
-                        }
-                        NuxeoToolTip {
-                            text: qsTr("OPEN_REMOTE") + tl.tr
-                            visible: parent.hoveredLink
-                        }
+                    MouseArea {
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: textIntro.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
+                        // In order to only set a mouse cursor shape for a region without reacting to mouse
+                        // events set the acceptedButtons to none. This is important to being able to click
+                        // on the remote path and let Qt opening the browser at the good URL.
+                        acceptedButtons: Qt.NoButton
+                    }
+
+                    NuxeoToolTip {
+                        text: qsTr("OPEN_REMOTE") + tl.tr
+                        visible: textIntro.hoveredLink
                     }
                 }
             }
 
-            // Items being transferred
-            model: DirectTransferModel
-            delegate: TransferItem {}
+            // The "content" rect
+            Rectangle {
+                width: parent.width
+                height: parent.height - headerRect.height
+                anchors.top: headerRect.bottom
+
+                // The items list
+                Flickable {
+                    anchors.fill: parent
+                    clip: true
+                    contentHeight: itemsList.height + 15
+                    ScrollBar.vertical: ScrollBar {}
+
+                    ListView {
+                        id: itemsList
+                        width: parent.width
+                        height: contentHeight
+                        spacing: 20
+                        visible: DirectTransferModel.count > 0
+                        interactive: false
+
+                        model: DirectTransferModel
+                        delegate: TransferItem {}
+                    }
+                }
+            }
         }
     }
 }

--- a/nxdrive/data/qml/Main.qml
+++ b/nxdrive/data/qml/Main.qml
@@ -66,7 +66,7 @@ QtObject {
     property var directTransferWindow: Window {
         id: directTransferWindow
         minimumWidth: 600
-        minimumHeight: 300
+        minimumHeight: 400
         objectName: "directTransferWindow"
         title: qsTr("DIRECT_TRANSFER_WINDOW_TITLE").arg(APP_NAME) + tl.tr
         width: directTransfer.width; height: directTransfer.height

--- a/nxdrive/data/qml/TransferItem.qml
+++ b/nxdrive/data/qml/TransferItem.qml
@@ -31,7 +31,6 @@ Rectangle {
             columns: 3
             Layout.fillWidth: true
             Layout.fillHeight: true
-            Layout.rightMargin: 10
             Layout.leftMargin: 10
 
             // Progression: bar

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -268,7 +268,7 @@ class Application(QApplication):
             # Direct Transfer
             self.direct_transfer_window = QQuickView()
             self.direct_transfer_window.setMinimumWidth(600)
-            self.direct_transfer_window.setMinimumHeight(300)
+            self.direct_transfer_window.setMinimumHeight(400)
             self._fill_qml_context(self.direct_transfer_window.rootContext())
             self.direct_transfer_window.setSource(
                 QUrl.fromLocalFile(str(find_resource("qml", "DirectTransfer.qml")))


### PR DESCRIPTION
- Reworked the entire window to place elements "correctly" (each element has its own rectangle, it eases positioning and thinking).
- The scrollbar is only affecting the items list: this allowes to not hide the selected remote folder on scrolling.
- Fixed the window resizing that was very weird and sometimes it was also not possible to resize it.
- Introduced tabs for next works, it renders better IMO.
- Commented the QML code to ease maintenance and reading.
- Fixed a QML error on Windows:
```
QWindowsWindow::setGeometry: Unable to set geometry 580x220+660+390 (frame: 598x267+651+352)
on QQuickView/"" on "\\.\DISPLAY1". Resulting geometry: 600x300+660+390
(frame: 618x347+651+352) margins: 9, 38, 9, 9 minimum size: 600x300
MINMAXINFO maxSize=0,0 maxpos=0,0 mintrack=618,347 maxtrack=0,0)
```