### PR TITLE
NXDRIVE-2241: Skip the release notes popup on alpha versions

### DIFF
--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -1146,7 +1146,7 @@ class Application(QApplication):
         channel = self.manager.get_update_channel()
         log.info(f"Showing release notes, version={version!r} channel={channel}")
 
-        if channel == "alpha":
+        if version.count(".") != 2:  # Alpha version
             return
 
         self.display_info(


### PR DESCRIPTION
Rely on the version rather than on the update channel as it would show release notes when using an alpha version and having the update channel set to something else than alpha.