### PR TITLE
NXDRIVE-2331: Check for ignored patterns against lowercased names

### DIFF
--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -16,7 +16,7 @@ Release date: `2020-xx-xx`
 
 ### Direct Transfer
 
-- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
+- [NXDRIVE-2331](https://jira.nuxeo.com/browse/NXDRIVE-2331): Check for ignored patterns against lowercased names
 
 ## GUI
 

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -326,7 +326,8 @@ def get_tree_list(path: Path) -> Generator[Tuple[Path, int], None, None]:
         return
 
     # Check that the path can be processed
-    if path.name.startswith(Options.ignored_prefixes) or path.name.endswith(
+    path_lower = path.name.lower()
+    if path_lower.startswith(Options.ignored_prefixes) or path_lower.endswith(
         Options.ignored_suffixes
     ):
         log.debug(f"Ignored path for Direct Transfer: {str(path)!r}")
@@ -339,7 +340,8 @@ def get_tree_list(path: Path) -> Generator[Tuple[Path, int], None, None]:
     with it:
         for entry in it:
             # Check the path can be processed
-            if entry.name.startswith(Options.ignored_prefixes) or entry.name.endswith(
+            entry_lower = entry.name.lower()
+            if entry_lower.startswith(Options.ignored_prefixes) or entry_lower.endswith(
                 Options.ignored_suffixes
             ):
                 log.debug(f"Ignored path for Direct Transfer: {entry.path!r}")

--- a/tools/deps/requirements-tests.txt
+++ b/tools/deps/requirements-tests.txt
@@ -145,6 +145,9 @@ pycodestyle==2.6.0 \
 pyflakes==2.2.0 \
     --hash=sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92 \
     --hash=sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8
+pyfakefs==4.1.0 \
+    --hash=sha256:1eae36f920e54a7f9f50789f21ab77ceb481ef697bec66de6495ecdf5db44f0f \
+    --hash=sha256:bbbaa8b622fa50751a5839350fff3c1f8b1bbd364cd40fd0c7442e18fe5edc8e
     # via flake8
 pyparsing==2.4.7 \
     --hash=sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1 \


### PR DESCRIPTION
It appears that our tests mocking `os.scandir()` were also bad.
So I fixed the tests by using the `pyfakefs` module, way cleaner now.