### PR TITLE
NXDRIVE-2341: [Direct Transfer] Non-chunked uploads must be put in pause when the session is paused

### DIFF
--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -27,6 +27,7 @@ Release date: `2020-xx-xx`
 
 - [NXDRIVE-2309](https://jira.nuxeo.com/browse/NXDRIVE-2309): Implement Active Transfer sessions tab
 - [NXDRIVE-2331](https://jira.nuxeo.com/browse/NXDRIVE-2331): Check for ignored patterns against lowercased names
+- [NXDRIVE-2341](https://jira.nuxeo.com/browse/NXDRIVE-2341): Non-chunked uploads must be put in pause when the session is paused
 
 ## GUI
 

--- a/nxdrive/client/uploader/direct_transfer.py
+++ b/nxdrive/client/uploader/direct_transfer.py
@@ -100,6 +100,7 @@ class DirectTransferUploader(BaseUploader):
                 remote_parent_path=doc_pair.remote_parent_path,
                 remote_parent_ref=doc_pair.remote_parent_ref,
                 doc_pair=doc_pair.id,
+                session=kwargs["session"],
             )
 
         return item

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -508,12 +508,15 @@ class Processor(EngineWorker):
             self.engine.directTranferError.emit(path)
             return
 
+        session = self.dao.get_session(doc_pair.session)
+
         # Do the upload
         self.remote.upload(
             path,
             engine_uid=self.engine.uid,
             uploader=DirectTransferUploader,
             doc_pair=doc_pair,
+            session=session,
         )
 
         self._direct_transfer_end(doc_pair)


### PR DESCRIPTION
A check is now done before starting a file upload to verify if the linked session is already paused.