### PR TITLE
NXDRIVE-2245: Use safe_long_path() in old functional tests

### DIFF
--- a/docs/changes/4.4.5.md
+++ b/docs/changes/4.4.5.md
@@ -29,7 +29,7 @@ Release date: `2020-xx-xx`
 
 ## Tests
 
-- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
+- [NXDRIVE-245](https://jira.nuxeo.com/browse/NXDRIVE-2245): Use safe_long_path() in old functional tests
 
 ## Docs
 

--- a/nxdrive/client/local/base.py
+++ b/nxdrive/client/local/base.py
@@ -51,7 +51,7 @@ class FileInfo:
         # computation if the synchronization thread needs to be suspended
         self.digest_callback = kwargs.pop("digest_callback", None)
 
-        filepath = root / path
+        filepath = safe_long_path(root / path)
         self.path = Path(unicodedata.normalize("NFC", str(path)))
         self.filepath = Path(unicodedata.normalize("NFC", str(filepath)))
 

--- a/nxdrive/manager.py
+++ b/nxdrive/manager.py
@@ -55,7 +55,7 @@ from .utils import (
     get_default_local_folder,
     get_device,
     if_frozen,
-    normalized_path,
+    safe_long_path,
     save_config,
 )
 
@@ -97,7 +97,7 @@ class Manager(QObject):
         self._platform = get_current_os_full()
 
         # Primary attributes to allow initializing the notification center early
-        self.home: Path = normalized_path(home)
+        self.home: Path = safe_long_path(home)
         self.home.mkdir(exist_ok=True)
 
         if self.home not in Manager._instances:

--- a/tests/old_functional/common.py
+++ b/tests/old_functional/common.py
@@ -21,7 +21,7 @@ from nxdrive.engine.watcher.local_watcher import WIN_MOVE_RESOLUTION_PERIOD
 from nxdrive.manager import Manager
 from nxdrive.options import Options
 from nxdrive.translator import Translator
-from nxdrive.utils import normalized_path
+from nxdrive.utils import safe_long_path
 from PyQt5.QtCore import QCoreApplication, QTimer, pyqtSignal, pyqtSlot
 from sentry_sdk import configure_scope
 
@@ -50,7 +50,7 @@ log = getLogger(__name__)
 DEFAULT_WAIT_SYNC_TIMEOUT = 10
 FILE_CONTENT = b"Lorem ipsum dolor sit amet ..."
 FAKER = Faker("en_US")
-LOCATION = normalized_path(__file__).parent.parent
+LOCATION = safe_long_path(__file__).parent.parent
 
 
 Translator(LOCATION / "resources" / "i18n")
@@ -181,9 +181,7 @@ class TwoUsersTest(TestCase):
         self._remote_changes_count = {}
         self._no_remote_changes = {}
 
-        self.tmpdir = (
-            normalized_path(tempfile.gettempdir()) / str(uuid4()).split("-")[0]
-        )
+        self.tmpdir = safe_long_path(tempfile.gettempdir()) / str(uuid4()).split("-")[0]
         self.upload_tmp_dir = self.tmpdir / "uploads"
         self.upload_tmp_dir.mkdir(parents=True)
 


### PR DESCRIPTION
Some old functional tests were broken as they don't use the
Windows long path prefix. The safe_long_path() method is 
now used to handle it.

Also changelog has been updated.