### PR TITLE
NXDRIVE-2221: Improve performances to prevent GUI freezes

### DIFF
--- a/docs/changes/4.4.4.md
+++ b/docs/changes/4.4.4.md
@@ -41,6 +41,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2158](https://jira.nuxeo.com/browse/NXDRIVE-2158): Review the warning message on conflict popup
 - [NXDRIVE-2219](https://jira.nuxeo.com/browse/NXDRIVE-2219): Display a remote folder icon for each transfer
 - [NXDRIVE-2220](https://jira.nuxeo.com/browse/NXDRIVE-2220): Asynchronous planification of uploads
+- [NXDRIVE-2221](https://jira.nuxeo.com/browse/NXDRIVE-2221): Improve performances to prevent GUI freezes
 
 ## GUI
 
@@ -113,12 +114,26 @@ Release date: `2020-xx-xx`
 ## Technical Changes
 
 - Added `Application.exit_app()`
+- Added `Application.update_direct_transfer_items_count()`
 - Removed `Application.add_qml_import_path()`
 - Added `USER_AGENT` in `constants.py`
+- Added `Engine.directTranferItemsCount` signal
 - Added `remote_ref` argument to `Engine.direct_transfer()`
 - Added `Engine.direct_transfer_async()`
-- Added `EngineDAO.insert_direct_transfer_state()`
+- Added `is_direct_transfer` keyword argument to `Engine.pause_transfer()`
+- Added `is_direct_transfer` keyword argument to `Engine.resume_transfer()`
+- Added `is_direct_transfer` keyword argument to `Engine.remove_transfer()`
+- Renamed `Engine._start` signal to `started`
+- Added `EngineDAO.directTransferUpdated`
+- Added `EngineDAO.get_dt_items_count()`
+- Added `EngineDAO.get_dt_uploads_with_status()`
+- Added `EngineDAO.get_dt_upload()`
+- Added `EngineDAO.plan_many_direct_transfer_items()`
+- Added `EngineDAO.queue_many_direct_transfer_items()`
 - Added `EngineDAO.update_upload()`
+- Added `is_direct_transfer` keyword argument to `EngineDAO.pause_transfer()`
+- Added `is_direct_transfer` keyword argument to `EngineDAO.resume_transfer()`
+- Added `is_direct_transfer` keyword argument to `EngineDAO.remove_transfer()`
 - Added `NuxeoDocumentInfo.is_proxy`
 - Added `Remote.get_note()`
 - Removed `Remote.direct_transfer()`. Use `DirectTransferUploader.upload()` instead.
@@ -140,7 +155,11 @@ Release date: `2020-xx-xx`
 - Removed utils.py::`version_lt()`. Use `nuxeo.utils.version_lt()` instead.
 - Added `Manager.get_feature_state()`
 - Added `Manager.set_feature_state()`
+- Added `QMLDriveApi.get_direct_transfer_items()`
+- Added `QMLDriveApi.get_dt_items_count()`
 - Added `QMLDriveApi.get_features_list()`
+- Added `is_direct_transfer` keyword argument to `QMLDriveApi.pause_transfer()`
+- Added `is_direct_transfer` keyword argument to `QMLDriveApi.resume_transfer()`
 - Added engine/workers.py::`Runner`
 - Added features.py::`Beta`
 - Added `state.py`
@@ -151,14 +170,24 @@ Release date: `2020-xx-xx`
 - Added `Application.direct_transfer_model`
 - Added `Application.close_direct_transfer_window()`
 - Added `Application.destroyed_server_folders()`
+- Added `Application.refresh_direct_transfer_items()`
+- Removed `Download.filesize`
 - Added `Application.show_direct_transfer_window()`
 - Added `FileAction.is_direct_transfer`
 - Added `FoldersDialog.remote_folder_ref`
+- Added `Transfer.filesize`
 - Added `Upload.is_direct_transfer`
 - Added `Upload.remote_parent_title`
 - Added `Upload.remote_parent_ref`
+- Added utils.py::`grouper()`
+- Added `size` to each entry returned by utils.py::`get_tree_list()`
 - Added view.py::`DirectTransferModel`
 - Added `Engine.cancel_upload()`
 - Added `Remote.cancel_batch()`
 - Added `Application.confirm_cancel_transfer()`
 - features.py::`DisabledFeatures`
+- Changed `FileAction.__init__(..., size, ...)` from float keyword argument to int positional argument
+- Added `size` positional argument to `DownloadAction`
+- Added `size` positional argument to `LinkingAction`
+- Added `size` positional argument to `UploadAction`
+- Added `size` positional argument to `VerificationAction`

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -295,9 +295,8 @@ class Remote(Nuxeo):
 
         if chunked:
             action = DownloadAction(
-                file_path, tmppath=file_out, reporter=QApplication.instance()
+                file_path, size, tmppath=file_out, reporter=QApplication.instance()
             )
-            action.size = size
             action.progress = downloaded
             log.debug(
                 f"Download progression is {action.get_percent():.2f}% "
@@ -348,6 +347,7 @@ class Remote(Nuxeo):
         Update the progress of the verification during the computation of the digest.
         """
         digester = get_digest_algorithm(digest)
+        size = download_action.size
         filepath = download_action.tmppath or download_action.filepath
 
         # Terminate the download action to be able to start the verification one as we are allowing
@@ -356,7 +356,9 @@ class Remote(Nuxeo):
         # one, but let's do things right.
         DownloadAction.finish_action()
 
-        verif_action = VerificationAction(filepath, reporter=QApplication.instance())
+        verif_action = VerificationAction(
+            filepath, size, reporter=QApplication.instance()
+        )
 
         def callback(_: Path) -> None:
             verif_action.progress += FILE_BUFFER_SIZE

--- a/nxdrive/client/uploader/direct_transfer.py
+++ b/nxdrive/client/uploader/direct_transfer.py
@@ -37,7 +37,7 @@ class DirectTransferUploader(BaseUploader):
 
     def get_upload(self, file_path: Path) -> Optional[Upload]:
         """Retrieve the eventual transfer associated to the given *file_path*."""
-        ret: Optional[Upload] = self.dao.get_upload(path=file_path)
+        ret: Optional[Upload] = self.dao.get_dt_upload(path=file_path)
         return ret
 
     def upload(
@@ -78,7 +78,7 @@ class DirectTransferUploader(BaseUploader):
             remote_parent_ref, file_path.name
         )
 
-        if not replace_blob and doc and doc.properties.get("file:content"):
+        if not replace_blob and doc:
             # The document already exists and has a blob attached. Ask the user what to do.
             raise DirectTransferDuplicateFoundError(file_path, doc)
 
@@ -101,6 +101,6 @@ class DirectTransferUploader(BaseUploader):
         )
 
         # Transfer is completed, delete the upload from the database
-        self.dao.remove_transfer("upload", file_path)
+        self.dao.remove_transfer("upload", file_path, is_direct_transfer=True)
 
         return item

--- a/nxdrive/data/qml/Main.qml
+++ b/nxdrive/data/qml/Main.qml
@@ -66,15 +66,17 @@ QtObject {
     property var directTransferWindow: Window {
         id: directTransferWindow
         minimumWidth: 600
-        minimumHeight: 450
+        minimumHeight: 480
         objectName: "directTransferWindow"
         title: qsTr("DIRECT_TRANSFER_WINDOW_TITLE").arg(APP_NAME) + tl.tr
         width: directTransfer.width; height: directTransfer.height
         visible: false
 
         signal setEngine(string uid)
+        signal setItemsCount(bool force)
 
         onSetEngine: directTransfer.setEngine(uid)
+        onSetItemsCount: directTransfer.updateCounts(force)
 
         DirectTransfer { id: directTransfer }
     }

--- a/nxdrive/data/qml/SystrayTransfer.qml
+++ b/nxdrive/data/qml/SystrayTransfer.qml
@@ -60,9 +60,9 @@ Rectangle {
                     var engine_uid = engine || accountSelect.getRole("uid")
                     var nature = download ? "download" : "upload"
                     if (paused) {
-                        api.resume_transfer(nature, engine_uid, uid)
+                        api.resume_transfer(nature, engine_uid, uid, false)
                     } else {
-                        api.pause_transfer(nature, engine_uid, uid, progress)
+                        api.pause_transfer(nature, engine_uid, uid, progress, false)
                     }
                 }
             }

--- a/nxdrive/data/qml/TransferItem.qml
+++ b/nxdrive/data/qml/TransferItem.qml
@@ -21,7 +21,7 @@ Rectangle {
 
         // Progression: transferred data
         ScaledText {
-            text: qsTr("DIRECT_TRANSFER_DETAILS").arg(Math.floor(progress || 0.0)).arg(progress_metrics[0]).arg(progress_metrics[1]) + tl.tr
+            text: qsTr("DIRECT_TRANSFER_DETAILS").arg(progress).arg(transferred).arg(size) + tl.tr
             color: darkGray
             Layout.leftMargin: icon.width + 5
             font.pointSize: point_size * 0.8

--- a/nxdrive/data/qml/TransferItem.qml
+++ b/nxdrive/data/qml/TransferItem.qml
@@ -21,7 +21,7 @@ Rectangle {
 
         // Progression: transferred data
         ScaledText {
-            text: qsTr("DIRECT_TRANSFER_DETAILS").arg(progress).arg(transferred).arg(size) + tl.tr
+            text: qsTr("DIRECT_TRANSFER_DETAILS").arg(progress).arg(transferred).arg(filesize) + tl.tr
             color: darkGray
             Layout.leftMargin: icon.width + 5
             font.pointSize: point_size * 0.8
@@ -75,9 +75,9 @@ Rectangle {
                     tooltip: qsTr(paused ? "RESUME" : "SUSPEND") + tl.tr
                     onClicked: {
                         if (paused) {
-                            api.resume_transfer("upload", engine, uid)
+                            api.resume_transfer("upload", engine, uid, true)
                         } else {
-                            api.pause_transfer("upload", engine, uid, progress)
+                            api.pause_transfer("upload", engine, uid, progress, true)
                         }
                     }
                 }
@@ -90,6 +90,7 @@ Rectangle {
                     iconColor: "red"
                     onClicked: {
                         application.confirm_cancel_transfer(engine, uid, name)
+                        directTransfer.updateCounts(true)
                     }
                 }
             }

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -272,7 +272,8 @@ class Processor(EngineWorker):
                 }
                 log.debug(f"Calling {handler_name}() on doc pair {doc_pair!r}")
 
-                self.pairSyncStarted.emit(self._current_metrics)
+                if "direct" not in handler_name:
+                    self.pairSyncStarted.emit(self._current_metrics)
                 soft_lock = self._lock_soft_path(doc_pair.local_path)
                 sync_handler(doc_pair)
 
@@ -282,7 +283,8 @@ class Processor(EngineWorker):
                         pair, self.local.abspath(pair.local_path)
                     )
 
-                self.pairSyncEnded.emit(self._current_metrics)
+                if "direct" not in handler_name:
+                    self.pairSyncEnded.emit(self._current_metrics)
             except ThreadInterrupt:
                 self.engine.queue_manager.push(doc_pair)
                 raise
@@ -498,7 +500,7 @@ class Processor(EngineWorker):
                 f"Cancelling Direct Transfer of {file!r} because it does not exist anymore"
             )
             self.dao.remove_state(doc_pair)
-            self.dao.remove_transfer("upload", file)
+            self.dao.remove_transfer("upload", file, is_direct_transfer=True)
             self.engine.directTranferError.emit(file)
             return
 

--- a/nxdrive/objects.py
+++ b/nxdrive/objects.py
@@ -456,6 +456,7 @@ class Transfer:
     is_direct_transfer: bool = False
     progress: float = 0.0
     doc_pair: Optional[int] = None
+    filesize: int = 0
 
     def __post_init__(self) -> None:
         self.name = self.path.name
@@ -464,7 +465,6 @@ class Transfer:
 @dataclass
 class Download(Transfer):
     transfer_type: str = field(init=False, default="download")
-    filesize: int = 0
     tmpname: Optional[Path] = None
     url: Optional[str] = None
 

--- a/tests/unit/test_action.py
+++ b/tests/unit/test_action.py
@@ -51,7 +51,7 @@ def test_action_with_values():
 
 def test_download_action():
     filepath = Path("fake/test.odt")
-    action = DownloadAction(filepath)
+    action = DownloadAction(filepath, 0)
     assert action.type == "Download"
 
     Action.finish_action()
@@ -64,7 +64,7 @@ def test_file_action(tmp):
     filepath = parent / "test.txt"
     size = filepath.write_bytes(b"This is Sparta!")
 
-    action = FileAction("Mocking", filepath)
+    action = FileAction("Mocking", filepath, size)
     assert action.type == "Mocking"
     assert not action.empty
 
@@ -94,7 +94,7 @@ def test_file_action_empty_file(tmp):
     filepath = parent / "test.txt"
     filepath.touch()
 
-    action = FileAction("Mocking", filepath)
+    action = FileAction("Mocking", filepath, filepath.stat().st_size)
 
     assert action.empty
     assert not action.uploaded
@@ -119,15 +119,15 @@ def test_file_action_inexistant_file(tmp):
     parent.mkdir()
     filepath = parent / "test.txt"
 
-    action = FileAction("Mocking", filepath)
-    assert not action.empty
+    action = FileAction("Mocking", filepath, 0)
+    assert action.empty
     assert not action.uploaded
 
     details = action.export()
     assert details["action_type"] == "Mocking"
     assert details["progress"] == 0.0
     assert isinstance(details["uid"], str)
-    assert details["size"] == -1.0
+    assert details["size"] == 0
     assert details["name"] == filepath.name
     assert details["filepath"] == str(filepath)
 
@@ -214,7 +214,7 @@ def test_upload_action(tmp):
     filepath = folder / "test-upload.txt"
     filepath.write_bytes(b"This is Sparta!")
 
-    action = UploadAction(filepath)
+    action = UploadAction(filepath, filepath.stat().st_size)
     assert action.type == "Upload"
 
     Action.finish_action()
@@ -227,7 +227,7 @@ def test_verification_action(tmp):
     filepath = folder / "test.txt"
     filepath.write_bytes(b"This is Sparta!")
 
-    action = VerificationAction(filepath)
+    action = VerificationAction(filepath, filepath.stat().st_size)
     assert action.type == "Verification"
 
     Action.finish_action()
@@ -240,7 +240,7 @@ def test_finalization_action(tmp):
     filepath = folder / "test.txt"
     filepath.write_bytes(b"This is Sparta!")
 
-    action = LinkingAction(filepath)
+    action = LinkingAction(filepath, filepath.stat().st_size)
     assert action.type == "Linking"
 
     Action.finish_action()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -495,7 +495,7 @@ def test_get_tree_list():
 
     # Check we got all paths
     expected_paths = [path] + sorted(path.glob("**/*"))
-    guessed_paths = sorted(p for p, _ in tree)
+    guessed_paths = sorted(p for p, *_ in tree)
     assert guessed_paths == expected_paths
 
     # Check we got correct remote paths
@@ -508,7 +508,7 @@ def test_get_tree_list():
         else:
             expected_rpaths.append(rpath)
     expected_rpaths = sorted(expected_rpaths)
-    guessed_rpaths = sorted(p for _, p in tree)
+    guessed_rpaths = sorted(p for _, p, _ in tree)
     assert guessed_rpaths == expected_rpaths
 
 
@@ -528,7 +528,6 @@ def test_get_tree_list_subdir_raise_os_error(mock_scandir):
     remote_ref = f"{env.WS_DIR}/foo"
     mock_scandir.return_value.__enter__.return_value = iter(
         [
-            FakeDirEntry(),
             FakeDirEntry(is_dir=True),
             FakeDirEntry(
                 is_dir=True,
@@ -540,7 +539,7 @@ def test_get_tree_list_subdir_raise_os_error(mock_scandir):
     tree = list(nxdrive.utils.get_tree_list(Path("/fake"), remote_ref))
 
     # We did not go into the third FakeDir because of OSError
-    assert len(tree) == 3
+    assert len(tree) == 2
 
 
 def test_get_tree_size():


### PR DESCRIPTION
- Do less work on the QML side.
- Improved upload file size computation: it is now done one-time only.
- Fixed duplicate prevention for documents without blobs.
- File size is only computed once for all `FileAction`s.
- Fixed `KeyError` in `BaseUploader.upload_chunks()` (`upload_idx`).
- A small sync icon + count is displayed at the bottom right.
- Items to transfer are first added to the database and then started. This is proper and will prevent GUI freeze because of too many bidirectional database access.

See my comment on https://jira.nuxeo.com/browse/NXDRIVE-2221 for more details + perf reports.
