### PR TITLE
NXDRIVE-2135: Check for proxy instantiation success when using a PAC

### DIFF
--- a/docs/changes/4.4.5.md
+++ b/docs/changes/4.4.5.md
@@ -4,6 +4,7 @@ Release date: `2020-xx-xx`
 
 ## Core
 
+- [NXDRIVE-2135](https://jira.nuxeo.com/browse/NXDRIVE-2135): Check for proxy instantexcexcexcexciation success when using a PAC
 - [NXDRIVE-2183](https://jira.nuxeo.com/browse/NXDRIVE-2183): Use `dict.copy()` for thread safety, better atomicity speed and memory efficiency
 - [NXDRIVE-2186](https://jira.nuxeo.com/browse/NXDRIVE-2186): Do not remove staled transfers at startup if the application crashed
 - [NXDRIVE-2210](https://jira.nuxeo.com/browse/NXDRIVE-2210): Fix files upload with S3 direct upload enabled

--- a/nxdrive/client/proxy.py
+++ b/nxdrive/client/proxy.py
@@ -186,13 +186,16 @@ def validate_proxy(proxy: Proxy, url: str) -> bool:
             url, headers=headers, proxies=proxy.settings(url=url), verify=verify
         ):
             return True
-    except OSError as exc:
+    except OSError:
         # OSError: Could not find a suitable TLS CA certificate bundle, invalid path: ...
-        log.critical(f"{exc}. Ensure the 'ca_bundle' option is correct.")
-        return False
+        log.error("Ensure the 'ca_bundle' option is correct.", exc_info=True)
+    except AttributeError:
+        log.error(
+            "Invalid PAC URL or invalid data retrieved from the PAC URL.", exc_info=True
+        )
     except Exception:
-        log.exception("Invalid proxy.")
-        return False
+        log.error("Invalid proxy.", exc_info=True)
+    return False
 
 
 def _get_cls(category: str) -> Type[Proxy]:

--- a/nxdrive/manager.py
+++ b/nxdrive/manager.py
@@ -590,7 +590,7 @@ class Manager(QObject):
         self.set_config("log_level_file", value)
 
     def set_proxy(self, proxy: "Proxy") -> str:
-        log.debug(f"Changed proxy to {proxy}")
+        log.debug(f"Trying to change proxy to {proxy}")
         for engine in self.engines.values():
             if not validate_proxy(proxy, engine.server_url):
                 return "PROXY_INVALID"


### PR DESCRIPTION
Also set a lower logging level on proxy validation error to prevent Sentry events spam.