### PR TITLE
NXDRIVE-2226: Disable temporarily S3 capability

### DIFF
--- a/docs/changes/4.4.4.md
+++ b/docs/changes/4.4.4.md
@@ -19,6 +19,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2188](https://jira.nuxeo.com/browse/NXDRIVE-2188): Remove the Hebrew language
 - [NXDRIVE-2190](https://jira.nuxeo.com/browse/NXDRIVE-2190): Refactored Remote client uploads
 - [NXDRIVE-2191](https://jira.nuxeo.com/browse/NXDRIVE-2191): Introduced the `State` object
+- [NXDRIVE-2226](https://jira.nuxeo.com/browse/NXDRIVE-2226): Disable temporarily S3 capability
 
 ### Direct Edit
 
@@ -160,3 +161,4 @@ Release date: `2020-xx-xx`
 - Added `Engine.cancel_upload()`
 - Added `Remote.cancel_batch()`
 - Added `Application.confirm_cancel_transfer()`
+- features.py::`DisabledFeatures`

--- a/nxdrive/data/qml/FeaturesTab.qml
+++ b/nxdrive/data/qml/FeaturesTab.qml
@@ -41,6 +41,7 @@ Rectangle {
 
                         text: item[0] + (beta_features.includes(item[1]) ? sup_tag: "")
                         checked: manager.get_feature_state(item[1])
+                        enabled: !disabled_features.includes(item[1])
                         onClicked: manager.set_feature_state(item[1], checked)
                         Layout.leftMargin: -5
                     }

--- a/nxdrive/feature.py
+++ b/nxdrive/feature.py
@@ -25,4 +25,6 @@ Feature = SimpleNamespace(
     auto_update=True, direct_edit=True, direct_transfer=False, s3=False,
 )
 
-Beta = ["direct_transfer"]
+Beta = ["direct_transfer", "s3"]
+
+DisabledFeatures = ["s3"]

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -43,7 +43,7 @@ from ..constants import (
 )
 from ..engine.activity import Action
 from ..engine.engine import Engine
-from ..feature import Beta, Feature
+from ..feature import Beta, DisabledFeatures, Feature
 from ..gui.folders_dialog import DialogMixin, DocumentsDialog, FoldersDialog
 from ..notification import Notification
 from ..options import Options
@@ -372,6 +372,7 @@ class Application(QApplication):
         context.setContextProperty("feat_direct_edit", Feature.direct_edit)
         context.setContextProperty("feat_direct_transfer", Feature.direct_transfer)
         context.setContextProperty("beta_features", Beta)
+        context.setContextProperty("disabled_features", DisabledFeatures)
         context.setContextProperty("tl", Translator.singleton)
         context.setContextProperty(
             "nuxeoVersionText", f"{APP_NAME} {self.manager.version}"

--- a/nxdrive/options.py
+++ b/nxdrive/options.py
@@ -50,7 +50,7 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Set, Tuple, Union
 
-from .feature import Feature
+from .feature import DisabledFeatures, Feature
 
 __all__ = ("Options",)
 
@@ -370,6 +370,10 @@ class MetaOptions(type):
 
         # Normalize the option
         item = item.replace("-", "_").replace(".", "_").lower()
+
+        if item.replace("feature_", "") in DisabledFeatures:
+            log.warning(f"{item!r} cannot be changed.")
+            return
 
         try:
             old_value, old_setter = MetaOptions.options[item]


### PR DESCRIPTION
Due to NXDRIVE-2210, the S3 feature is now temporarily disabled.

Changelog has been updated.