### PR TITLE
NXDRIVE-2324: Fix the transfer progression reset if it was paused at …

### DIFF
--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -7,6 +7,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2311](https://jira.nuxeo.com/browse/NXDRIVE-2311): Add an option to control doc types where Direct Transfer is disallowed
 - [NXDRIVE-2322](https://jira.nuxeo.com/browse/NXDRIVE-2322): Do not retry a HTTP call that failed on 500 error
 - [NXDRIVE-2323](https://jira.nuxeo.com/browse/NXDRIVE-2323): Add `LOG_EVERYTHING` envar to ... log everything
+- [NXDRIVE-2324](https://jira.nuxeo.com/browse/NXDRIVE-2324): Fix the transfer progression reset if it was paused at startup
 
 ### Direct Edit
 

--- a/nxdrive/engine/dao/sqlite.py
+++ b/nxdrive/engine/dao/sqlite.py
@@ -2278,8 +2278,14 @@ class EngineDAO(ConfigurationDAO):
                 Path(res.path),
                 TransferStatus(res.status),
                 res.engine,
-                doc_pair=res.doc_pair,
                 batch=json.loads(res.batch),
+                chunk_size=res.chunk_size,
+                doc_pair=res.doc_pair,
+                filesize=res.filesize,
+                is_direct_transfer=True,
+                progress=res.progress,
+                remote_parent_path=res.remote_parent_path,
+                remote_parent_ref=res.remote_parent_ref,
             )
 
     def get_dt_uploads_raw(self, limit: int = 1) -> List[Dict[str, Any]]:

--- a/nxdrive/objects.py
+++ b/nxdrive/objects.py
@@ -475,7 +475,7 @@ class Download(Transfer):
 class Upload(Transfer):
     transfer_type: str = field(init=False, default="upload")
     batch: dict = field(default_factory=dict)
-    chunk_size: Optional[int] = None
+    chunk_size: Optional[int] = 0
     remote_parent_path: Optional[str] = ""
     remote_parent_ref: Optional[str] = ""
 


### PR DESCRIPTION
…startup

Also fix the `chunk_size` used to compute progressions: the one from the uploader is now used to prevent bad progression bars.