### PR TITLE
NXDRIVE-2019: Do not fetch the database lazily to prevent deadlocks

### DIFF
--- a/docs/changes/4.4.5.md
+++ b/docs/changes/4.4.5.md
@@ -17,6 +17,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2272](https://jira.nuxeo.com/browse/NXDRIVE-2272): Save username changes when updating credentials
 - [NXDRIVE-2278](https://jira.nuxeo.com/browse/NXDRIVE-2278): Fix S3 direct upload key computation
 - [NXDRIVE-2279](https://jira.nuxeo.com/browse/NXDRIVE-2279): Use S3 accelerate endpoint when enabled
+- [NXDRIVE-2282](https://jira.nuxeo.com/browse/NXDRIVE-2282): Use a bigger SQL transaction timeout
 
 ### Direct Edit
 

--- a/nxdrive/engine/dao/sqlite.py
+++ b/nxdrive/engine/dao/sqlite.py
@@ -2183,7 +2183,7 @@ class EngineDAO(ConfigurationDAO):
     def get_downloads(self) -> Generator[Download, None, None]:
         con = self._get_read_connection()
         c = con.cursor()
-        for res in c.execute("SELECT * FROM Downloads"):
+        for res in c.execute("SELECT * FROM Downloads").fetchall():
             try:
                 status = TransferStatus(res.status)
             except ValueError:
@@ -2206,7 +2206,9 @@ class EngineDAO(ConfigurationDAO):
     def get_uploads(self) -> Generator[Upload, None, None]:
         con = self._get_read_connection()
         c = con.cursor()
-        for res in c.execute("SELECT * FROM Uploads WHERE is_direct_transfer = 0"):
+        for res in c.execute(
+            "SELECT * FROM Uploads WHERE is_direct_transfer = 0"
+        ).fetchall():
             try:
                 status = TransferStatus(res.status)
             except ValueError:
@@ -2230,7 +2232,9 @@ class EngineDAO(ConfigurationDAO):
         """Retrieve all Direct Transfer items (only needed details)."""
         con = self._get_read_connection()
         c = con.cursor()
-        for res in c.execute("SELECT * FROM Uploads WHERE is_direct_transfer = 1"):
+        for res in c.execute(
+            "SELECT * FROM Uploads WHERE is_direct_transfer = 1"
+        ).fetchall():
             yield Upload(
                 res.uid,
                 Path(res.path),
@@ -2247,7 +2251,9 @@ class EngineDAO(ConfigurationDAO):
         """
         con = self._get_read_connection()
         c = con.cursor()
-        for res in c.execute("SELECT * FROM Uploads WHERE is_direct_transfer = 1"):
+        for res in c.execute(
+            "SELECT * FROM Uploads WHERE is_direct_transfer = 1"
+        ).fetchall():
             path = Path(res.path)
             yield {
                 "uid": res.uid,

--- a/nxdrive/engine/dao/sqlite.py
+++ b/nxdrive/engine/dao/sqlite.py
@@ -307,6 +307,7 @@ class ConfigurationDAO(QObject):
             check_same_thread=False,
             factory=AutoRetryConnection,
             isolation_level=None,
+            timeout=10,
         )
         self.conn.row_factory = self._state_factory
         self._connections.append(self.conn)
@@ -346,6 +347,7 @@ class ConfigurationDAO(QObject):
                 check_same_thread=False,
                 factory=AutoRetryConnection,
                 isolation_level=None,
+                timeout=10,
             )
             self._conns.conn.row_factory = self._state_factory
             self._connections.append(self._conns.conn)


### PR DESCRIPTION
Also:
- NXDRIVE-2282: Use a bigger SQL transaction timeout