### PR TITLE
NXDRIVE-2301: [Direct Transfer] Handle a transfer cancel during sessions

### DIFF
--- a/docs/changes/4.4.5.md
+++ b/docs/changes/4.4.5.md
@@ -112,12 +112,14 @@ Release date: `2020-xx-xx`
 - Removed `Engine.get_remote_url()`. Use `server_url` attribute instead.
 - Added `Engine.have_folder_upload`
 - Added `Engine.directTransferSessionFinished`
+- Added `Engine.handle_session_status()`
 - Removed `Engine.remove_staled_transfers()`
 - Added `limit` keyword argument to `EngineDAO.get_dt_uploads_raw()`
 - Added `session` keyword argument to `EngineDAO.plan_many_direct_transfer_items()`
 - Added `EngineDao.get_session()`
 - Added `EngineDao.create_session()`
 - Added `EngineDao.update_session()`
+- Added `EngineDao.decrease_session_total()`
 - Changed the return type of `EngineDAO.get_dt_uploads_raw()` from `Generator[Dict[str, Any], None, None]` to `List[Dict[str, Any]]`
 - Added `engine` keyword argument to `LinkingAction`
 - Removed `Manager.get_tracker_id()`. Use `tracker.uid` attribute instead.

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -520,8 +520,7 @@ class Processor(EngineWorker):
 
         # Update session and send notification if status is DONE
         session = self.dao.update_session(doc_pair.session)
-        if session and session.status is TransferStatus.DONE:
-            self.engine.directTransferSessionFinished.emit(session.remote_path)
+        self.engine.handle_session_status(session)
 
         # For analytics
         self.engine.manager.directTransferStats.emit(doc_pair.folderish, doc_pair.size)


### PR DESCRIPTION
When a Direct Transfer session is ongoing, the user can cancel one
of the documents. The session is now updated when the user remove
an element from the Transfer session.

Also changelog has been updated.