### PR TITLE
NXDRIVE-1888: Improve database queries to anihile any deadlock

### DIFF
--- a/docs/changes/4.4.5.md
+++ b/docs/changes/4.4.5.md
@@ -4,6 +4,7 @@ Release date: `2020-xx-xx`
 
 ## Core
 
+- [NXDRIVE-1888](https://jira.nuxeo.com/browse/NXDRIVE-1888): Improve database queries to anihile any deadlock
 - [NXDRIVE-2135](https://jira.nuxeo.com/browse/NXDRIVE-2135): Check for proxy instantexcexcexcexciation success when using a PAC
 - [NXDRIVE-2183](https://jira.nuxeo.com/browse/NXDRIVE-2183): Use `dict.copy()` for thread safety, better atomicity speed and memory efficiency
 - [NXDRIVE-2186](https://jira.nuxeo.com/browse/NXDRIVE-2186): Do not remove staled transfers at startup if the application crashed

--- a/nxdrive/engine/dao/sqlite.py
+++ b/nxdrive/engine/dao/sqlite.py
@@ -284,8 +284,7 @@ class ConfigurationDAO(QObject):
             self.store_int(SCHEMA_VERSION, 1)
 
     def _init_db(self, cursor: Cursor) -> None:
-        # http://www.stevemcarthur.co.uk/blog/post/some-kind-of-disk-io-error-occurred-sqlite
-        cursor.execute("PRAGMA journal_mode = MEMORY")
+        cursor.execute("PRAGMA journal_mode = WAL")
         self._create_configuration_table(cursor)
 
     def _create_configuration_table(self, cursor: Cursor) -> None:


### PR DESCRIPTION
Before the patch, the journal mode was MEMORY, which is prone to data loss (and we saw it a lot!).

Now the "new" WAL mode is used, resulting in better integrity, no more data loss (even if the app crashes), and way better performances.