### PR TITLE
NXDRIVE-2180: Fix more QML errors

### DIFF
--- a/nxdrive/data/qml/FileCard.qml
+++ b/nxdrive/data/qml/FileCard.qml
@@ -11,8 +11,9 @@ ShadowRectangle {
     property variant fileData
     property string type: fileData.state == "conflicted" ? "conflict" : "error"
 
-    width: parent.width - 10; height: cardContent.height + 40
-    anchors.horizontalCenter: parent.horizontalCenter
+    width: parent ? parent.width - 10 : 0
+    height: cardContent.height + 40
+    anchors.horizontalCenter: parent ? parent.horizontalCenter : undefined
 
     RowLayout {
         id: cardContent

--- a/nxdrive/data/qml/SystrayFile.qml
+++ b/nxdrive/data/qml/SystrayFile.qml
@@ -6,7 +6,8 @@ import "icon-font/Icon.js" as MdiFont
 Rectangle {
     id: control
     property variant fileData: model
-    width: parent.width; height: 55
+    width: parent ? parent.width : 0
+    height: 55
 
     ColumnLayout {
         anchors.fill: parent

--- a/nxdrive/data/qml/SystrayTransfer.qml
+++ b/nxdrive/data/qml/SystrayTransfer.qml
@@ -8,7 +8,7 @@ Rectangle {
     property variant fileData: model
     property bool paused: status == "PAUSED" || status == "SUSPENDED"
     property bool download: transfer_type == "download"
-    width: parent.width
+    width: parent ? parent.width : 0
     height: 55
 
     ColumnLayout {


### PR DESCRIPTION
    FileCard.qml:14: TypeError: Cannot read property 'width' of null
    FileCard.qml:15: TypeError: Cannot read property 'horizontalCenter' of null
    SystrayFile.qml:9: TypeError: Cannot read property 'width' of null
    SystrayTransfer.qml:11: TypeError: Cannot read property 'width' of null