### PR TITLE
NXDRIVE-2232: Add an option to control the database batch size

### DIFF
--- a/docs/changes/4.4.4.md
+++ b/docs/changes/4.4.4.md
@@ -43,6 +43,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2219](https://jira.nuxeo.com/browse/NXDRIVE-2219): Display a remote folder icon for each transfer
 - [NXDRIVE-2220](https://jira.nuxeo.com/browse/NXDRIVE-2220): Asynchronous planification of uploads
 - [NXDRIVE-2221](https://jira.nuxeo.com/browse/NXDRIVE-2221): Improve performances to prevent GUI freezes
+- [NXDRIVE-2232](https://jira.nuxeo.com/browse/NXDRIVE-2232): Add an option to control the database batch size
 
 ## GUI
 
@@ -137,6 +138,7 @@ Release date: `2020-xx-xx`
 - Added `is_direct_transfer` keyword argument to `EngineDAO.resume_transfer()`
 - Added `is_direct_transfer` keyword argument to `EngineDAO.remove_transfer()`
 - Added `NuxeoDocumentInfo.is_proxy`
+- Added `Options.database_batch_size`
 - Added `Remote.get_note()`
 - Removed `Remote.direct_transfer()`. Use `DirectTransferUploader.upload()` instead.
 - Removed `Remote.get_document_or_none()`. Use `DirectTransferUploader.get_document_or_none()` instead.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,6 +46,7 @@ Parameter values are taken as is, except for booleans. In that case, you can spe
 | `chunk_limit` | 20 | int | 4.1.2 | Size in MiB above which files will be uploaded in chunks (if `chunk_upload` is `True`). Has to be above 0.
 | `chunk_size` | 20 | int | 4.1.2 | Size of the chunks in MiB. Has to be above 0 and lower or equal to 20.
 | `chunk_upload` | True | bool | 4.1.2 | Activate the upload in chunks for files bigger than `chunk_limit`.
+| `database_batch_size` | 256 | int | 4.4.4 | [Direct Transfer] When adding files into the database, the operation is done by batch instead of one at a time. This option controls the batch size.
 | `delay` | 30 | int | 2 | Define the delay before each remote check.
 | `feature` | [...](#features) | map | 4.4.2 | Application features that can be turned on/off on-demand.
 | `force-locale` | None | str | 2 | Force the reset to the language.

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -448,13 +448,17 @@ class Engine(QObject):
                         )
                     )
 
-        # Add all paths into the database to plan the upload, by batch of 100 items
+        # Add all paths into the database to plan the upload, by batch
+        bsize = Options.database_batch_size
+        log.info(
+            f"Planning items to Direct Transfer, database_batch_size is {bsize} ..."
+        )
         current_max_row_id = -1
-        for batch_items in grouper(items, 500):
+        for batch_items in grouper(items, bsize):
             row_id = self.dao.plan_many_direct_transfer_items(batch_items)
             if current_max_row_id == -1:
                 current_max_row_id = row_id
-            self.directTranferItemsCount.emit(True)
+            self.directTranferItemsCount.emit(False)
 
         log.info(f"Planned {len(items):,} item(s) to Direct Transfer, let's gooo!")
 

--- a/nxdrive/options.py
+++ b/nxdrive/options.py
@@ -228,6 +228,7 @@ class MetaOptions(type):
         "chunk_size": (20, "default"),
         "chunk_upload": (True, "default"),
         "client_version": (None, "default"),
+        "database_batch_size": (256, "default"),
         "debug": (False, "default"),
         "debug_pydev": (False, "default"),
         "delay": (30, "default"),


### PR DESCRIPTION
Introduced `Options.database_batch_size` defaults to 256.