### PR TITLE
NXDRIVE-1926: Improve performances by removing an unused QVariant

### DIFF
--- a/nxdrive/data/qml/TransferItem.qml
+++ b/nxdrive/data/qml/TransferItem.qml
@@ -7,7 +7,6 @@ import "icon-font/Icon.js" as MdiFont
 
 Rectangle {
     id: control
-    property variant fileData: model
     property bool paused: status == "PAUSED" || status == "SUSPENDED"
     width: parent.width
     height: 55


### PR DESCRIPTION
From https://developer.blackberry.com/native/documentation/best_practices/performance/performance.html

> **Avoid declaring variant properties.**
> The variant type in QML is useful because it allows your app to store values from any of the basic Qt types. Although the variant type is versatile, the versatility comes at a price. Using a variant type when you can use a more specific type means that you get less compile-time help (the compiler may not recognize certain type-related errors) and your app pays a performance penalty for converting the value into and from a QVariant each time. If the variable is always a number, you should use the int or real types. If the variable is always text, use a string type.

This is for the history mostly :)

But here, the property was not used at all, and creating thousands of `TransferItem`s was making the UI in a bad health.