### PR TITLE
NXDRIVE-2277: [Direct Edit] Changes not uploaded anymore when saving file on Windows

### DIFF
--- a/docs/changes/4.4.5.md
+++ b/docs/changes/4.4.5.md
@@ -19,6 +19,7 @@ Release date: `2020-xx-xx`
 
 - [NXDRIVE-2144](https://jira.nuxeo.com/browse/NXDRIVE-2144): Prevent unintentional upload of files
 - [NXDRIVE-2147](https://jira.nuxeo.com/browse/NXDRIVE-2147): Add a maximum retry count for items in the upload queue
+- [NXDRIVE-2277](https://jira.nuxeo.com/browse/NXDRIVE-2277): Changes not uploaded anymore when saving file on Windows
 
 ### Direct Transfer
 

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -512,7 +512,7 @@ def normalize_event_filename(filename: Union[str, Path], action: bool = True) ->
     normalized = normalized.with_name(safe_filename(normalized.name))
 
     if WINDOWS and path.exists():
-        path = normalized_path(path).with_name(path.name)
+        path = safe_long_path(path).with_name(path.name)
 
     if not MAC and action and path != normalized and path.exists():
         log.info(f"Forcing normalization: {path!r} -> {normalized!r}")


### PR DESCRIPTION
The error was due to a bad comparison in `utils.py::normalize_event_filename()`. 
The method has been fixed and now use windows long path.

Also changelog has been updated.