### PR TITLE
NXDRIVE-2326: Fix test test_get_metadata_infos()

### DIFF
--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -33,6 +33,7 @@ Release date: `2020-xx-xx`
 ## Tests
 
 - [NXDRIVE-2316](https://jira.nuxeo.com/browse/NXDRIVE-2316): Skip the synchronization in the auto-update check script
+- [NXDRIVE-2326](https://jira.nuxeo.com/browse/NXDRIVE-2326): Fix test `test_get_metadata_infos()`
 
 ## Docs
 

--- a/tests/old_functional/test_context_menu.py
+++ b/tests/old_functional/test_context_menu.py
@@ -45,6 +45,7 @@ class TestContextMenu(OneUserTest):
     def test_get_metadata_infos(self):
         """This will test "Access online" and "Edit metadata" entries."""
         manager = self.manager_1
+        engine = self.engine_1
         local = self.local_1
 
         # Document does not inexist
@@ -66,5 +67,9 @@ class TestContextMenu(OneUserTest):
         # "Edit metadata" entry
         url_edit = manager.get_metadata_infos(path, edit=True)
         assert url.startswith("http")
-        assert url_edit != url
+        if engine.wui == "web":
+            assert url_edit == url
+        else:
+            # JSF has a different view
+            assert url_edit != url
         assert "token" not in url


### PR DESCRIPTION
We changed the default UI in NXDRIVE-2223 and since then the test was failing.