### PR TITLE
NXDRIVE-2219: Display a remote folder icon for each transfer

### DIFF
--- a/docs/changes/4.4.4.md
+++ b/docs/changes/4.4.4.md
@@ -38,6 +38,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2208](https://jira.nuxeo.com/browse/NXDRIVE-2208): Enable to cancel one or more transfer
 - [NXDRIVE-2155](https://jira.nuxeo.com/browse/NXDRIVE-2155): Improvements on the main popup
 - [NXDRIVE-2158](https://jira.nuxeo.com/browse/NXDRIVE-2158): Review the warning message on conflict popup
+- [NXDRIVE-2219](https://jira.nuxeo.com/browse/NXDRIVE-2219): Display a remote folder icon for each transfer
 
 ## GUI
 
@@ -111,11 +112,10 @@ Release date: `2020-xx-xx`
 - Added `Application.exit_app()`
 - Removed `Application.add_qml_import_path()`
 - Added `USER_AGENT` in `constants.py`
-- Add `remote_ref` argument to `Engine.direct_transfer()`
+- Added `remote_ref` argument to `Engine.direct_transfer()`
+- Added `EngineDAO.insert_direct_transfer_state()`
 - Added `EngineDAO.update_upload()`
 - Added `NuxeoDocumentInfo.is_proxy`
-- Added `DirectTransferUploader.get_document_by_uid()`
-- Added `DirectTransferUploader.get_document_by_title()`
 - Added `Remote.get_note()`
 - Removed `Remote.direct_transfer()`. Use `DirectTransferUploader.upload()` instead.
 - Removed `Remote.get_document_or_none()`. Use `DirectTransferUploader.get_document_or_none()` instead.
@@ -149,8 +149,9 @@ Release date: `2020-xx-xx`
 - Added `Application.show_direct_transfer_window()`
 - Added `FileAction.is_direct_transfer`
 - Added `FoldersDialog.remote_folder_ref`
-- Added `State.dt_remote_link`
 - Added `Upload.is_direct_transfer`
+- Added `Upload.remote_parent_title`
+- Added `Upload.remote_parent_ref`
 - Added view.py::`DirectTransferModel`
 - Added `Engine.cancel_upload()`
 - Added `Remote.cancel_batch()`

--- a/nxdrive/client/uploader/__init__.py
+++ b/nxdrive/client/uploader/__init__.py
@@ -164,6 +164,8 @@ class BaseUploader:
             engine_uid = kwargs.pop("engine_uid", None)
             is_direct_edit = kwargs.pop("is_direct_edit", False)
             is_direct_transfer = kwargs.pop("is_direct_transfer", False)
+            remote_parent_path = kwargs.pop("remote_parent_path", "")
+            remote_parent_ref = kwargs.pop("remote_parent_ref", "")
 
             # Set those attributes as FileBlob does not have them
             # and they are required for the step 2 of .upload_impl()
@@ -194,6 +196,8 @@ class BaseUploader:
                     batch=batch.as_dict(),
                     chunk_size=chunk_size,
                     is_direct_transfer=is_direct_transfer,
+                    remote_parent_path=remote_parent_path,
+                    remote_parent_ref=remote_parent_ref,
                 )
                 self.dao.save_upload(transfer)
             elif transfer.batch["batchId"] != batch.uid:

--- a/nxdrive/client/uploader/direct_transfer.py
+++ b/nxdrive/client/uploader/direct_transfer.py
@@ -10,7 +10,6 @@ from nuxeo.models import Document
 from ...engine.activity import LinkingAction, UploadAction
 from ...exceptions import DirectTransferDuplicateFoundError
 from ...objects import Upload
-from ..local import LocalClient
 from . import BaseUploader
 
 log = getLogger(__name__)
@@ -22,65 +21,19 @@ class DirectTransferUploader(BaseUploader):
     linking_action = LinkingAction
     upload_action = UploadAction
 
-    def get_document_by_uid(self, uid: str) -> Optional[Document]:
+    def get_document_or_none(self, parent_ref: str, name: str) -> Optional[Document]:
         """
-        Fetch a document based on its UID.
+        Fetch a document based on its parent's UID and document's name.
         Return None if not found on the server.
         """
-        ref = self.remote._escape(uid)
-        query = f"SELECT * FROM Document WHERE ecm:uuid = '{ref}' AND ecm:isVersion = 0 LIMIT 1"
-        results = self.remote.query(query)["entries"]
-        return Document.parse(results[0]) if results else None
-
-    def get_document_by_title(self, parent_path: str, name: str) -> Optional[Document]:
-        """
-        Fetch a document based on its parent's path and document's name.
-        Return None if not found on the server.
-
-        May be better to update the query when NXP-19605 will be available.
-        A benchmark should be done then before choosing one or another.
-        """
-        parent_path = self.remote._escape(self.remote.check_ref(parent_path))
         name = self.remote._escape(name)
         query = (
-            f"SELECT * FROM Document WHERE ecm:path STARTSWITH '{parent_path}/'"
-            f" AND dc:title = '{name}' AND ecm:isVersion = 0 LIMIT 1"
+            "SELECT * FROM Document WHERE "
+            f"ecm:parentId = '{parent_ref}' AND dc:title = '{name}'"
+            " AND ecm:isVersion = 0 AND ecm:isTrashed = 0 LIMIT 1"
         )
         results = self.remote.query(query)["entries"]
         return Document.parse(results[0]) if results else None
-
-    def get_document_or_none(
-        self, uid: str = "", parent_path: str = "", name: str = ""
-    ) -> Optional[Document]:
-        """
-        Fetch a document based on given criteria.
-        Return None if not found on the server.
-
-        :param uid: Document reference (UID).
-        :param path: Document reference (path).
-        :rtype: Document or None
-        """
-        doc: Optional[Document] = None
-
-        if uid:
-            # The remote ref is known, so it means either the file has already been uploaded,
-            # either a previous upload failed: the document was created, or not, and it has
-            # a blob attached, or not. In any cases, we need to ensure the user can upload
-            # without headhache.
-            doc = self.get_document_by_uid(uid)
-
-        if not doc:
-            # We need to handle possbile duplicates based on the file name and
-            # the destination folder on the server.
-            # Note: using this way may still result in duplicates:
-            #  - the user created 2 documents with the same name on Web-UI or another way
-            #  - the user then deleted the 1st document
-            #  - the other document has a path like "name.TIMESTAMP"
-            # So then Drive will not see that document as a duplicate because it will check
-            # a path with "name" only.
-            doc = self.get_document_by_title(parent_path, name)
-
-        return doc
 
     def get_upload(self, file_path: Path) -> Optional[Upload]:
         """Retrieve the eventual transfer associated to the given *file_path*."""
@@ -113,21 +66,17 @@ class DirectTransferUploader(BaseUploader):
             - https://jira.nuxeo.com/browse/NXP-22959;
             - create a new operation `Document.GetOrCreate` that ensures atomicity.
         """
-        parent_path = kwargs.pop("parent_path")
+        remote_parent_path = kwargs.pop("remote_parent_path")
+        remote_parent_ref = kwargs.pop("remote_parent_ref")
         engine_uid = kwargs.pop("engine_uid")
         replace_blob = kwargs.get("replace_blob", False)
-        log.info(f"Direct Transfer of {file_path!r} into {parent_path!r}")
-
-        # The remote file, when created, is stored in the file xattrs.
-        # So retrieve it and if it is defined, the document creation should
-        # be skipped to prevent duplicate creations.
-        remote_ref = LocalClient.get_path_remote_id(file_path, name="remote")
+        log.info(
+            f"Direct Transfer of {file_path!r} into {remote_parent_path!r} ({remote_parent_ref!r})"
+        )
 
         doc: Optional[Document] = self.get_document_or_none(
-            uid=remote_ref, parent_path=parent_path, name=file_path.name
+            remote_parent_ref, file_path.name
         )
-        if doc:
-            remote_ref = doc.uid
 
         if not replace_blob and doc and doc.properties.get("file:content"):
             # The document already exists and has a blob attached. Ask the user what to do.
@@ -138,19 +87,17 @@ class DirectTransferUploader(BaseUploader):
         #     details: Dict[str, Any] = doc.as_dict() if doc else {}
         #     return details
 
-        # Save the remote document's UID into the file xattrs, in case next steps fails
-        if remote_ref:
-            LocalClient.set_path_remote_id(file_path, remote_ref, name="remote")
-
         # Upload the blob and use the FileManager importer to create the document
         item = super().upload_impl(
             file_path,
             "FileManager.Import",
-            context={"currentDocument": parent_path},
+            context={"currentDocument": remote_parent_path},
             params={"overwite": True},  # NXP-29286
             headers={"nx-es-sync": "true", "X-Batch-No-Drop": "true"},
             engine_uid=engine_uid,
             is_direct_transfer=True,
+            remote_parent_path=remote_parent_path,
+            remote_parent_ref=remote_parent_ref,
         )
 
         # Transfer is completed, delete the upload from the database

--- a/nxdrive/data/i18n/i18n.json
+++ b/nxdrive/data/i18n/i18n.json
@@ -96,7 +96,6 @@
     "DIRECT_TRANSFER_NOT_ALLOWED": "Direct Transfer of „%1“ is not allowed for synced files.",
     "DIRECT_TRANSFER_NOT_ENABLED": "The Direct Transfer feature is not enabled.",
     "DIRECT_TRANSFER_NOT_POSSIBLE": "The Direct Transfer feature is not usable right now.<br>Please try again later.",
-    "DIRECT_TRANSFER_SEND": "Sending files to %1",
     "DIRECT_TRANSFER_START": "Transfer start: „%1“",
     "DIRECT_TRANSFER_WINDOW_TITLE": "Direct Transfer - %1",
     "DISCONNECT": "Remove account",
@@ -221,6 +220,7 @@
     "NETWORK_ERROR_UnknownNetworkError": "Unknown error",
     "NETWORK_ERROR_UnknownProxyError": "Unknown error",
     "NEW_ENGINE": "Add account",
+    "NO": "No",
     "NONE": "None",
     "NOTIF_UPDATE_TITLE": "Update available",
     "NOTIF_UPDATE_DOWNGRADE": "Downgrade to %1 is needed",
@@ -330,5 +330,6 @@
     "WINDOWS_ERROR_TITLE": "Document error",
     "WINDOWS_ERROR_OPENED_FILE": "The file „%1“ is open by another software. Please close it before %2 can process the deletion from your local storage.",
     "WINDOWS_ERROR_OPENED_FOLDER": "The folder „%1“ or its children is locked by another software. Please close it before %2 can process the deletion from your local storage.",
-    "WRONG_CHANNEL": "You are running version %1 which is from the „%2“ channel, but your current channel is „%3“. Do you want to downgrade to the latest version of your current channel, or switch channels?"
+    "WRONG_CHANNEL": "You are running version %1 which is from the „%2“ channel, but your current channel is „%3“. Do you want to downgrade to the latest version of your current channel, or switch channels?",
+    "YES": "Yes"
 }

--- a/nxdrive/data/qml/DirectTransfer.qml
+++ b/nxdrive/data/qml/DirectTransfer.qml
@@ -49,70 +49,27 @@ Rectangle {
         height: parent.height - bar.height
         anchors.bottom: parent.bottom
 
-        // The overall rect
+        // The "active" transfers rect
         Rectangle {
             Layout.fillWidth: true
             Layout.fillHeight: true
 
-            // The "header" rect
-            Rectangle {
-                id: headerRect
-                width: parent.width
-                height: 60
-                anchors.top: parent.top
+            Flickable {
+                anchors.fill: parent
+                anchors.topMargin: 20
+                clip: true
+                contentHeight: itemsList.height
+                interactive: false
 
-                // The text above items
-                ScaledText {
-                    id: textIntro
-                    anchors.fill: parent
-                    anchors.margins: 20
-                    elide: Text.ElideMiddle
-                    text: qsTr("DIRECT_TRANSFER_SEND").arg(DirectTransferModel.destination_link) + tl.tr
-                    font.pointSize: point_size * 1.2
-                    linkColor: nuxeoBlue
-                    onLinkActivated: Qt.openUrlExternally(link)
+                ListView {
+                    id: itemsList
+                    width: parent.width
+                    height: contentHeight
+                    spacing: 20
+                    // visible: DirectTransferModel.count > 0
 
-                    MouseArea {
-                        anchors.fill: parent
-                        hoverEnabled: true
-                        cursorShape: textIntro.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
-                        // In order to only set a mouse cursor shape for a region without reacting to mouse
-                        // events set the acceptedButtons to none. This is important to being able to click
-                        // on the remote path and let Qt opening the browser at the good URL.
-                        acceptedButtons: Qt.NoButton
-                    }
-
-                    NuxeoToolTip {
-                        text: qsTr("OPEN_REMOTE") + tl.tr
-                        visible: textIntro.hoveredLink
-                    }
-                }
-            }
-
-            // The "content" rect
-            Rectangle {
-                width: parent.width
-                height: parent.height - headerRect.height
-                anchors.top: headerRect.bottom
-
-                // The items list
-                Flickable {
-                    anchors.fill: parent
-                    clip: true
-                    contentHeight: itemsList.height + 15
-                    ScrollBar.vertical: ScrollBar {}
-
-                    ListView {
-                        id: itemsList
-                        width: parent.width
-                        height: contentHeight
-                        spacing: 20
-                        visible: DirectTransferModel.count > 0
-                        interactive: false
-
-                        model: DirectTransferModel
-                        delegate: TransferItem {}
-                    }
+                    model: DirectTransferModel
+                    delegate: TransferItem {}
                 }
             }
         }

--- a/nxdrive/data/qml/Main.qml
+++ b/nxdrive/data/qml/Main.qml
@@ -66,7 +66,7 @@ QtObject {
     property var directTransferWindow: Window {
         id: directTransferWindow
         minimumWidth: 600
-        minimumHeight: 400
+        minimumHeight: 450
         objectName: "directTransferWindow"
         title: qsTr("DIRECT_TRANSFER_WINDOW_TITLE").arg(APP_NAME) + tl.tr
         width: directTransfer.width; height: directTransfer.height

--- a/nxdrive/data/qml/TransferItem.qml
+++ b/nxdrive/data/qml/TransferItem.qml
@@ -15,70 +15,82 @@ Rectangle {
         id: transfer
         anchors.fill: parent
         anchors.centerIn: parent
+        anchors.leftMargin: 20
         anchors.rightMargin: 20
         spacing: 3
 
         // Progression: transferred data
         ScaledText {
             text: qsTr("DIRECT_TRANSFER_DETAILS").arg(Math.floor(progress || 0.0)).arg(progress_metrics[0]).arg(progress_metrics[1]) + tl.tr
-            Layout.leftMargin: 10
-            opacity: 0.7
+            color: darkGray
+            Layout.leftMargin: icon.width + 5
+            font.pointSize: point_size * 0.8
         }
 
         GridLayout {
-            id: item_control
             columns: 3
             Layout.fillWidth: true
             Layout.fillHeight: true
-            Layout.leftMargin: 10
 
-            // Progression: bar
-            Rectangle {
-                Layout.fillWidth: true
-                height: 30
-                border.color: nuxeoBlue
-                border.width: 1
-                radius: 3
-                opacity: 0.7
-
-                NuxeoProgressBar {
-                    width: parent.width - 2
-                    height: parent.height - 2
-                    anchors.verticalCenter: parent.verticalCenter
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    color: nuxeoBlue50
-                    bgColor2: "#eeeeee"
-                    value: progress || 0.0
-                    text: name
-                    // Indeterminate progress bar when linking the blob to the document (last upload step)
-                    indeterminate: finalizing
-                    easingType: Easing.Bezier
+            RowLayout {
+                // Remote folder icon
+                IconLabel {
+                    id: icon
+                    icon: MdiFont.Icon.folder
+                    tooltip: remote_parent_path
+                    onClicked: api.open_remote_document(engine, remote_parent_ref, remote_parent_path)
                 }
-            }
 
-            // Pause/Resume icon
-            IconLabel {
-                enabled: !finalizing
-                icon: paused ? MdiFont.Icon.play : MdiFont.Icon.pause
-                iconColor: nuxeoBlue
-                tooltip: qsTr(paused ? "RESUME" : "SUSPEND") + tl.tr
-                onClicked: {
-                    if (paused) {
-                        api.resume_transfer("upload", engine, uid)
-                    } else {
-                        api.pause_transfer("upload", engine, uid, progress)
+                // Progress bar
+                // Note: the rect is necessary to display a nice border around the progress bar.
+                Rectangle {
+                    id: progressBar
+                    Layout.fillWidth: true
+                    height: 30
+                    border.color: nuxeoBlue
+                    border.width: 1
+                    radius: 3
+                    opacity: 0.7
+
+                    NuxeoProgressBar {
+                        width: parent.width - 2
+                        height: parent.height - 2
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        color: nuxeoBlue50
+                        bgColor2: "#eeeeee"
+                        value: progress || 0.0
+                        text: name
+                        // Indeterminate progress bar when linking the blob to the document (last upload step)
+                        indeterminate: finalizing
+                        easingType: Easing.Bezier
                     }
                 }
-            }
 
-            // Stop icon
-            IconLabel {
-                enabled: paused
-                icon: MdiFont.Icon.close
-                tooltip: qsTr("CANCEL") + tl.tr
-                iconColor: "red"
-                onClicked: {
-                    application.confirm_cancel_transfer(engine, uid, name)
+                // Pause/Resume icon
+                IconLabel {
+                    enabled: !finalizing
+                    icon: paused ? MdiFont.Icon.play : MdiFont.Icon.pause
+                    iconColor: nuxeoBlue
+                    tooltip: qsTr(paused ? "RESUME" : "SUSPEND") + tl.tr
+                    onClicked: {
+                        if (paused) {
+                            api.resume_transfer("upload", engine, uid)
+                        } else {
+                            api.pause_transfer("upload", engine, uid, progress)
+                        }
+                    }
+                }
+
+                // Stop icon
+                IconLabel {
+                    enabled: paused
+                    icon: MdiFont.Icon.close
+                    tooltip: qsTr("CANCEL") + tl.tr
+                    iconColor: "red"
+                    onClicked: {
+                        application.confirm_cancel_transfer(engine, uid, name)
+                    }
                 }
             }
         }

--- a/nxdrive/gui/api.py
+++ b/nxdrive/gui/api.py
@@ -910,10 +910,21 @@ class QMLDriveApi(QObject):
 
     @pyqtSlot(str, str, str)
     def open_remote(self, uid: str, remote_ref: str, remote_name: str) -> None:
-        log.info(f"Should open this : {remote_name} ({remote_ref})")
+        log.info(f"Should open {remote_name!r} ({remote_ref!r})")
         try:
             engine = self._manager.engines.get(uid)
             if engine:
                 engine.open_edit(remote_ref, remote_name)
         except OSError:
             log.exception("Remote open error")
+
+    @pyqtSlot(str, str, str)
+    def open_remote_document(self, uid: str, remote_ref: str, remote_path: str) -> None:
+        log.info(f"Should open remote document {remote_path!r} ({remote_ref!r})")
+        try:
+            engine = self._manager.engines.get(uid)
+            if engine:
+                url = engine.get_metadata_url(remote_ref)
+                engine.open_remote(url=url)
+        except OSError:
+            log.exception("Remote document cannot be opened")

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -268,7 +268,7 @@ class Application(QApplication):
             # Direct Transfer
             self.direct_transfer_window = QQuickView()
             self.direct_transfer_window.setMinimumWidth(600)
-            self.direct_transfer_window.setMinimumHeight(400)
+            self.direct_transfer_window.setMinimumHeight(450)
             self._fill_qml_context(self.direct_transfer_window.rootContext())
             self.direct_transfer_window.setSource(
                 QUrl.fromLocalFile(str(find_resource("qml", "DirectTransfer.qml")))
@@ -818,8 +818,8 @@ class Application(QApplication):
             Translator.get("DIRECT_TRANSFER_CANCEL", [name]),
             QMessageBox.NoButton,
         )
-        continued = msgbox.addButton("OK", QMessageBox.AcceptRole)
-        cancel = msgbox.addButton(Translator.get("CANCEL"), QMessageBox.RejectRole)
+        continued = msgbox.addButton(Translator.get("YES"), QMessageBox.AcceptRole)
+        cancel = msgbox.addButton(Translator.get("NO"), QMessageBox.RejectRole)
         msgbox.setDefaultButton(cancel)
         msgbox.setIcon(QMessageBox.Question)
         msgbox.exec_()

--- a/nxdrive/gui/view.py
+++ b/nxdrive/gui/view.py
@@ -12,7 +12,6 @@ from PyQt5.QtCore import (
     pyqtSlot,
 )
 
-from ..state import State
 from ..utils import force_decode, sizeof_fmt
 
 if TYPE_CHECKING:
@@ -268,6 +267,8 @@ class DirectTransferModel(QAbstractListModel):
     ENGINE = Qt.UserRole + 5
     FINALIZING = Qt.UserRole + 6
     PROGRESS_METRICS = Qt.UserRole + 7
+    REMOTE_PARENT_PATH = Qt.UserRole + 8
+    REMOTE_PARENT_REF = Qt.UserRole + 9
 
     def __init__(self, translate: Callable, parent: QObject = None) -> None:
         super().__init__(parent)
@@ -283,6 +284,8 @@ class DirectTransferModel(QAbstractListModel):
             # The is the Verification step for downloads
             # and Linking step for uploads.
             self.FINALIZING: b"finalizing",
+            self.REMOTE_PARENT_PATH: b"remote_parent_path",
+            self.REMOTE_PARENT_REF: b"remote_parent_ref",
         }
 
     def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:
@@ -297,11 +300,6 @@ class DirectTransferModel(QAbstractListModel):
         if count == 0:
             self.noItems.emit()
         return count
-
-    @pyqtProperty(str, notify=fileChanged)
-    def destination_link(self) -> str:
-        """Return the link to the remote path that will be used in DirectTransfer.qml."""
-        return State.dt_remote_link
 
     def set_items(
         self, items: List[Dict[str, Any]], parent: QModelIndex = QModelIndex()

--- a/nxdrive/objects.py
+++ b/nxdrive/objects.py
@@ -474,3 +474,5 @@ class Upload(Transfer):
     transfer_type: str = field(init=False, default="upload")
     batch: dict = field(default_factory=dict)
     chunk_size: Optional[int] = None
+    remote_parent_path: Optional[str] = ""
+    remote_parent_ref: Optional[str] = ""

--- a/nxdrive/state.py
+++ b/nxdrive/state.py
@@ -8,10 +8,7 @@ Available parameters:
 - about_to_quit (4.4.4)
     This is set from the GUI when clicking on Quit.
 
-- dt_remote_link (4.4.4)
-    The HTML link pointing to the current Direct Transfer remote path.
-
 """
 from types import SimpleNamespace
 
-State = SimpleNamespace(about_to_quit=False, dt_remote_link="")
+State = SimpleNamespace(about_to_quit=False)

--- a/tools/whitelist.py
+++ b/tools/whitelist.py
@@ -59,9 +59,10 @@ QMLDriveApi.get_proxy_settings  # Used in QML
 QMLDriveApi.get_update_url  # Used in QML
 QMLDriveApi.get_update_version  # Used in QML
 QMLDriveApi.open_direct_transfer  # Used in QML
+QMLDriveApi.open_document  # Used in QML
 QMLDriveApi.open_local  # Used in QML
 QMLDriveApi.open_remote_server  # Used in QML
-QMLDriveApi.open_document  # Used in QML
+QMLDriveApi.open_remote_document  # Used in QML
 QMLDriveApi.open_report  # Used in QML
 QMLDriveApi.set_proxy_settings  # Used in QML
 QMLDriveApi.set_server_ui  # Used in QML


### PR DESCRIPTION
This fixes UI performance issues because there is no need to do QML > C > Python > C > QML to fetch the remote folder path and UID (it was displayed in the header of the Direct transfer window).

Another performance issue was tackled: the use of xattrs to store remote paths and UIDs. Sending 50,000 files was freezing the UI; not it is still frozen but quite less. I may need additionnal work to completely tackle that issue.

Some interesting fixes/improvements:

- A nice folder icon is shown on the left of each progress bar to access the remote destination folder.
- Clean-up Direct transfer tests.
- Notifications are shown when the uploaded file is >= 25 MiB.
- The buttons available when cancelling a transfer are now Yes/No.