### PR TITLE
NXDRIVE-2376: Use the dedicated test server whenever possible

### DIFF
--- a/.github/workflows/functional_tests.yml
+++ b/.github/workflows/functional_tests.yml
@@ -1,0 +1,103 @@
+name: Functional tests
+
+on:
+  pull_request:
+    paths:
+    - '.github/workflows/functional_tests.yml'
+    - 'nxdrive/**/*.py'
+    - 'tests/functional/*.py'
+
+env:
+  NXDRIVE_TEST_NUXEO_URL: https://nuxeo-drive-preview.platform.dev.nuxeo.com/nuxeo
+
+jobs:
+  ft_linux:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.7.9  # XXX_PYTHON
+    - uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+        restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+    - uses: actions/cache@v1
+      with:
+        path: .tox
+        key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+        restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+    - name: Install tox
+      run: python -m pip install -r tools/deps/requirements-tox.txt
+    - name: Functional tests
+      run: tox -e ft
+
+  ft_macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.7.9  # XXX_PYTHON
+    - uses: actions/cache@v1
+      with:
+        path: ~/Library/Caches/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+        restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+    - uses: actions/cache@v1
+      with:
+        path: .tox
+        key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+        restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+    - name: Install tox
+      run: python -m pip install -r tools/deps/requirements-tox.txt
+    - name: Functional tests
+      run: tox -e ft
+
+  ft_windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.7.9  # XXX_PYTHON
+    - uses: actions/cache@v1
+      with:
+        path: ~\AppData\Local\pip\Cache
+        key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+        restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+    # Cannot be used for now: OSError: [WinError 193] %1 is not a valid Win32 application
+    # - uses: actions/cache@v1
+    #  with:
+    #    path: .tox
+    #    key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+    #    restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+    - name: Install tox
+      run: python -m pip install -r tools/deps/requirements-tox.txt
+    - name: Functional tests
+      run: tox -e ft
+
+  cleanup:
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [ft_linux, ft_macos, ft_windows]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.7.9  # XXX_PYTHON
+    - uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-clean.txt', 'tools/deps/requirements-tox.txt') }}
+        restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-clean.txt', 'tools/deps/requirements-tox.txt') }}
+    - uses: actions/cache@v1
+      with:
+        path: .tox
+        key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-clean.txt', 'tools/deps/requirements-tox.txt') }}
+        restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-clean.txt', 'tools/deps/requirements-tox.txt') }}
+    - name: Install tox
+      run: python -m pip install -r tools/deps/requirements-tox.txt
+    - name: Clean-up tests data
+      run: tox -e clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ os: linux
 env:
   global:
     - MAKEFLAGS="-j 2"
-    - NXDRIVE_TEST_NUXEO_URL="https://nightly.nuxeo.com/nuxeo"
+    - NXDRIVE_TEST_NUXEO_URL="https://nuxeo-drive-preview.platform.dev.nuxeo.com/nuxeo"
     # Set to "release" for a beta release
     - RELEASE_TYPE="alpha"
 

--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -49,6 +49,7 @@ Release date: `2020-xx-xx`
 
 ## Tests
 
+- [NXDRIVE-2071](https://jira.nuxeo.com/browse/NXDRIVE-2071): Use GitHub Actions to run functional tests
 - [NXDRIVE-2316](https://jira.nuxeo.com/browse/NXDRIVE-2316): Skip the synchronization in the auto-update check script
 - [NXDRIVE-2326](https://jira.nuxeo.com/browse/NXDRIVE-2326): Fix test `test_get_metadata_infos()`
 - [NXDRIVE-2339](https://jira.nuxeo.com/browse/NXDRIVE-2339): Tell `test_proxy.py` to use a temporary folder instead of the current directory

--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -54,6 +54,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2339](https://jira.nuxeo.com/browse/NXDRIVE-2339): Tell `test_proxy.py` to use a temporary folder instead of the current directory
 - [NXDRIVE-2345](https://jira.nuxeo.com/browse/NXDRIVE-2345): Fix `test_site_update_url()`
 - [NXDRIVE-2348](https://jira.nuxeo.com/browse/NXDRIVE-2348): Fix `test_updater.py`
+- [NXDRIVE-2376](https://jira.nuxeo.com/browse/NXDRIVE-2376): Use the dedicated test server whenever possible
 
 ## Docs
 

--- a/nxdrive/manager.py
+++ b/nxdrive/manager.py
@@ -247,6 +247,10 @@ class Manager(QObject):
     def close(self) -> None:
         try:
             self.stop()
+        except RuntimeError:
+            # wrapped C/C++ object of type Manager has been deleted
+            # Happens on Windows when running functional tests
+            pass
         finally:
             Manager._instances.pop(self.home, None)
 

--- a/tests/functional/test_server_options.py
+++ b/tests/functional/test_server_options.py
@@ -2,6 +2,7 @@ from time import sleep
 from unittest.mock import patch
 
 import pytest
+
 from nxdrive.behavior import Behavior
 from nxdrive.feature import Feature
 from nxdrive.options import Options
@@ -180,4 +181,4 @@ def test_delay_remote_watcher(app, manager_factory):
                 # Check remote checks are using the new delay
                 count = 0
                 sleep(10)
-                assert count > 4
+                assert count >= 4


### PR DESCRIPTION
Great news, I also unlocked:
- NXDRIVE-2071: Use GitHub Actions to run functional tests 