### PR TITLE
NXDRIVE-2156: [Direct Transfer] Cleanup useless notification

### DIFF
--- a/docs/changes/4.4.5.md
+++ b/docs/changes/4.4.5.md
@@ -32,9 +32,9 @@ Release date: `2020-xx-xx`
 ### Direct Transfer
 
 - [NXDRIVE-2019](https://jira.nuxeo.com/browse/NXDRIVE-2019): Enable folder uploads
+- [NXDRIVE-2256](https://jira.nuxeo.com/browse/NXDRIVE-2156): Add a notification once transfer session is complete
 - [NXDRIVE-2234](https://jira.nuxeo.com/browse/NXDRIVE-2234): Add a new graphical option to choose the duplicate behavior
 - [NXDRIVE-2255](https://jira.nuxeo.com/browse/NXDRIVE-2255): Update the transfer list according to the selected account
-- [NXDRIVE-2256](https://jira.nuxeo.com/browse/NXDRIVE-2256): Add a notification once transfer session is complete
 - [NXDRIVE-2266](https://jira.nuxeo.com/browse/NXDRIVE-2266): Should ignore same file patterns as the sync engine
 - [NXDRIVE-2267](https://jira.nuxeo.com/browse/NXDRIVE-2267): Do not open the file selection box on click in the systray
 - [NXDRIVE-2268](https://jira.nuxeo.com/browse/NXDRIVE-2268): Best efforts to center a window on the screen
@@ -114,6 +114,7 @@ Release date: `2020-xx-xx`
 - Added `Engine.directTransferSessionFinished`
 - Added `Engine.handle_session_status()`
 - Removed `Engine.remove_staled_transfers()`
+- Removed `Engine.directTranferStatus`
 - Added `limit` keyword argument to `EngineDAO.get_dt_uploads_raw()`
 - Added `session` keyword argument to `EngineDAO.plan_many_direct_transfer_items()`
 - Added `EngineDao.get_session()`
@@ -137,6 +138,7 @@ Release date: `2020-xx-xx`
 - Renamed engine/blacklist_queue.py to blocklist_queue.py
 - Removed exceptions.py::`DirectTransferDuplicateFoundError`
 - Added notification.py::`DirectTransferSessionFinished`
+- Removed notification.py::`DirectTransferStatus`
 - Added objects.py::`Session`
 - Added tracker.py::`analytics_enabled()`
 - Added utils.py::`test_url()`

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -104,7 +104,6 @@ class Engine(QObject):
 
     # Direct Transfer
     directTranferError = pyqtSignal(Path)
-    directTranferStatus = pyqtSignal(Path, bool)
     directTranferItemsCount = pyqtSignal()
     directTransferSessionFinished = pyqtSignal(str)
 
@@ -420,7 +419,6 @@ class Engine(QObject):
         duplicate_behavior: str,
     ) -> None:
         """Plan the Direct Transfer."""
-        # self.directTranferStatus.emit(local_path[0], True)
 
         # Save the remote location for next times
         self._save_remote_parent_infos(

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -514,11 +514,7 @@ class Processor(EngineWorker):
         # Clean-up
         self.dao.remove_state(doc_pair, recursive=False)
 
-        # Display a notification only for files >= 25 MiB (to prevent notifications flood)
-        if not doc_pair.folderish and doc_pair.size >= 25 * 1024 * 1024:
-            self.engine.directTranferStatus.emit(path, False)
-
-        # Update session and send notification if status is DONE
+        # Update session then handle the status
         session = self.dao.update_session(doc_pair.session)
         self.engine.handle_session_status(session)
 

--- a/nxdrive/notification.py
+++ b/nxdrive/notification.py
@@ -435,21 +435,6 @@ class DirectTransferError(Notification):
         )
 
 
-class DirectTransferStatus(Notification):
-    """Display a notification when a Direct Transfer is starting or finished."""
-
-    def __init__(self, file: Path, status: bool) -> None:
-        label = "DIRECT_TRANSFER_START" if status else "DIRECT_TRANSFER_END"
-        values = [file.name]
-        super().__init__(
-            label,
-            title="Direct Transfer",
-            description=Translator.get(label, values=values),
-            level=Notification.LEVEL_INFO,
-            flags=Notification.FLAG_VOLATILE | Notification.FLAG_BUBBLE,
-        )
-
-
 class DirectTransferSessionFinished(Notification):
     """Display a notification when a Direct Transfer session is finished."""
 
@@ -532,7 +517,6 @@ class DefaultNotificationService(NotificationService):
         engine.errorOpenedFile.connect(self._errorOpenedFile)
         engine.longPathError.connect(self._longPathError)
         engine.directTranferError.connect(self._direct_transfer_error)
-        engine.directTranferStatus.connect(self._direct_transfer_status)
         engine.directTransferSessionFinished.connect(
             self._direct_transfer_session_finshed
         )
@@ -540,10 +524,6 @@ class DefaultNotificationService(NotificationService):
     def _direct_transfer_error(self, file: Path) -> None:
         """Display a notification when a Direct Transfer is in error."""
         self.send_notification(DirectTransferError(file))
-
-    def _direct_transfer_status(self, file: Path, status: bool) -> None:
-        """Display a notification when a Direct Transfer is starting or finished."""
-        self.send_notification(DirectTransferStatus(file, status))
 
     def _direct_transfer_session_finshed(self, remote_path: str) -> None:
         """Display a notification when a Direct Transfer session is finished."""


### PR DESCRIPTION
The notification on large file upload is not sent anymore.

Changelog has been updated.