### PR TITLE
NXDRIVE-2302: Use an adapter to store path-like objects in the database

### DIFF
--- a/docs/changes/4.4.5.md
+++ b/docs/changes/4.4.5.md
@@ -23,6 +23,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2285](https://jira.nuxeo.com/browse/NXDRIVE-2285): Fix formatting issues following the upgrade to Black 20.8b1
 - [NXDRIVE-2294](https://jira.nuxeo.com/browse/NXDRIVE-2294): Improve logging of the transfer speed
 - [NXDRIVE-2298](https://jira.nuxeo.com/browse/NXDRIVE-2298): Improve large file upload resiliency
+- [NXDRIVE-2302](https://jira.nuxeo.com/browse/NXDRIVE-2302): Use an adapter to store path-like objects in the database
 
 ### Direct Edit
 
@@ -143,6 +144,7 @@ Release date: `2020-xx-xx`
 - Removed notification.py::`DirectTransferStatus`
 - Added objects.py::`Session`
 - Added tracker.py::`analytics_enabled()`
+- Removed sqlite.py::`prepare_args()`
 - Added utils.py::`test_url()`
 - Changed return type of utils.py::`get_tree_list()` from `Generator[Tuple[Path, str, int], None, None]` to `Generator[Tuple[Path, int], None, None]`
 - Removed `remote_ref` argument from utils.py::`get_tree_list()`

--- a/tests/unit/test_engine_dao.py
+++ b/tests/unit/test_engine_dao.py
@@ -1,30 +1,9 @@
 # coding: utf-8
-import sys
 from pathlib import Path
 
-import pytest
-
 from nxdrive.constants import TransferStatus
-from nxdrive.engine.dao.sqlite import prepare_args
-from nxdrive.utils import WINDOWS
 
 from ..markers import windows_only
-
-
-@pytest.mark.parametrize(
-    "args, expected_args, skip",
-    [
-        (("a", "b", "c"), ("a", "b", "c"), False),
-        ((Path("a"),), ("/a",), False),
-        ((Path("/a"),), ("/a",), WINDOWS),
-        ((Path("C:\\a"),), ("C:/a",), not WINDOWS),
-        ((Path(),), ("/",), False),
-    ],
-)
-def test_prepare_args(args, expected_args, skip):
-    if skip:
-        pytest.skip(f"Not relevant on {sys.platform}")
-    assert prepare_args(args) == expected_args
 
 
 def test_acquire_processors(engine_dao):


### PR DESCRIPTION
The previous code allowing to store path-like objects in
the database was quite intrusive.

The code has been replaced by the usage of an sqlite adapter.

Also changelog has been updated.