### PR TITLE
NXDRIVE-2379: Review how the GUI is repainted to fix a crash

### DIFF
--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -44,6 +44,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2349](https://jira.nuxeo.com/browse/NXDRIVE-2349): Fix a QML margin in the account addition
 - [NXDRIVE-2353](https://jira.nuxeo.com/browse/NXDRIVE-2353): Fix the window centering for multi-screen setup
 - [NXDRIVE-2359](https://jira.nuxeo.com/browse/NXDRIVE-2359): Improve question message boxes rendering
+- [NXDRIVE-2379](https://jira.nuxeo.com/browse/NXDRIVE-2379): Review how the GUI is repainted to fix a crash
 - [NXDRIVE-2389](https://jira.nuxeo.com/browse/NXDRIVE-2389): Update Qt Quick Controls version for PyQt 5.15
 - [NXDRIVE-2393](https://jira.nuxeo.com/browse/NXDRIVE-2393): Display a proper error message when the nuxeo-drive addon is not installed on the server
 
@@ -135,6 +136,8 @@ Release date: `2020-xx-xx`
 - Added `TransferStatus.CANCELLED`
 - Added `Upload.batch_obj`
 - Removed `cls` keyword argument from utils.py::`normalized_path()`
+- Added constants.py::`DT_ACTIVE_SESSIONS_MAX_ITEMS`
+- Added constants.py::`DT_MONITORING_MAX_ITEMS`
 - Added exceptions.py::`AddonNotInstalledError`
 - Added exceptions.py::`TransferCancelled`
 - Added exceptions.py::`UploadCancelled`

--- a/nxdrive/constants.py
+++ b/nxdrive/constants.py
@@ -31,6 +31,12 @@ BATCH_SIZE = 500  # Scroll descendants batch size (max is 1,000)
 # time, the server will finish way before that timeout.
 TX_TIMEOUT = 60 * 60 * 6  # 6 hours
 
+# Number of transfers displayed in the Direct Transfer window, onto the monitoring tab
+DT_MONITORING_MAX_ITEMS = 5
+
+# Number of sessions displayed in the Direct Transfer window, onto the active sessions tab
+DT_ACTIVE_SESSIONS_MAX_ITEMS = 15
+
 # Default update channel
 DEFAULT_CHANNEL = "centralized"
 

--- a/nxdrive/data/qml/DirectTransfer.qml
+++ b/nxdrive/data/qml/DirectTransfer.qml
@@ -69,6 +69,7 @@ Rectangle {
                 text: qsTr("NEW_TRANSFER") + tl.tr
                 Layout.alignment: Qt.AlignRight
                 Layout.rightMargin: 30
+                enabled: !ActiveSessionModel.is_full
                 onClicked: api.open_server_folders(engineUid)
             }
         }

--- a/nxdrive/data/qml/SessionItem.qml
+++ b/nxdrive/data/qml/SessionItem.qml
@@ -8,8 +8,9 @@ Rectangle {
     id: control
     property bool active: status == "PAUSED" || status == "ONGOING"
     property bool paused: status == "PAUSED"
+    visible: !shadow
     width: parent ? parent.width : 0
-    height: 116
+    height: shadow ? 0: 116
     RowLayout {
         anchors.fill: parent
         anchors.centerIn: parent

--- a/nxdrive/data/qml/TransferItem.qml
+++ b/nxdrive/data/qml/TransferItem.qml
@@ -7,8 +7,9 @@ import "icon-font/Icon.js" as MdiFont
 Rectangle {
     id: control
     property bool paused: status == "PAUSED" || status == "SUSPENDED"
+    visible: !shadow
     width: parent ? parent.width : 0
-    height: 55
+    height: shadow ? 0: 55
 
     ColumnLayout {
         id: transfer

--- a/nxdrive/gui/api.py
+++ b/nxdrive/gui/api.py
@@ -19,6 +19,7 @@ from ..constants import (
     APP_NAME,
     CONNECTION_ERROR,
     DEFAULT_SERVER_TYPE,
+    DT_MONITORING_MAX_ITEMS,
     TOKEN_PERMISSION,
     TransferStatus,
 )
@@ -209,8 +210,8 @@ class QMLDriveApi(QObject):
         return result
 
     def get_direct_transfer_items(self, dao: EngineDAO) -> List[Dict[str, Any]]:
-        # 5 files are displayed in the DT window
-        return dao.get_dt_uploads_raw(limit=5)
+        """Fetch at most *DT_MONITORING_MAX_ITEMS* transfers from the database."""
+        return dao.get_dt_uploads_raw(limit=DT_MONITORING_MAX_ITEMS)
 
     def get_active_sessions_items(self, dao: EngineDAO) -> List[Dict[str, Any]]:
         """Fetch the list of active sessions from the database."""

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -1668,15 +1668,23 @@ class Application(QApplication):
     @pyqtSlot(object)
     def refresh_direct_transfer_items(self, dao: EngineDAO) -> None:
         transfers = self.api.get_direct_transfer_items(dao)
-        if transfers != self.direct_transfer_model.items:
-            self.direct_transfer_model.set_items(transfers)
+        items = self.direct_transfer_model.items
+        if transfers != items:
+            if not items:
+                self.direct_transfer_model.set_items(transfers)
+            else:
+                self.direct_transfer_model.update_items(transfers)
 
     @pyqtSlot(object)
     def refresh_active_sessions_items(self, dao: EngineDAO) -> None:
         """Refresh the list of active sessions if a change is detected."""
         sessions = self.api.get_active_sessions_items(dao)
-        if sessions != self.active_session_model.sessions:
-            self.active_session_model.set_sessions(sessions)
+        current_sessions = self.active_session_model.sessions
+        if sessions != current_sessions:
+            if not current_sessions:
+                self.active_session_model.set_sessions(sessions)
+            else:
+                self.active_session_model.update_sessions(sessions)
 
     @pyqtSlot(object)
     def refresh_completed_sessions_items(self, dao: EngineDAO) -> None:

--- a/tools/skiplist.py
+++ b/tools/skiplist.py
@@ -1,6 +1,7 @@
 # Code to ignore for Vulture.
 
 AbstractOSIntegration.cb_get  # OSI
+ActiveSessionModel.is_full  # Used in QML
 Application.about_to_quit  # Used in QML
 Application.close_direct_transfer_window  # Used in QML
 Application.confirm_cancel_transfer  # Used in QML


### PR DESCRIPTION
Previously, items were added and removed from the ListView when a change in sessions or direct transfer items was detected.
This behaviour caused the app to crash if an item from the list was removed while in use (cancel popup).

Now, a fixed list of items is used an just edited when changes are detected, preventing the interface to remove used items.