### PR TITLE
NXDRIVE-2322: Do not retry a HTTP call that failed on 500 error

### DIFF
--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -5,6 +5,7 @@ Release date: `2020-xx-xx`
 ## Core
 
 - [NXDRIVE-2311](https://jira.nuxeo.com/browse/NXDRIVE-2311): Add an option to control doc types where Direct Transfer is disallowed
+- [NXDRIVE-2322](https://jira.nuxeo.com/browse/NXDRIVE-2322): Do not retry a HTTP call that failed on 500 error
 - [NXDRIVE-2323](https://jira.nuxeo.com/browse/NXDRIVE-2323): Add `LOG_EVERYTHING` envar to ... log everything
 
 ### Direct Edit

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -8,6 +8,7 @@ from time import monotonic_ns
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, Union
 from urllib.parse import unquote
 
+import nuxeo.constants
 import requests
 from nuxeo.auth import TokenAuth
 from nuxeo.client import Nuxeo
@@ -49,6 +50,10 @@ __all__ = ("Remote",)
 log = getLogger(__name__)
 
 socket.setdefaulttimeout(TX_TIMEOUT)
+
+# NXDRIVE-2323: patch HTTP errors that trigger retries
+if 500 in nuxeo.constants.RETRY_STATUS_CODES:
+    nuxeo.constants.RETRY_STATUS_CODES.remove(500)
 
 
 class Remote(Nuxeo):


### PR DESCRIPTION
Retrying on HTTP 500 was leading to obscure issues when finalizing a transfer done via a third-party provider like S3.