### PR TITLE
NXDRIVE-2266: Fix file patterns filtering

### DIFF
--- a/docs/changes/4.4.5.md
+++ b/docs/changes/4.4.5.md
@@ -77,6 +77,8 @@ Release date: `2020-xx-xx`
 - Added `DirectTransferUploader.upload_folder()`
 - Added `DocPair.duplicate_behavior`
 - Added `username` argument to `Engine.update_token()`
+- Changed `local_paths` argument type from `Set[Path]` to `Dict[Path, int]` for `Enfine.direct_transfer()`
+- Changed `local_paths` argument type from `Set[Path]` to `Dict[Path, int]` for `Enfine.direct_transfer_async()`
 - Removed `Engine.directTranferDuplicateError` signal
 - Removed `Engine.direct_transfer_cancel()`
 - Removed `Engine.direct_transfer_replace_blob()`
@@ -96,6 +98,9 @@ Release date: `2020-xx-xx`
 - Added commandline.py::`HealthCheck`
 - Removed exceptions.py::`DirectTransferDuplicateFoundError`
 - Added utils.py::`test_url()`
+- Changed return type of utils.py::`get_tree_list()` from `Generator[Tuple[Path, str, int], None, None]` to `Generator[Tuple[Path, int], None, None]`
+- Removed `remote_ref` argument from utils.py::`get_tree_list()`
 - Removed utils.py::`compute_urls()`
+- Removed utils.py::`get_tree_size()`
 - Removed utils.py::`guess_server_url()`
 - Added `QMLDriveApi.get_hostname_from_url()`


### PR DESCRIPTION
Let's image a folder containing:

    sources
    └── repos
    │   │   └── file.ext
    .tox
    ├── base
    │   ├── bin
    │   │   └── activate.sh
    logs.txt
    .travis.yml

Before the patch, when selecting such folder, the ".tox" folder was filtered out, but not its contents.