### PR TITLE
NXDRIVE-2231: Partly revert the patch

### DIFF
--- a/docs/changes/4.4.4.md
+++ b/docs/changes/4.4.4.md
@@ -195,5 +195,3 @@ Release date: `2020-xx-xx`
 - Added `size` positional argument to `LinkingAction`
 - Added `size` positional argument to `UploadAction`
 - Added `size` positional argument to `VerificationAction`
-- Added `page_size` keyword argument to `Remote.query()`
-- Added `current_page_index` keyword argument to `Remote.query()`

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -613,16 +613,8 @@ class Remote(Nuxeo):
                 ref = self._base_folder_path + ref
         return ref
 
-    def query(
-        self, query: str, page_size: int = 1, current_page_index: int = 0
-    ) -> Dict[str, Any]:
-        url = f"{self.client.api_path}/query"
-        params = {
-            "pageSize": page_size,
-            "currentPageIndex": current_page_index,
-            "query": query,
-        }
-        return self.client.request("GET", url, params=params).json()
+    def query(self, query: str) -> Dict[str, Any]:
+        return self.execute(command="Document.Query", query=query)
 
     def get_info(
         self, ref: str, raise_if_missing: bool = True, fetch_parent_uid: bool = True

--- a/tests/old_functional/__init__.py
+++ b/tests/old_functional/__init__.py
@@ -213,7 +213,7 @@ class RemoteBase(Remote):
     def get_children(self, ref: str) -> Dict[str, Any]:
         return self.execute(command="Document.GetChildren", input_obj=f"doc:{ref}")
 
-    def get_children_info(self, ref: str, limit: int = 1000) -> List[NuxeoDocumentInfo]:
+    def get_children_info(self, ref: str) -> List[NuxeoDocumentInfo]:
         ref = self._escape(self.check_ref(ref))
         types = "', '".join(
             ("Note", "Workspace", "Picture", env.DOCTYPE_FILE, env.DOCTYPE_FOLDERISH)
@@ -227,7 +227,7 @@ class RemoteBase(Remote):
             "          AND ecm:isVersion = 0"
             "     ORDER BY dc:title, dc:created"
         )
-        entries = self.query(query, page_size=limit)["entries"]
+        entries = self.query(query)["entries"]
         return self._filtered_results(entries)
 
     def get_content(self, fs_item_id: str, **kwargs: Any) -> Path:


### PR DESCRIPTION
We finally can't rely on ES for that task. ES is intrinsically async and the query does not make sens anymore then. Restored the old behavior.

Also fixed the duplicate creation (the `overwite` parameter).

Another small improvement was done: if `replace_blob` is True, then no need to check for existent documents on the server.