### PR TITLE
NXDRIVE-2259: Fix

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -26,10 +26,8 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: docker-private.packages.nuxeo.com/drive
-        registry: docker-private.packages.nuxeo.com
+        repository: docker-private.packages.nuxeo.com
         build_args: VERSION=${{ github.event.inputs.buildVersion }},SCM_REF=${{ env.GITHUB_SHA }}
         dockerfile: tools/linux/Dockerfile
         tags: nuxeo-drive-build:py-${{ github.event.inputs.pythonVersion }}
-        tag_with_sha: true
         push: true


### PR DESCRIPTION
    invalid argument "docker-private.packages.nuxeo.com/docker-private.packages.nuxeo.com/drive:nuxeo-drive-build:py-3.7.7"
    for "-t, --tag" flag: invalid reference format