### PR TITLE
NXDRIVE-2319: Do not use the undocumented and unreliable Path.absolut…

### DIFF
--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -5,6 +5,7 @@ Release date: `2020-xx-xx`
 ## Core
 
 - [NXDRIVE-2311](https://jira.nuxeo.com/browse/NXDRIVE-2311): Add an option to control doc types where Direct Transfer is disallowed
+- [NXDRIVE-2319](https://jira.nuxeo.com/browse/NXDRIVE-2319): Do not use the undocumented and unreliable `Path.absolute()` method
 - [NXDRIVE-2322](https://jira.nuxeo.com/browse/NXDRIVE-2322): Do not retry a HTTP call that failed on 500 error
 - [NXDRIVE-2323](https://jira.nuxeo.com/browse/NXDRIVE-2323): Add `LOG_EVERYTHING` envar to ... log everything
 - [NXDRIVE-2324](https://jira.nuxeo.com/browse/NXDRIVE-2324): Fix the transfer progression reset if it was paused at startup
@@ -101,5 +102,6 @@ Release date: `2020-xx-xx`
 - Added `QMLDriveApi.resume_session()`
 - Added `TransferStatus.CANCELLED`
 - Added `Upload.batch_obj`
+- Removed `cls` keyword argument from utils.py::`normalized_path()`
 - Added view.py::`ActiveSessionModel`
 - Added view.py::`CompletedSessionModel`

--- a/nxdrive/client/local/base.py
+++ b/nxdrive/client/local/base.py
@@ -549,23 +549,12 @@ class LocalClientMixin:
 
     def get_path(self, target: Path) -> Path:
         """ Relative path to the local client from an absolute OS path. """
-        # Overwriting the name because .resolve() can change its casing
-        # depending on what exists, e.g.:
-        # - target.name == "ABCDE.txt"
-        # - "abcde.txt" exists on the filesystem
-        # -> target.resolve() will set target.name as "abcde.txt"
+        # NXDRIVE-2319: using os.path.abspath() instead of .resolve and .absolute().
         try:
-            target = target.resolve().with_name(target.name)
-        except PermissionError:
-            # On Windows, we can get a PermissionError when the file is being
-            # opened in another software, fallback on .absolute() then.
-            target = target.absolute().with_name(target.name)
-
-        try:
-            return target.relative_to(self.base_folder)
+            return Path(os.path.abspath(str(target))).relative_to(self.base_folder)
         except ValueError:
-            # From the doc: if the operation is not possible (because
-            # this is not a subpath of the other path), raise ValueError.
+            # From the Path.relative_to() doc: if the operation is not possible
+            # (because this is not a subpath of the other path), raise ValueError.
             return ROOT
 
     def abspath(self, ref: Path) -> Path:

--- a/nxdrive/options.py
+++ b/nxdrive/options.py
@@ -296,18 +296,18 @@ class MetaOptions(type):
     # The return value is not checked.
     callbacks: Dict[str, Callable] = {}
 
-    def __getattr__(cls, item: str) -> Any:
+    def __getattr__(_, item: str) -> Any:
         """
         Override to allow retrieving an option as simply as `Options.delay`.
         If the option does not exist, returns `None`.
         """
         try:
-            value, _ = MetaOptions.options[item]
+            value, _ = MetaOptions.options[item]  # type: ignore
         except KeyError:
             value = None
         return value
 
-    def __setattr__(cls, item: str, value: Any) -> None:
+    def __setattr__(_, item: str, value: Any) -> None:
         """
         Override to allow setting an option as simply as `Options.delay = 42`.
         If the option does not exist, it does nothing.
@@ -316,7 +316,7 @@ class MetaOptions(type):
         with suppress(KeyError):
             MetaOptions.set(item, value, setter="manual")
 
-    def __repr__(cls) -> str:
+    def __repr__(_) -> str:
         """ Display all options. """
         options = [
             f"{name}[{setter}]={value!r}"
@@ -324,7 +324,7 @@ class MetaOptions(type):
         ]
         return f"Options({', '.join(options)})"
 
-    def __str__(cls) -> str:
+    def __str__(_) -> str:
         """ Display non default options. """
         options = [
             f"{name}[{setter}]={value!r}"

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -452,21 +452,16 @@ def is_generated_tmp_file(name: str) -> Tuple[bool, Optional[bool]]:
     return do_not_ignore, no_delay_effect
 
 
-def normalized_path(path: Union[bytes, str, Path], cls: Callable = Path) -> Path:
+def normalized_path(path: Union[bytes, str, Path]) -> Path:
     """Return absolute, normalized file path.
-    The *cls* argument is used in tests, it must be a class or subclass of Path.
 
     Note: this function cannot be decorated with lru_cache().
     """
     if not isinstance(path, Path):
         path = force_decode(path)
-    expanded = cls(path).expanduser()
-    try:
-        return expanded.resolve()  # type: ignore
-    except PermissionError:
-        # On Windows, we can get a PermissionError when the file is being
-        # opened in another software, fallback on .absolute() then.
-        return expanded.absolute()  # type: ignore
+    expanded = Path(path).expanduser()
+    # NXDRIVE-2319: using os.path.abspath() instead of .resolve and .absolute().
+    return Path(os.path.abspath(str(expanded)))
 
 
 def normalize_and_expand_path(path: str) -> Path:

--- a/tests/unit/test_local_client.py
+++ b/tests/unit/test_local_client.py
@@ -1,6 +1,5 @@
 import pathlib
 from time import sleep
-from unittest.mock import patch
 
 from nxdrive.client.local import LocalClient
 from nxdrive.constants import ROOT
@@ -17,23 +16,6 @@ def test_get_path(tmp_path):
     # The path exists, it returns
     assert local.get_path(path) == pathlib.Path("foo.txt")
     assert local.get_path(path_upper) == pathlib.Path("FOO.TXT")
-
-
-@patch("pathlib.Path.resolve")
-@patch("pathlib.Path.absolute")
-def test_get_path_permission_error(mocked_resolve, mocked_absolute, tmp_path):
-    local = LocalClient(tmp_path)
-    path = tmp_path / "foo.txt"
-
-    # Path.resolve() raises a PermissionError, it should fallback on .absolute()
-    mocked_resolve.side_effect = PermissionError()
-    path_abs = local.get_path(path)
-    assert mocked_absolute.called
-
-    # Restore the original ehavior and check that .resolved() and .absolute()
-    # return the same value.
-    mocked_resolve.reset_mock()
-    assert local.get_path(path) == path_abs
 
 
 def test_xattr_crud(tmp_path):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -538,21 +538,6 @@ def test_if_frozen_decorator():
     assert checkpoint
 
 
-def test_normalized_path_permission_error(tmp):
-    func = nxdrive.utils.normalized_path
-
-    folder = tmp()
-    folder.mkdir()
-    path = folder / "foo.txt"
-
-    # Path.resolve() raises a PermissionError, it should fallback on .absolute()
-    path_abs = func(str(path), cls=MockedPath)  # Test giving a str
-
-    # Restore the original behavior and check that .resolved() and .absolute()
-    # return the same value.
-    assert func(path) == path_abs  # Test giving a Path
-
-
 def test_normalize_and_expand_path():
     if WINDOWS:
         path = "%userprofile%/foo"


### PR DESCRIPTION
…e() method