### PR TITLE
NXDRIVE-2144: [Direct Edit] Prevent unintentional upload of files

### DIFF
--- a/docs/changes/4.4.5.md
+++ b/docs/changes/4.4.5.md
@@ -8,7 +8,7 @@ Release date: `2020-xx-xx`
 
 ### Direct Edit
 
-- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
+- [NXDRIVE-2144](https://jira.nuxeo.com/browse/NXDRIVE-2144): Prevent unintentional upload of files
 
 ### Direct Transfer
 

--- a/nxdrive/direct_edit.py
+++ b/nxdrive/direct_edit.py
@@ -196,7 +196,21 @@ class DirectEdit(Worker):
                 purge(child.path)
                 continue
 
-            ref = children[0].path
+            # Get filename stored in folder nxdirecteditname attribute
+            expected_name = self.local.get_remote_id(
+                child.path, name="nxdirecteditname"
+            )
+            if not expected_name:
+                continue
+
+            filtered = [file for file in children if file.name == expected_name]
+            # Folder doesn't contain the expected file so we do nothing.
+            if not filtered:
+                continue
+
+            # The expected file is found so we use it
+            ref = filtered[0].path
+
             try:
                 details = self._extract_edit_info(ref)
             except NotFound:
@@ -217,6 +231,10 @@ class DirectEdit(Worker):
                     continue
             except Exception:
                 log.exception("Unhandled clean-up error")
+                continue
+
+            # Other files are present next to the edited file, we should not delete them nor the edit file
+            if len(children) > 1:
                 continue
 
             # Place for handle reopened of interrupted Direct Edit


### PR DESCRIPTION
When Direct Edit'ing a file, a temporary file may be created next to
the edited file. During Drive startup, all the orphaned Direct Edit'ed files
are listed. If a temporary file is listed before the orphaned file then
it will be uploaded instead of the original file.

Some security has been added to prevent Drive from uploading these files
as it may result in data loss on Nuxeo.

Also changelog has been updated.