### PR TITLE
NXDRIVE-2225: Remove the server URL below the account name in the systray

### DIFF
--- a/docs/changes/4.4.5.md
+++ b/docs/changes/4.4.5.md
@@ -18,6 +18,7 @@ Release date: `2020-xx-xx`
 ## GUI
 
 - [NXDRIVE-2193](https://jira.nuxeo.com/browse/NXDRIVE-2193): Stop trying to guess the server URL
+- [NXDRIVE-2225](https://jira.nuxeo.com/browse/NXDRIVE-2225): Remove the server URL below the account name in the systray
 - [NXDRIVE-2241](https://jira.nuxeo.com/browse/NXDRIVE-2241): Review Popup Release Notes
 
 ## Packaging / Build
@@ -54,6 +55,7 @@ Release date: `2020-xx-xx`
 - Removed `Engine.directTranferDuplicateError` signal
 - Removed `Engine.direct_transfer_cancel()`
 - Removed `Engine.direct_transfer_replace_blob()`
+- Removed `Engine.get_remote_url()`. Use `server_url` attribute instead.
 - Removed `Engine.remove_staled_transfers()`
 - Added `State.has_crashed`
 - Removed `EngineDAO.update_pair_state()`
@@ -62,3 +64,4 @@ Release date: `2020-xx-xx`
 - Added utils.py::`test_url()`
 - Removed utils.py::`compute_urls()`
 - Removed utils.py::`guess_server_url()`
+- Added `QMLDriveApi.get_hostname_from_url()`

--- a/nxdrive/data/i18n/i18n.json
+++ b/nxdrive/data/i18n/i18n.json
@@ -238,7 +238,7 @@
     "OPEN_LOCAL": "Open local",
     "OPEN_REMOTE": "Open remote",
     "OPEN_ROOT_FOLDER": "Open %1 folder",
-    "OPEN_SERVER": "Browse Nuxeo server",
+    "OPEN_SERVER": "Open %1",
     "OPEN_SETTINGS": "Open settings",
     "OPEN_WINDOW": "Open window",
     "OPTIONS": "Options:",

--- a/nxdrive/data/qml/Systray.qml
+++ b/nxdrive/data/qml/Systray.qml
@@ -138,34 +138,15 @@ Rectangle {
                             doUpdateCounts()
                         }
                     }
-
-                    // The current account server URL
-                    ScaledText {
-                        id: accountUrl
-                        Layout.maximumWidth: parent.width
-                        text: accountSelect.getRole("server_url")
-                        font.pointSize: point_size * 0.8
-                        color: mediumGray
-
-                        MouseArea {
-                            id: urlHover
-                            z: parent.z + 10
-                            anchors.fill: parent
-                            anchors.margins: -3
-                            hoverEnabled: true
-                        }
-                        NuxeoToolTip {
-                            text: accountUrl.text
-                            visible: urlHover.containsMouse
-                        }
-                    }
                 }
 
                 // Icon 2: open remote server's URL
                 IconLabel {
+                    property string server_url: api.get_hostname_from_url(accountSelect.getRole("server_url"))
+
                     icon: MdiFont.Icon.nuxeo
                     onClicked: api.open_remote_server(accountSelect.getRole("uid"))
-                    tooltip: qsTr("OPEN_SERVER") + tl.tr
+                    tooltip: qsTr("OPEN_SERVER").arg(server_url) + tl.tr
                 }
 
                 // Icon 3: open local sync root folder

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -543,23 +543,6 @@ class Engine(QObject):
         }
         return urls[self.force_ui or self.wui]
 
-    def get_remote_url(self) -> str:
-        """
-        Build the server's URL based on the server's UI.
-        Default is Web-UI.  In case of unknown UI, use the default value.
-
-        :return: The complete URL.
-        """
-
-        urls = {
-            "jsf": (
-                f"{self.server_url}nxhome/{Options.remote_repo}/@view_home?"
-                "tabIds=USER_CENTER%3AuserCenterNuxeoDrive"
-            ),
-            "web": f"{self.server_url}ui/#!/drive",
-        }
-        return urls[self.force_ui or self.wui]
-
     def is_syncing(self) -> bool:
         return self._sync_started
 
@@ -583,7 +566,7 @@ class Engine(QObject):
 
     def open_remote(self, url: str = None) -> None:
         if url is None:
-            url = self.get_remote_url()
+            url = self.server_url
         self.manager.open_local_file(url)
 
     def resume(self) -> None:

--- a/nxdrive/gui/api.py
+++ b/nxdrive/gui/api.py
@@ -6,7 +6,7 @@ from os import getenv
 from os.path import abspath
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
-from urllib.parse import urlencode, urlsplit, urlunsplit
+from urllib.parse import urlencode, urlparse, urlsplit, urlunsplit
 
 import requests
 from nuxeo.exceptions import HTTPError, Unauthorized
@@ -351,6 +351,11 @@ class QMLDriveApi(QObject):
             self.application.show_direct_transfer_window(engine.uid)
         else:
             self.application.show_server_folders(engine, None)
+
+    @pyqtSlot(str, result=str)
+    def get_hostname_from_url(self, url: str) -> str:
+        urlp = urlparse(url)
+        return urlp.hostname or url
 
     @pyqtSlot(str)
     def open_remote_server(self, uid: str) -> None:

--- a/tests/functional/test_direct_edit.py
+++ b/tests/functional/test_direct_edit.py
@@ -211,7 +211,7 @@ def test_document_hijacking(manager_factory, obj_factory):
     """
     There are 2 situations we need to prevent:
 
-    1. Softwares LibreOffice or MS Office may leave temporary files behind them.
+    1. Software LibreOffice or MS Office may leave temporary files behind them.
     2. Someone could intentionally put a bad file in the good folder.
 
     Both will corrupt the remote document (data loss) at the next startup.

--- a/tools/whitelist.py
+++ b/tools/whitelist.py
@@ -54,6 +54,7 @@ QMLDriveApi.get_disk_space_info_to_width  # Used in QML
 QMLDriveApi.get_drive_disk_space  # Used in QML
 QMLDriveApi.get_features_list  # Used in QML
 QMLDriveApi.get_free_disk_space  # Used in QML
+QMLDriveApi.get_hostname_from_url  # Used in QML
 QMLDriveApi.get_used_space_without_synced  # Used in QML
 QMLDriveApi.get_proxy_settings  # Used in QML
 QMLDriveApi.get_update_url  # Used in QML


### PR DESCRIPTION
The server url in the systray has been removed and the Nuxeo icon action
tooltip has been updated.

Also changelog has been updated.