### PR TITLE
NXDRIVE-2339: Tell test_proxy.py to use a temporary folder instead of…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ cover
 coverage
 .coverage*
 *.db-shm
-*.db-wall
+*.db-wal
 debian
 dist
 dist-beta

--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -35,6 +35,7 @@ Release date: `2020-xx-xx`
 
 - [NXDRIVE-2316](https://jira.nuxeo.com/browse/NXDRIVE-2316): Skip the synchronization in the auto-update check script
 - [NXDRIVE-2326](https://jira.nuxeo.com/browse/NXDRIVE-2326): Fix test `test_get_metadata_infos()`
+- [NXDRIVE-2339](https://jira.nuxeo.com/browse/NXDRIVE-2339): Tell `test_proxy.py` to use a temporary folder instead of the current directory
 
 ## Docs
 

--- a/tests/unit/test_proxy.py
+++ b/tests/unit/test_proxy.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -33,8 +31,8 @@ def js():
 
 
 @pytest.fixture()
-def config_dao():
-    db = Path("tmp.db")
+def config_dao(tmp_path):
+    db = tmp_path / "tmp.db"
     dao = ConfigurationDAO(db)
     yield dao
     dao.dispose()


### PR DESCRIPTION
… the current directory

Also fixed the ignored pattern for databases in WAL mode.