### PR TITLE
NXDRIVE-2065: Remove headers and params

### DIFF
--- a/nxdrive/client/uploader/direct_transfer.py
+++ b/nxdrive/client/uploader/direct_transfer.py
@@ -95,8 +95,6 @@ class DirectTransferUploader(BaseUploader):
             file_path,
             "FileManager.Import",
             context={"currentDocument": remote_parent_path},
-            params={"overwite": True},  # NXP-29286
-            headers={"nx-es-sync": "true", "X-Batch-No-Drop": "true"},
             engine_uid=engine_uid,
             is_direct_transfer=True,
             remote_parent_path=remote_parent_path,


### PR DESCRIPTION
- Using the `X-Batch-No-Drop` header is not for our use case.
- Using the `nx-es-sync` header is a bad idea as it will start a synchronous thread just to try to wait for ES, which is async by design. For big uploads (files count) it will just start many threads for no real benefits for us.
- Using the `overwite` param is not a good idea as it would just create another document with the same name and thus generating duplicates. Even if we are doing a pre-check, concurrency can always catch us.