### PR TITLE
NXDRIVE-2147: [Direct Edit] Add a maximum retry count for items in the upload queue

### DIFF
--- a/docs/changes/4.4.5.md
+++ b/docs/changes/4.4.5.md
@@ -17,6 +17,7 @@ Release date: `2020-xx-xx`
 ### Direct Edit
 
 - [NXDRIVE-2144](https://jira.nuxeo.com/browse/NXDRIVE-2144): Prevent unintentional upload of files
+- [NXDRIVE-2147](https://jira.nuxeo.com/browse/NXDRIVE-2147): Add a maximum retry count for items in the upload queue
 
 ### Direct Transfer
 

--- a/nxdrive/data/i18n/i18n.json
+++ b/nxdrive/data/i18n/i18n.json
@@ -86,6 +86,7 @@
     "DIRECT_EDIT_UNLOCK_ERROR": "Unlocking issue",
     "DIRECT_EDIT_UNLOCK_ERROR_DESCRIPTION": "The document \"%1\" was not unlocked",
     "DIRECT_EDIT_UPDATED_FILE": "The file \"%1\" has been updated",
+    "DIRECT_EDIT_UPLOAD_FAILED": "Failed to upload changes for \"%1\"",
     "DIRECT_EDIT_VERSION": "You are trying to perform a Direct Edit on version %1 of \"%2\". It is not the current version of the document, so it is readonly and cannot be edited.",
     "DIRECT_TRANSFER_CANCEL": "Confirm the cancellation of the transfer of \"%1\"?",
     "DIRECT_TRANSFER_DETAILS": "[%1%] %2 of %3",

--- a/nxdrive/engine/blacklist_queue.py
+++ b/nxdrive/engine/blacklist_queue.py
@@ -57,7 +57,7 @@ class BlacklistQueue:
     def push(self, path: Path) -> None:
         with self._lock:
             item = BlacklistItem(path, next_try=self._delay)
-            log.debug(f"Blacklisting {item!r}")
+            log.debug(f"Blacklisting {item!r} for {self._delay} seconds")
             self._queue[path] = item
 
     def repush(self, item: BlacklistItem, increase_wait: bool = True) -> None:


### PR DESCRIPTION
Unhandled error while uploading a file where retried indefinitely.
This was quite bad as it exploded server logs, client logs and
the Sentry quote. From now, a failing upload will be tried 3 times
before being dropped from the upload_queue.

Also changelog has been updated.