### PR TITLE
NXDRIVE-2305: Do not display the filters window on new account if the synchronization is disabled

### DIFF
--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -16,7 +16,7 @@ Release date: `2020-xx-xx`
 
 ## GUI
 
-- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
+- [NXDRIVE-2305](https://jira.nuxeo.com/browse/NXDRIVE-2305): Do not display the filters window on new account if the synchronization is disabled
 
 ## Packaging / Build
 

--- a/nxdrive/gui/api.py
+++ b/nxdrive/gui/api.py
@@ -628,7 +628,8 @@ class QMLDriveApi(QObject):
         self.application.close_settings_too = True
 
         # Display the filters window to let the user choose what to sync
-        self.filters_dialog(engine.uid)
+        if Options.synchronization_enabled:
+            self.filters_dialog(engine.uid)
         self.setMessage.emit("CONNECTION_SUCCESS", "success")
 
     @pyqtSlot(str, str, str, str, str)


### PR DESCRIPTION
When adding a new account and the synchronization is
disabled, the Filters windows will be skipped as it
is useless.

Also changelog has been updated.