### PR TITLE
NXDRIVE-2309: [Direct Transfer] Fix multiple non-chunked uploads pause and cancel

### DIFF
--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -100,6 +100,7 @@ Release date: `2020-xx-xx`
 - Added `EngineDAO.change_session_status()`
 - Added `EngineDAO.decrease_session_planned_items()`
 - Added `EngineDAO.get_active_sessions_raw()`
+- Added `EngineDAO.save_dt_upload()`
 - Added `table` keyword argument to `EngineDAO.get_count()`
 - Added `EngineDAO.get_completed_sessions_raw()`
 - Added `EngineDAO.pause_session()`
@@ -122,5 +123,7 @@ Release date: `2020-xx-xx`
 - Added `TransferStatus.CANCELLED`
 - Added `Upload.batch_obj`
 - Removed `cls` keyword argument from utils.py::`normalized_path()`
+- Added exceptions.py::`TransferCancelled`
+- Added exceptions.py::`UploadCancelled`
 - Added view.py::`ActiveSessionModel`
 - Added view.py::`CompletedSessionModel`

--- a/nxdrive/client/uploader/direct_transfer.py
+++ b/nxdrive/client/uploader/direct_transfer.py
@@ -100,7 +100,6 @@ class DirectTransferUploader(BaseUploader):
                 remote_parent_path=doc_pair.remote_parent_path,
                 remote_parent_ref=doc_pair.remote_parent_ref,
                 doc_pair=doc_pair.id,
-                session=kwargs["session"],
             )
 
         return item

--- a/nxdrive/data/qml/SessionItem.qml
+++ b/nxdrive/data/qml/SessionItem.qml
@@ -98,14 +98,25 @@ Rectangle {
 
                     // Pause/Resume icon
                     IconLabel {
+                        id: pause_resume_button
                         icon: paused ? MdiFont.Icon.play : MdiFont.Icon.pause
                         iconColor: nuxeoBlue
                         tooltip: qsTr(paused ? "RESUME" : "SUSPEND") + tl.tr
                         onClicked: {
                             if (paused) {
-                                api.resume_session(engine, uid)
+                                try {
+                                    pause_resume_button.enabled = false
+                                    api.resume_session(engine, uid)
+                                } finally {
+                                    pause_resume_button.enabled = true
+                                }
                             } else {
-                                api.pause_session(engine, uid)
+                                try {
+                                    pause_resume_button.enabled = false
+                                    api.pause_session(engine, uid)
+                                } finally {
+                                    pause_resume_button.enabled = true
+                                }
                             }
                         }
                     }

--- a/nxdrive/exceptions.py
+++ b/nxdrive/exceptions.py
@@ -139,6 +139,13 @@ class StartupPageConnectionError(DriveError):
     pass
 
 
+class TransferCancelled(DriveError):
+    """ A transfer has been cancelled, the file's processing should stop. """
+
+    def __init__(self, transfer_id: int) -> None:
+        self.transfer_id = transfer_id
+
+
 class TransferPaused(DriveError):
     """ A transfer has been paused, the file's processing should stop. """
 
@@ -154,6 +161,12 @@ class DownloadPaused(TransferPaused):
 
 class UploadPaused(TransferPaused):
     """ An upload has been paused, the file's processing should stop. """
+
+    pass
+
+
+class UploadCancelled(TransferCancelled):
+    """ An upload has been cancelled, the file's processing should stop. """
 
     pass
 


### PR DESCRIPTION
Direct Transfer uploads will now inherit the session status when saved into database. Uploads from cancelled sessions won't be uploaded anymore.