### PR TITLE
NXDRIVE-2232: Better signal management

### DIFF
--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -458,8 +458,9 @@ class Engine(QObject):
             row_id = self.dao.plan_many_direct_transfer_items(batch_items)
             if current_max_row_id == -1:
                 current_max_row_id = row_id
-            self.directTranferItemsCount.emit(True)
+            self.directTranferItemsCount.emit(False)
 
+        self.directTranferItemsCount.emit(True)
         log.info(f"Planned {len(items):,} item(s) to Direct Transfer, let's gooo!")
 
         # And add new pairs to the queue


### PR DESCRIPTION
The idea is to not force the signal when doing batch insertions and force a signal call when all items are added.

This will go easier on the database when adding a lot of files, and still it will works when adding only one file.