### PR TITLE
NXDRIVE-2180: Really fix the QML error when Direct Transfer'ring lot …

### DIFF
--- a/nxdrive/data/qml/TransferItem.qml
+++ b/nxdrive/data/qml/TransferItem.qml
@@ -8,7 +8,7 @@ import "icon-font/Icon.js" as MdiFont
 Rectangle {
     id: control
     property bool paused: status == "PAUSED" || status == "SUSPENDED"
-    width: parent.width || 500
+    width: parent ? parent.width : 0
     height: 55
 
     ColumnLayout {


### PR DESCRIPTION
…of small files

    TransferItem.qml:11: TypeError: Cannot read property 'width' of null

The old fix (2fe7ebf76ea212c238c5850bae0132a917d53dfe) was not effective.