### PR TITLE
NXDRIVE-2336: Fix mypy issues following the update to version 0.790

### DIFF
--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -9,6 +9,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2323](https://jira.nuxeo.com/browse/NXDRIVE-2323): Add `LOG_EVERYTHING` envar to ... log everything
 - [NXDRIVE-2324](https://jira.nuxeo.com/browse/NXDRIVE-2324): Fix the transfer progression reset if it was paused at startup
 - [NXDRIVE-2325](https://jira.nuxeo.com/browse/NXDRIVE-2325): Save the upload state when it is completed on the server
+- [NXDRIVE-2336](https://jira.nuxeo.com/browse/NXDRIVE-2336): Fix `mypy` issues following the update to version 0.790
 
 ### Direct Edit
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,7 +6,7 @@ warn_unused_configs = True
 
 # Imports management
 ignore_missing_imports = True
-follow_imports = True
+follow_imports = normal
 
 # Ensure full coverage
 disallow_untyped_defs = True

--- a/nxdrive/osi/windows/registry.py
+++ b/nxdrive/osi/windows/registry.py
@@ -117,7 +117,8 @@ def write(key: str, content: Union[str, Dict[Optional[str], str]]) -> bool:
     try:
         with winreg.CreateKeyEx(HKCU, key) as handle:
             for name, data in content.items():
-                winreg.SetValueEx(handle, name, 0, winreg.REG_SZ, data)
+                # TODO: remove the comment when https://github.com/python/typeshed/pull/4663 is done
+                winreg.SetValueEx(handle, name, 0, winreg.REG_SZ, data)  # type: ignore
             log.info(f"Wrote {key!r}: {content!r}")
     except OSError:
         log.exception(f"Couldn't write {key!r}")


### PR DESCRIPTION
The error has been patched upstream, see https://github.com/python/typeshed/pull/4663.