### PR TITLE
NXDRIVE-2019: Improve database queries

### DIFF
--- a/docs/changes/4.4.5.md
+++ b/docs/changes/4.4.5.md
@@ -99,6 +99,8 @@ Release date: `2020-xx-xx`
 - Removed `Engine.get_remote_url()`. Use `server_url` attribute instead.
 - Added `Engine.have_folder_upload`
 - Removed `Engine.remove_staled_transfers()`
+- Added `limit` keyword argument to `EngineDAO.get_dt_uploads_raw()`
+- Changed the return type of `EngineDAO.get_dt_uploads_raw()` from `Generator[Dict[str, Any], None, None]` to `List[Dict[str, Any]]`
 - Removed `Manager.get_tracker_id()`. Use `tracker.uid` attribute instead.
 - Added `username` argument to `QMLDriveApi.update_token()`
 - Removed `QMLDriveApi.get_tracker_id()`

--- a/nxdrive/gui/api.py
+++ b/nxdrive/gui/api.py
@@ -207,15 +207,8 @@ class QMLDriveApi(QObject):
         return result
 
     def get_direct_transfer_items(self, dao: EngineDAO) -> List[Dict[str, Any]]:
-        limit = 5  # 5 files are displayed in the DT window
-        result: List[Dict[str, Any]] = []
-
-        for count, transfer in enumerate(dao.get_dt_uploads_raw()):
-            if count >= limit:
-                break
-            result.append(transfer)
-
-        return result
+        # 5 files are displayed in the DT window
+        return dao.get_dt_uploads_raw(limit=5)
 
     @pyqtSlot(str, str, int, float, bool)
     def pause_transfer(


### PR DESCRIPTION
A small naive benchmark: Direct Transfer a folder containing 100 files.

- Before: ~ 281 req/s
- After:  ~ 352 req/s

From the UX POV, it feels like a significant gain on the overall upload speed.