### PR TITLE
NXDRIVE-2349: Fix a QML margin in the account addition

### DIFF
--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -30,6 +30,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2305](https://jira.nuxeo.com/browse/NXDRIVE-2305): Do not display the filters window on new account if the synchronization is disabled
 - [NXDRIVE-2306](https://jira.nuxeo.com/browse/NXDRIVE-2306): Do not validate again settings when the value did not change
 - [NXDRIVE-2346](https://jira.nuxeo.com/browse/NXDRIVE-2346): Link to the current OS installer in the fatal error window
+- [NXDRIVE-2349](https://jira.nuxeo.com/browse/NXDRIVE-2349): Fix a QML margin in the account addition
 
 ## Packaging / Build
 

--- a/nxdrive/data/qml/NewAccountPopup.qml
+++ b/nxdrive/data/qml/NewAccountPopup.qml
@@ -18,7 +18,7 @@ NuxeoPopup {
 
     contentItem: ColumnLayout {
         GridLayout {
-            Layout.topMargin: 20
+            Layout.topMargin: 30  // NXDRIVE-2349: should be 20 here
             columns: 2
             rowSpacing: 20
             columnSpacing: 10


### PR DESCRIPTION
Since the upgrade to PyQt 5.15.1, when adding an account there is a missing margin above the URL field. But as soon as a character is entered into the field, the margin comes again and all is fine.

So let's increase the margin and see later when the Qt/PyQt issue will be addressed to remove it.