### PR TITLE
NXDRIVE-2206: [macOS] Fix favorites unregistering process

### DIFF
--- a/docs/changes/4.4.4.md
+++ b/docs/changes/4.4.4.md
@@ -19,6 +19,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2188](https://jira.nuxeo.com/browse/NXDRIVE-2188): Remove the Hebrew language
 - [NXDRIVE-2190](https://jira.nuxeo.com/browse/NXDRIVE-2190): Refactored Remote client uploads
 - [NXDRIVE-2191](https://jira.nuxeo.com/browse/NXDRIVE-2191): Introduced the `State` object
+- [NXDRIVE-2206](https://jira.nuxeo.com/browse/NXDRIVE-2206): [macOS] Fix the favorites unregistering process
 - [NXDRIVE-2226](https://jira.nuxeo.com/browse/NXDRIVE-2226): Disable temporarily S3 capability
 
 ### Direct Edit

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -704,6 +704,7 @@ class Engine(QObject):
         except Exception:
             log.exception("Unbind error")
 
+        self.manager.osi.unwatch_folder(self.local_folder)
         self.manager.osi.unregister_folder_link(self.local_folder)
 
         self.dispose_db()

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -715,7 +715,7 @@ class Application(QApplication):
     @pyqtSlot()  # From systray.py
     @pyqtSlot(str)  # All other calls
     def show_settings(self, section: str = "General") -> None:
-        sections = {"General": 0, "Accounts": 1, "About": 2}
+        sections = {"General": 0, "Features": 1, "Accounts": 2, "About": 3}
         self._window_root(self.settings_window).setSection.emit(sections[section])
         self._show_window(self.settings_window)
 

--- a/nxdrive/manager.py
+++ b/nxdrive/manager.py
@@ -817,9 +817,6 @@ class Manager(QObject):
         if not engine:
             return
 
-        # Unwatch folder
-        self.osi.unwatch_folder(engine.local_folder)
-        engine.suspend()
         engine.unbind()
         self.dao.delete_engine(uid)
 


### PR DESCRIPTION
The interesting error was:
```python
Traceback (most recent call last):
  File "osi/darwin/darwin.py", line 340, in unregister_folder_link
    LSSharedFileListItemRemove(favorites, item)
ValueError: NSInvalidArgumentException - -[__NSCFString identifier]: unrecognized selector sent to instance 0x7fa036c71f50
```

---

Also a small fix in the same area:

- NXDRIVE-2138: Fix Account display on no account