### PR TITLE
NXDRIVE-2316: Skip the synchronization in the auto-update check script

### DIFF
--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -22,6 +22,7 @@ Release date: `2020-xx-xx`
 
 ## Packaging / Build
 
+- [NXDRIVE-2308](https://jira.nuxeo.com/browse/NXDRIVE-2308): Reduce the release process time
 - [NXDRIVE-2314](https://jira.nuxeo.com/browse/NXDRIVE-2314): Remove more files from the final package
 - [NXDRIVE-2315](https://jira.nuxeo.com/browse/NXDRIVE-2315): Do not show the progress bar on module installation
 

--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -27,7 +27,7 @@ Release date: `2020-xx-xx`
 
 ## Tests
 
-- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
+- [NXDRIVE-2316](https://jira.nuxeo.com/browse/NXDRIVE-2316): Skip the synchronization in the auto-update check script
 
 ## Docs
 

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -1152,6 +1152,9 @@ class Application(QApplication):
     def show_release_notes(self, version: str) -> None:
         """ Display release notes of a given version. """
 
+        if "CI" in os.environ:
+            return
+
         channel = self.manager.get_update_channel()
         log.info(f"Showing release notes, version={version!r} channel={channel}")
 

--- a/tools/osx/deploy_ci_agent.sh
+++ b/tools/osx/deploy_ci_agent.sh
@@ -134,15 +134,17 @@ create_package() {
     fi
 
     echo ">>> [package] Creating the DMG file"
+
+    app_version="$(grep __version__ nxdrive/__init__.py | cut -d'"' -f2)"
+    local dmg_path="${output_dir}/nuxeo-drive-${app_version}.dmg"
+
     # Clean-up
-    rm -fv ${output_dir}/*.dmg
+    rm -fv "${dmg_path}"
     rm -rf "${src_folder_tmp}" "${dmg_tmp}"
     mkdir "${src_folder_tmp}"
 
-    app_version="$(grep __version__ nxdrive/__init__.py | cut -d'"' -f2)"
     echo ">>> [DMG] ${bundle_name} version ${app_version}"
     # Compute DMG name and size
-    local dmg_path="${output_dir}/nuxeo-drive-${app_version}.dmg"
     local dmg_size=$(( $(du -sm "${pkg_path}" | cut -d$'\t' -f1,1) + 20 ))
     echo ">>> [DMG ${app_version}] ${dmg_path} (${dmg_size} Mo)"
 

--- a/tools/osx/travis.sh
+++ b/tools/osx/travis.sh
@@ -11,11 +11,8 @@ echo "${PRIV_APP_MACOS}" | base64 --decode > nuxeo-drive.priv
 bash tools/osx/deploy_ci_agent.sh --install-release
 
 # Test the auto-updater
-bash tools/osx/deploy_ci_agent.sh --check-upgrade
-
-# Build the app
 rm -rf build dist
-bash tools/osx/deploy_ci_agent.sh --build
+bash tools/osx/deploy_ci_agent.sh --check-upgrade
 
 # Upload artifacts
 for f in dist/*.dmg; do

--- a/tools/scripts/check_update_process.py
+++ b/tools/scripts/check_update_process.py
@@ -242,12 +242,13 @@ def set_options():
         metrics = f"{home}/metrics.state"
 
     options = [
-        "sync-and-quit = True",
+        "channel = alpha",
         "log-level-console = WARNING",
         "log-level-file = DEBUG",
-        "update-site-url = http://localhost:8000",
+        "synchronization-enabled = False",
+        "sync-and-quit = True",
         "update-check-delay = 8",
-        "channel = alpha",
+        "update-site-url = http://localhost:8000",
     ]
 
     if not os.path.isdir(home):

--- a/tools/windows/deploy_ci_agent.ps1
+++ b/tools/windows/deploy_ci_agent.ps1
@@ -109,8 +109,10 @@ function build_installer {
 		zip_files "dist\nuxeo-drive-windows-$app_version.zip" "dist\ndrive"
 	}
 
-	build "$app_version" "tools\windows\setup-addons.iss"
-	sign "dist\nuxeo-drive-addons.exe"
+	if (-Not ($Env:SKIP_ADDONS)) {
+		build "$app_version" "tools\windows\setup-addons.iss"
+		sign "dist\nuxeo-drive-addons.exe"
+	}
 
 	build "$app_version" "tools\windows\setup.iss"
 	sign "dist\nuxeo-drive-$app_version.exe"

--- a/tools/windows/travis.sh
+++ b/tools/windows/travis.sh
@@ -12,11 +12,8 @@ powershell Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope LocalMachine
 powershell ".\\tools\\windows\\deploy_ci_agent.ps1" -install_release
 
 # Test the auto-updater
-powershell ".\\tools\\windows\\deploy_ci_agent.ps1" -check_upgrade
-
-# Build the app
 rm -rf build dist
-powershell ".\\tools\\windows\\deploy_ci_agent.ps1" -build
+powershell ".\\tools\\windows\\deploy_ci_agent.ps1" -check_upgrade
 
 # Upload artifacts
 for f in dist/*.exe; do


### PR DESCRIPTION
This is currently preventing the alpha job to work on Travis-CI.

Also reduced the release process time by 33% on macOs and Windows!