### PR TITLE
NXDRIVE-2370: Allow dependabot to check GitHub actions monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -45,6 +45,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2314](https://jira.nuxeo.com/browse/NXDRIVE-2314): Remove more files from the final package
 - [NXDRIVE-2315](https://jira.nuxeo.com/browse/NXDRIVE-2315): Do not show the progress bar on module installation
 - [NXDRIVE-2347](https://jira.nuxeo.com/browse/NXDRIVE-2347): Fix packaging following the sentry-sdk upgrade to 0.19.0
+- [NXDRIVE-2370](https://jira.nuxeo.com/browse/NXDRIVE-2370): Allow dependabot to check GitHub actions monthly
 
 ## Tests
 


### PR DESCRIPTION
Let Dependabot update GitHub Actions dependency once a month.

Here's reference to the dependabot configs.
https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/keeping-your-actions-up-to-date-with-github-dependabot

Source: https://github.com/python/cpython/pull/22787