### PR TITLE
NXDRIVE-2076: Change the cursor on click on new account connect button

### DIFF
--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -16,6 +16,7 @@ Release date: `2020-xx-xx`
 
 ## GUI
 
+- [NXDRIVE-2076](https://jira.nuxeo.com/browse/NXDRIVE-2076): Change the cursor on click on new account connect button
 - [NXDRIVE-2305](https://jira.nuxeo.com/browse/NXDRIVE-2305): Do not display the filters window on new account if the synchronization is disabled
 
 ## Packaging / Build

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -2,6 +2,7 @@
 """ Main Qt application handling OS events and system tray UI. """
 import os
 import sys
+import webbrowser
 from functools import partial
 from logging import getLogger
 from math import sqrt
@@ -849,7 +850,11 @@ class Application(QApplication):
             through the app, it opens in the browser and retrieves the login token
             by opening an nxdrive:// URL.
             """
-            self.manager.open_local_file(url)
+            QApplication.setOverrideCursor(Qt.WaitCursor)
+            try:
+                webbrowser.open_new_tab(url)
+            finally:
+                QApplication.restoreOverrideCursor()
         else:
             self._web_auth_not_frozen(url)
 


### PR DESCRIPTION
When adding an account, the browser may take some time
to open. A waiting cursor has been added so the user
can know that something is currently happening.

Also changelog has been updated.