### PR TITLE
NXDRIVE-2368: Bump the chunk_limit upper limit from 20 MiB to 5120 Mi…

### DIFF
--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -16,6 +16,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2344](https://jira.nuxeo.com/browse/NXDRIVE-2344): [GNU/Linux] Use `os.*attr()` builtin functions instead of the `xattr` module
 - [NXDRIVE-2360](https://jira.nuxeo.com/browse/NXDRIVE-2360): [GNU/Linux] Do not spawn a process for doing a simple `chmod`
 - [NXDRIVE-2365](https://jira.nuxeo.com/browse/NXDRIVE-2365): Remove all database-related files on account removal
+- [NXDRIVE-2368](https://jira.nuxeo.com/browse/NXDRIVE-2368): Bump the `chunk_limit` upper limit from 20 MiB to 5120 MiB (5 GiB)
 
 ### Direct Edit
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -112,10 +112,11 @@ Has to be above 0.
 
 #### `chunk-size`
 
-Size of the chunks in MiB. Has to be above 0 and lower or equal to 20.
+Size of the chunks in MiB. Has to be above 0 and lower or equal to 5120 (5 GiB).
 
 - Default value (int): `20`
 - Version added: 4.1.2
+- Version changed: 4.4.6, bumped the upper limit from `20` to `5120`
 
 * * *
 

--- a/nxdrive/options.py
+++ b/nxdrive/options.py
@@ -540,9 +540,11 @@ def validate_chunk_limit(value: int) -> int:
 
 
 def validate_chunk_size(value: int) -> int:
-    if 0 < value <= 20:
+    if 0 < value <= 1024 * 5:
         return value
-    raise ValueError(f"Chunk size must be between 1 and 20 MiB (got {value!r})")
+    raise ValueError(
+        f"Chunk size must be between 1 MiB and 5120 MiB [5 GiB] (got {value!r})"
+    )
 
 
 def validate_client_version(value: str) -> str:

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -274,7 +274,11 @@ def test_str_utf8():
 @Options.mock()
 @pytest.mark.parametrize(
     "option, a_bad_value, a_good_value",
-    [("chunk_limit", -42, 42), ("chunk_size", 42, 16), ("tmp_file_limit", -42.0, 42.0)],
+    [
+        ("chunk_limit", -42, 42),
+        ("chunk_size", 1024 * 5 + 1, 16),
+        ("tmp_file_limit", -42.0, 42.0),
+    ],
 )
 def test_validator(option, a_bad_value, a_good_value):
     # Setting a bad value is a no-op


### PR DESCRIPTION
…B (5 GiB)

The original limit (20 MiB) was quite a random value. This may be inefficient to use such low value when one can upload a part size of 5GiB to S3 and test a local network with terabyte links.

So I bumped the upper limit to 5120 MiB to allow using S3 at its full power.