### PR TITLE
NXDRIVE-2306: Do not validate again settings when the value did not change

### DIFF
--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -18,6 +18,7 @@ Release date: `2020-xx-xx`
 
 - [NXDRIVE-2076](https://jira.nuxeo.com/browse/NXDRIVE-2076): Change the cursor on click on new account connect button
 - [NXDRIVE-2305](https://jira.nuxeo.com/browse/NXDRIVE-2305): Do not display the filters window on new account if the synchronization is disabled
+- [NXDRIVE-2306](https://jira.nuxeo.com/browse/NXDRIVE-2306): Do not validate again settings when the value did not change
 
 ## Packaging / Build
 

--- a/nxdrive/data/qml/ChannelPopup.qml
+++ b/nxdrive/data/qml/ChannelPopup.qml
@@ -86,8 +86,12 @@ NuxeoPopup {
                 text: qsTr("APPLY") + tl.tr
                 inverted: true
                 onClicked: {
+                    var current_channel = api.get_update_channel()
                     var channel = channelType.model.get(channelType.currentIndex).value
-                    if (channel == 'alpha') {
+                    if (channel == current_channel) {
+                        control.close()
+                    }
+                    else if (channel == 'alpha') {
                         useAlpha.open()
                     } else {
                         api.set_update_channel(channel)

--- a/nxdrive/data/qml/DeletionPopup.qml
+++ b/nxdrive/data/qml/DeletionPopup.qml
@@ -75,8 +75,11 @@ NuxeoPopup {
                 text: qsTr("APPLY") + tl.tr
                 inverted: true
                 onClicked: {
+                    var current_value = api.get_deletion_behavior()
                     var value = deletionBehavior.model.get(deletionBehavior.currentIndex).value
-                    api.set_deletion_behavior(value)
+                    if (current_value != value) {
+                        api.set_deletion_behavior(value)
+                    }
                     control.close()
                 }
             }

--- a/nxdrive/data/qml/LogLevelPopup.qml
+++ b/nxdrive/data/qml/LogLevelPopup.qml
@@ -65,8 +65,10 @@ NuxeoPopup {
                 inverted: true
                 onClicked: {
                     var level = logLevel.currentText
-                    api.set_log_level(level)
-                    control.level = level
+                    if (level != control.level) {
+                        api.set_log_level(level)
+                        control.level = level
+                    }
                     control.close()
                 }
             }

--- a/nxdrive/data/qml/ProxyPopup.qml
+++ b/nxdrive/data/qml/ProxyPopup.qml
@@ -112,6 +112,7 @@ NuxeoPopup {
                     || (isAuto && pacUrlInput.text)
                 inverted: true
                 onClicked: {
+                    // No check is done on setting change as we want to revalidate the existing proxy
                     if (api.set_proxy_settings(
                         proxyType.model.get(proxyType.currentIndex).value,
                         urlInput.text,


### PR DESCRIPTION
When validating a setting, a QML check is done to check if
the setting value has changed and prevent useless calls to
Python code.

Also changelog has been updated.