### PR TITLE
NXDRIVE-2259: This is the good one (hopefully)

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -27,8 +27,8 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         registry: docker-private.packages.nuxeo.com
-        repository: drive
+        repository: nuxeo-drive-build
         build_args: VERSION=${{ github.event.inputs.buildVersion }},SCM_REF=${{ env.GITHUB_SHA }}
         dockerfile: tools/linux/Dockerfile
-        tags: nuxeo-drive-build:py-${{ github.event.inputs.pythonVersion }}
+        tags: py-${{ github.event.inputs.pythonVersion }}
         push: true


### PR DESCRIPTION
    invalid argument "docker-private.packages.nuxeo.com/drive:nuxeo-drive-build:py-3.7.7"
    for "-t, --tag" flag: invalid reference format