### PR TITLE
NXDRIVE-2268: Fix a regression where the file would be uploaded again

### DIFF
--- a/nxdrive/client/uploader/direct_transfer.py
+++ b/nxdrive/client/uploader/direct_transfer.py
@@ -101,9 +101,6 @@ class DirectTransferUploader(BaseUploader):
                 remote_parent_ref=doc_pair.remote_parent_ref,
             )
 
-        # Transfer is completed, delete the upload from the database
-        self.dao.remove_transfer("upload", file_path, is_direct_transfer=True)
-
         return item
 
     def upload_folder(self, **kwargs: Any) -> Dict[str, Any]:


### PR DESCRIPTION
It would happen when all chunks have been uploaded but there wouldbe an error at the `FileManager.Import` call.
In that case, we should not re-upload the file but just skip it.