### PR TITLE
NXDRIVE-2267: [Direct Transfer] Do not open the file selection box on click in the systray

### DIFF
--- a/docs/changes/4.4.5.md
+++ b/docs/changes/4.4.5.md
@@ -21,6 +21,7 @@ Release date: `2020-xx-xx`
 
 - [NXDRIVE-2019](https://jira.nuxeo.com/browse/NXDRIVE-2019): Enable folder uploads
 - [NXDRIVE-2234](https://jira.nuxeo.com/browse/NXDRIVE-2234): Add a new graphical option to choose the duplicate behavior
+- [NXDRIVE-2267](https://jira.nuxeo.com/browse/NXDRIVE-2267): Do not open the file selection box on click in the systray
 
 ## GUI
 

--- a/nxdrive/gui/folders_dialog.py
+++ b/nxdrive/gui/folders_dialog.py
@@ -234,10 +234,6 @@ class FoldersDialog(DialogMixin):
 
         self.button_ok_state()
 
-        # Open the files selection dialog if there is no pre-selected paths
-        if not self.paths:
-            self._select_more_files()
-
     def _add_group_local(self) -> QGroupBox:
         """Group box for source files."""
         groupbox = QGroupBox(Translator.get("SOURCE_FILES"))


### PR DESCRIPTION
The file picker is not opened anymore when clicking on the Direct Transfer icon in the systray menu. Now that
folders can also be uploaded, the remote selection window with the add folder button is opened instead to avoid
any confusion.

Also changelog has been updated.