### PR TITLE
NXDRIVE-2231: [Direct Transfer] Improve the NXQL duplicate check

### DIFF
--- a/docs/changes/4.4.4.md
+++ b/docs/changes/4.4.4.md
@@ -193,3 +193,5 @@ Release date: `2020-xx-xx`
 - Added `size` positional argument to `LinkingAction`
 - Added `size` positional argument to `UploadAction`
 - Added `size` positional argument to `VerificationAction`
+- Added `page_size` keyword argument to `Remote.query()`
+- Added `current_page_index` keyword argument to `Remote.query()`

--- a/nxdrive/client/uploader/__init__.py
+++ b/nxdrive/client/uploader/__init__.py
@@ -285,6 +285,8 @@ class BaseUploader:
         # Remove additional parameters to prevent a BadQuery
         kwargs.pop("engine_uid", None)
         kwargs.pop("is_direct_edit", None)
+        kwargs.pop("remote_parent_path", None)
+        kwargs.pop("remote_parent_ref", None)
         file_path = kwargs.pop("file_path", None)
 
         headers = kwargs.pop("headers", {})

--- a/nxdrive/client/uploader/direct_transfer.py
+++ b/nxdrive/client/uploader/direct_transfer.py
@@ -28,9 +28,12 @@ class DirectTransferUploader(BaseUploader):
         """
         name = self.remote._escape(name)
         query = (
-            "SELECT * FROM Document WHERE "
-            f"ecm:parentId = '{parent_ref}' AND dc:title = '{name}'"
-            " AND ecm:isVersion = 0 AND ecm:isTrashed = 0 LIMIT 1"
+            "SELECT * FROM Document"
+            f" WHERE ecm:parentId = '{parent_ref}' AND dc:title = '{name}'"
+            " AND ecm:mixinType != HiddenInNavigation"
+            " AND ecm:isProxy = 0"
+            " AND ecm:isVersion = 0"
+            " AND ecm:isTrashed = 0"
         )
         results = self.remote.query(query)["entries"]
         return Document.parse(results[0]) if results else None

--- a/tests/old_functional/__init__.py
+++ b/tests/old_functional/__init__.py
@@ -215,23 +215,19 @@ class RemoteBase(Remote):
 
     def get_children_info(self, ref: str, limit: int = 1000) -> List[NuxeoDocumentInfo]:
         ref = self._escape(self.check_ref(ref))
-        types = {
-            "Note",
-            "Workspace",
-            "Picture",
-            env.DOCTYPE_FILE,
-            env.DOCTYPE_FOLDERISH,
-        }
+        types = "', '".join(
+            ("Note", "Workspace", "Picture", env.DOCTYPE_FILE, env.DOCTYPE_FOLDERISH)
+        )
 
         query = (
             "SELECT * FROM Document"
-            "       WHERE ecm:parentId = '%s'"
-            "       AND ecm:primaryType IN ('%s')"
-            "       %s"
-            "       AND ecm:isVersion = 0"
-            "       ORDER BY dc:title, dc:created LIMIT %d"
-        ) % (ref, "', '".join(types), self._get_trash_condition(), limit)
-        entries = self.query(query)["entries"]
+            f"       WHERE ecm:parentId = '{ref}'"
+            f"         AND ecm:primaryType IN ('{types}')"
+            f"             {self._get_trash_condition()}"
+            "          AND ecm:isVersion = 0"
+            "     ORDER BY dc:title, dc:created"
+        )
+        entries = self.query(query, page_size=limit)["entries"]
         return self._filtered_results(entries)
 
     def get_content(self, fs_item_id: str, **kwargs: Any) -> Path:


### PR DESCRIPTION
The request is almost the same, but the "trick" is to use ElasticSearch instead of the current database.

The improvement is quite significative: for a folder containing 100,000 documents; the old way was taking up-to 15 seconds to complete. With the new way, it is a matter of milliseconds.