### PR TITLE
NXDRIVE-2294: Improve logging of the transfer speed

### DIFF
--- a/docs/changes/4.4.5.md
+++ b/docs/changes/4.4.5.md
@@ -20,6 +20,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2282](https://jira.nuxeo.com/browse/NXDRIVE-2282): Use a bigger SQL transaction timeout
 - [NXDRIVE-2283](https://jira.nuxeo.com/browse/NXDRIVE-2283): Ensure that `get_tree_list()` can actually browse a folder
 - [NXDRIVE-2285](https://jira.nuxeo.com/browse/NXDRIVE-2285): Fix formatting issues following the upgrade to Black 20.8b1
+- [NXDRIVE-2294](https://jira.nuxeo.com/browse/NXDRIVE-2294): Improve logging of the transfer speed
 
 ### Direct Edit
 

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -154,7 +154,7 @@ class Remote(Nuxeo):
         if duration > 1_000_000_000:  # 1 second in nanoseconds
             # x 1,073,741,824 to counter the duration that is exprimed in nanoseconds
             speed = action.last_chunk_transfer_speed = (
-                action.chunk_size
+                (action.chunk_size or action.size)
                 * action.transferred_chunks
                 * 1_073_741_824.0
                 / duration


### PR DESCRIPTION
A small patch to prevent useless logs like:

    Chunk transfer speed was 0.0 B/s

When the transfer was too fast on small files.