### PR TITLE
NXDRIVE-2266: [Direct Transfer] Should ignore same file patterns as the sync engine

### DIFF
--- a/docs/changes/4.4.5.md
+++ b/docs/changes/4.4.5.md
@@ -21,6 +21,7 @@ Release date: `2020-xx-xx`
 
 - [NXDRIVE-2019](https://jira.nuxeo.com/browse/NXDRIVE-2019): Enable folder uploads
 - [NXDRIVE-2234](https://jira.nuxeo.com/browse/NXDRIVE-2234): Add a new graphical option to choose the duplicate behavior
+- [NXDRIVE-2266](https://jira.nuxeo.com/browse/NXDRIVE-2266): Should ignore same file patterns as the sync engine
 - [NXDRIVE-2267](https://jira.nuxeo.com/browse/NXDRIVE-2267): Do not open the file selection box on click in the systray
 
 ## GUI

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -430,12 +430,20 @@ class Engine(QObject):
         items = []
 
         for local_path in sorted(local_paths):
+            name = local_path.name
+            if name.startswith(Options.ignored_prefixes) or name.endswith(
+                Options.ignored_suffixes
+            ):
+                log.debug(
+                    f"Cannot add {local_path!r} to Direct Transfer queue as it is ignored."
+                )
+                continue
             if local_path.is_file():
                 items.append(
                     (
                         str(local_path),
                         str(local_path.parent),
-                        local_path.name,
+                        name,
                         False,
                         local_path.stat().st_size,
                         remote_parent_path,
@@ -447,13 +455,21 @@ class Engine(QObject):
             else:
                 tree = sorted(get_tree_list(local_path, remote_parent_path))
                 for path, remote_subparent_path, size in tree:
+                    name = path.name
+                    if name.startswith(Options.ignored_prefixes) or name.endswith(
+                        Options.ignored_suffixes
+                    ):
+                        log.debug(
+                            f"Cannot add {path!r} to Direct Transfer queue as it is ignored."
+                        )
+                        continue
                     remote_state = "unknown" if path == local_path else "todo"
                     folderish = path.is_dir()
                     items.append(
                         (
                             str(path),
                             str(path.parent),
-                            path.name,
+                            name,
                             folderish,
                             size,
                             remote_subparent_path,


### PR DESCRIPTION
Hidden files are now ignored during Direct Transfer.

Also changelog has been updated.