### PR TITLE
NXDRIVE-2303: Fix useless reports generated in tests

### DIFF
--- a/docs/changes/4.4.5.md
+++ b/docs/changes/4.4.5.md
@@ -67,6 +67,7 @@ Release date: `2020-xx-xx`
 
 - [NXDRIVE-2245](https://jira.nuxeo.com/browse/NXDRIVE-2245): [Windows] Fix test_orphan_should_unlock()
 - [NXDRIVE-2253](https://jira.nuxeo.com/browse/NXDRIVE-2253): Minor configuration change following tox upgrade to 3.18.0
+- [NXDRIVE-2303](https://jira.nuxeo.com/browse/NXDRIVE-2303): Fix useless reports generated in tests
 
 ## Docs
 

--- a/tests/old_functional/test_context_menu.py
+++ b/tests/old_functional/test_context_menu.py
@@ -17,6 +17,7 @@ class TestContextMenu(OneUserTest):
         """It will test the copy/paste clipboard stuff."""
 
         if MAC and "JENKINS_URL" in os.environ:
+            self.app.quit()
             pytest.skip(
                 "macOS 10.11+ limitation: it's not possible to call CFPasteboardCreate when"
                 " there is no pasteboard, i.e. when the computer is on the loginwindow."

--- a/tests/old_functional/test_direct_edit.py
+++ b/tests/old_functional/test_direct_edit.py
@@ -855,6 +855,7 @@ class TestDirectEdit(OneUserTest, MixinTests):
         """Ensure we can rename a file between different partitions."""
         second_partoche = Path(env.SECOND_PARTITION)
         if not second_partoche.is_dir():
+            self.app.quit()
             pytest.skip(f"There is no such {second_partoche!r} partition.")
 
         local_folder = second_partoche / str(uuid4())

--- a/tests/old_functional/test_direct_transfer.py
+++ b/tests/old_functional/test_direct_transfer.py
@@ -177,6 +177,7 @@ class DirectTransfer:
 
     def test_with_engine_not_started(self):
         """A Direct Transfer should work even if engines are stopped."""
+        self.app.quit()
         pytest.xfail("Waiting for NXDRIVE-1910")
 
         self.engine_1.stop()
@@ -430,6 +431,7 @@ class DirectTransfer:
         Test an error happening after chunks were uploaded and the FileManager.Import operation call.
         This could happen if a proxy does not understand well the final requests as seen in NXDRIVE-1753.
         """
+        self.app.quit()
         pytest.skip("Not yet implemented.")
 
         class BadUploader(DirectTransferUploader):
@@ -634,6 +636,7 @@ class TestDirectTransferNoSync(OneUserNoSync, DirectTransfer):
 class DirectTransferFolder:
     def setUp(self):
         if not self.engine_1.have_folder_upload:
+            self.app.quit()
             pytest.skip("FileManager.CreateFolder API not available.")
 
         # No sync root, to ease testing

--- a/tests/old_functional/test_permission_hierarchy.py
+++ b/tests/old_functional/test_permission_hierarchy.py
@@ -225,6 +225,7 @@ class TestPermissionHierarchy2(TwoUsersTest):
 
     def test_sync_move_permission_removal(self):
         if WINDOWS:
+            self.app.quit()
             pytest.xfail(
                 "Following the NXDRIVE-836 fix, this test always fails because "
                 "when moving a file from a RO folder to a RW folder will end up"

--- a/tests/old_functional/test_permission_hierarchy.py
+++ b/tests/old_functional/test_permission_hierarchy.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 from nuxeo.exceptions import Forbidden
+
 from nxdrive.constants import WINDOWS
 
 from ..markers import windows_only

--- a/tests/old_functional/test_volume.py
+++ b/tests/old_functional/test_volume.py
@@ -6,6 +6,7 @@ from copy import copy
 from pathlib import Path
 
 import pytest
+
 from nxdrive.constants import ROOT
 
 from ..utils import random_png

--- a/tests/old_functional/test_volume.py
+++ b/tests/old_functional/test_volume.py
@@ -176,6 +176,7 @@ class TestVolume(OneUserTest):
         # While we are started
         # Move one parent to the second children
         if len(self.tree["children"]) < 3 or DEPTH < 2:
+            self.app.quit()
             pytest.skip("Can't execute this test on so few data")
 
         # Move root 2 in, first subchild of 1


### PR DESCRIPTION
Also fixed the case when a test should be skipped or xfailed and it would go until the kill timeout. Such tests are now "returning" quickly as they should.