### PR TITLE
NXDRIVE-2194: Force refetch of the server's config on Direct Edit com…

### DIFF
--- a/docs/changes/4.4.5.md
+++ b/docs/changes/4.4.5.md
@@ -8,6 +8,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2135](https://jira.nuxeo.com/browse/NXDRIVE-2135): Check for proxy instantexcexcexcexciation success when using a PAC
 - [NXDRIVE-2183](https://jira.nuxeo.com/browse/NXDRIVE-2183): Use `dict.copy()` for thread safety, better atomicity speed and memory efficiency
 - [NXDRIVE-2186](https://jira.nuxeo.com/browse/NXDRIVE-2186): Do not remove staled transfers at startup if the application crashed
+- [NXDRIVE-2194](https://jira.nuxeo.com/browse/NXDRIVE-2194): Force refetch of the server's config on Direct Edit command
 - [NXDRIVE-2210](https://jira.nuxeo.com/browse/NXDRIVE-2210): Fix files upload with S3 direct upload enabled
 - [NXDRIVE-2230](https://jira.nuxeo.com/browse/NXDRIVE-2230): Date/time display should be OS aware
 - [NXDRIVE-2247](https://jira.nuxeo.com/browse/NXDRIVE-2247): Rename "Direct Transfer" context menu to "Upload content"
@@ -127,6 +128,7 @@ Release date: `2020-xx-xx`
 - Added `EngineDao.decrease_session_total()`
 - Changed the return type of `EngineDAO.get_dt_uploads_raw()` from `Generator[Dict[str, Any], None, None]` to `List[Dict[str, Any]]`
 - Added `engine` keyword argument to `LinkingAction`
+- Added `Manager.wait_for_server_config()`
 - Removed `Manager.get_tracker_id()`. Use `tracker.uid` attribute instead.
 - Added `username` argument to `QMLDriveApi.update_token()`
 - Removed `QMLDriveApi.get_tracker_id()`

--- a/nxdrive/data/i18n/i18n.json
+++ b/nxdrive/data/i18n/i18n.json
@@ -79,6 +79,7 @@
     "DIRECT_EDIT_LOCK_ERROR_DESCRIPTION": "The document \"%1\" was not locked",
     "DIRECT_EDIT_NOT_FOUND": "Document \"%1\" not found on %2",
     "DIRECT_EDIT_NOT_ENABLED": "The Direct Edit feature is not enabled.",
+    "DIRECT_EDIT_NOT_POSSIBLE": "The Direct Edit feature is not usable right now.<br>Please try again later.",
     "DIRECT_EDIT_PROXY": "You are trying to perform a Direct Edit on \"%1\". This is a proxy so it cannot be edited.",
     "DIRECT_EDIT_READONLY_FILE": "Cannot edit \"%1\" as it is read-only",
     "DIRECT_EDIT_STARTING_TITLE": "Opening from %1",


### PR DESCRIPTION
…mand

The issue I tried to fix here is that Direct Edit starts only when the server configuration has been retrieved first. So when the app started and there were connection issues (bad network, no VPN, ...) then there was no Direct Edit thread started.

After that, even if the network issues were fixed, it was not possible to use Direct Edit without restarting the app.

Now the server's config is fetched "on-demand" before doing any Direct Edit.