### PR TITLE
NXDRIVE-2389: Update Qt Quick Controls version for PyQt 5.15

### DIFF
--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -43,6 +43,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2349](https://jira.nuxeo.com/browse/NXDRIVE-2349): Fix a QML margin in the account addition
 - [NXDRIVE-2353](https://jira.nuxeo.com/browse/NXDRIVE-2353): Fix the window centering for multi-screen setup
 - [NXDRIVE-2359](https://jira.nuxeo.com/browse/NXDRIVE-2359): Improve question message boxes rendering
+- [NXDRIVE-2389](https://jira.nuxeo.com/browse/NXDRIVE-2389): Update Qt Quick Controls version for PyQt 5.15
 
 ## Packaging / Build
 

--- a/nxdrive/data/qml/AboutTab.qml
+++ b/nxdrive/data/qml/AboutTab.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 import "icon-font/Icon.js" as MdiFont
 
 Rectangle {
@@ -73,7 +73,6 @@ Rectangle {
             width: parent.width
             wrapMode: Text.WordWrap
             font.family: "Courier"
-            // GPL.txt content
             text: "The source code of Nuxeo Drive is available under the LGPL 2.1." +
                   "https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html\n\n" +
                   "Nuxeo Drive depends on those components:" +

--- a/nxdrive/data/qml/AccountsComboBox.qml
+++ b/nxdrive/data/qml/AccountsComboBox.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 NuxeoComboBox {
     id: control

--- a/nxdrive/data/qml/AccountsTab.qml
+++ b/nxdrive/data/qml/AccountsTab.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 import "icon-font/Icon.js" as MdiFont
 
 Rectangle {

--- a/nxdrive/data/qml/Alert.qml
+++ b/nxdrive/data/qml/Alert.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.13
+import QtQuick 2.15
 
 ShadowRectangle {
     id: control

--- a/nxdrive/data/qml/ChannelPopup.qml
+++ b/nxdrive/data/qml/ChannelPopup.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 NuxeoPopup {
     id: control

--- a/nxdrive/data/qml/ConfirmPopup.qml
+++ b/nxdrive/data/qml/ConfirmPopup.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.13
-import QtQuick.Layouts 1.13
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
 
 NuxeoPopup {
     id: control

--- a/nxdrive/data/qml/Conflicts.qml
+++ b/nxdrive/data/qml/Conflicts.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
-import QtQuick.Window 2.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Window 2.15
 
 Rectangle {
     id: conflicts

--- a/nxdrive/data/qml/DeletionPopup.qml
+++ b/nxdrive/data/qml/DeletionPopup.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 NuxeoPopup {
     id: control

--- a/nxdrive/data/qml/DirectTransfer.qml
+++ b/nxdrive/data/qml/DirectTransfer.qml
@@ -1,8 +1,7 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
-import QtQuick.Window 2.13
-import QtQuick.Controls.Styles 1.4
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Window 2.15
 import "icon-font/Icon.js" as MdiFont
 
 Rectangle {

--- a/nxdrive/data/qml/FeaturesTab.qml
+++ b/nxdrive/data/qml/FeaturesTab.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 Rectangle {
     id: control

--- a/nxdrive/data/qml/FileCard.qml
+++ b/nxdrive/data/qml/FileCard.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 ShadowRectangle {
     id: control

--- a/nxdrive/data/qml/GPL.txt
+++ b/nxdrive/data/qml/GPL.txt
@@ -1,9 +1,0 @@
-The source code of Nuxeo Drive is available under the LGPL 2.1.
-https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
-
-Nuxeo Drive depends on those components:
-- Qt: GNU Lesser General Public License, version 3
-- PyQt: GNU General Public License, version 2 or 3
-
-Thus any code written on the top of Nuxeo Drive must be distributed
-under the terms of a GPL compliant license.

--- a/nxdrive/data/qml/GeneralTab.qml
+++ b/nxdrive/data/qml/GeneralTab.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 Rectangle {
     id: control

--- a/nxdrive/data/qml/HorizontalSeparator.qml
+++ b/nxdrive/data/qml/HorizontalSeparator.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.13
+import QtQuick 2.15
 
 Rectangle {
     property real factor: 1.0

--- a/nxdrive/data/qml/HoverRectangle.qml
+++ b/nxdrive/data/qml/HoverRectangle.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.13
+import QtQuick 2.15
 
 Rectangle {
     id: control

--- a/nxdrive/data/qml/IconLabel.qml
+++ b/nxdrive/data/qml/IconLabel.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.13
+import QtQuick 2.15
 
  ScaledText {
     id: control

--- a/nxdrive/data/qml/IconLink.qml
+++ b/nxdrive/data/qml/IconLink.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.13
-import QtQuick.Layouts 1.13
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
 
 RowLayout {
     id: control

--- a/nxdrive/data/qml/Link.qml
+++ b/nxdrive/data/qml/Link.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.13
+import QtQuick 2.15
 
 ScaledText {
     id: control

--- a/nxdrive/data/qml/LogLevelPopup.qml
+++ b/nxdrive/data/qml/LogLevelPopup.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 NuxeoPopup {
     id: control

--- a/nxdrive/data/qml/Main.qml
+++ b/nxdrive/data/qml/Main.qml
@@ -1,5 +1,8 @@
-import QtQuick 2.13
-import QtQuick.Window 2.13
+// Import versions are 2.x where x is the Qt minor version
+// Exception for QtQuick.Layouts which use 1.x
+// https://doc.qt.io/qt-5/qtquickcontrols-index.html
+import QtQuick 2.15
+import QtQuick.Window 2.15
 import SystrayWindow 1.0
 
 QtObject {

--- a/nxdrive/data/qml/NewAccountPopup.qml
+++ b/nxdrive/data/qml/NewAccountPopup.qml
@@ -1,6 +1,7 @@
-import QtQuick 2.13
+import QtQuick 2.15
+// QtQuick.Dialogs has another unknown versioning
 import QtQuick.Dialogs 1.3
-import QtQuick.Layouts 1.13
+import QtQuick.Layouts 1.15
 import "icon-font/Icon.js" as MdiFont
 
 NuxeoPopup {

--- a/nxdrive/data/qml/NuxeoButton.qml
+++ b/nxdrive/data/qml/NuxeoButton.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 Button {
     id: control

--- a/nxdrive/data/qml/NuxeoCheckBox.qml
+++ b/nxdrive/data/qml/NuxeoCheckBox.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 CheckBox {
     id: control

--- a/nxdrive/data/qml/NuxeoComboBox.qml
+++ b/nxdrive/data/qml/NuxeoComboBox.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import "icon-font/Icon.js" as MdiFont
 
 ComboBox {

--- a/nxdrive/data/qml/NuxeoInput.qml
+++ b/nxdrive/data/qml/NuxeoInput.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.13
+import QtQuick 2.15
 
 TextInput {
     id: control

--- a/nxdrive/data/qml/NuxeoPopup.qml
+++ b/nxdrive/data/qml/NuxeoPopup.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 Popup {
     id: control

--- a/nxdrive/data/qml/NuxeoProgressBar.qml
+++ b/nxdrive/data/qml/NuxeoProgressBar.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 ProgressBar {
     id: control

--- a/nxdrive/data/qml/NuxeoRadioButton.qml
+++ b/nxdrive/data/qml/NuxeoRadioButton.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 RadioButton {
     id: control

--- a/nxdrive/data/qml/NuxeoSwitch.qml
+++ b/nxdrive/data/qml/NuxeoSwitch.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 Switch {
     id: control

--- a/nxdrive/data/qml/NuxeoToolTip.qml
+++ b/nxdrive/data/qml/NuxeoToolTip.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 ToolTip {
     id: control

--- a/nxdrive/data/qml/PauseButton.qml
+++ b/nxdrive/data/qml/PauseButton.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.13
+import QtQuick 2.15
 import "icon-font/Icon.js" as MdiFont
 
 IconLabel {

--- a/nxdrive/data/qml/ProxyPopup.qml
+++ b/nxdrive/data/qml/ProxyPopup.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 NuxeoPopup {
     id: control

--- a/nxdrive/data/qml/RectangleTooltip.qml
+++ b/nxdrive/data/qml/RectangleTooltip.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 Rectangle {
     id: control

--- a/nxdrive/data/qml/ScaledText.qml
+++ b/nxdrive/data/qml/ScaledText.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.13
+import QtQuick 2.15
 
 Text {
     font.pointSize: point_size

--- a/nxdrive/data/qml/SelectableText.qml
+++ b/nxdrive/data/qml/SelectableText.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.13
+import QtQuick 2.15
 
 TextEdit {
     font.pointSize: point_size

--- a/nxdrive/data/qml/SessionItem.qml
+++ b/nxdrive/data/qml/SessionItem.qml
@@ -1,8 +1,7 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Controls.Styles 1.4
-import QtQuick.Layouts 1.13
-import QtQuick.Window 2.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Window 2.15
 import "icon-font/Icon.js" as MdiFont
 
 Rectangle {

--- a/nxdrive/data/qml/Settings.qml
+++ b/nxdrive/data/qml/Settings.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
-import QtQuick.Window 2.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Window 2.15
 
 Item {
     id: settings

--- a/nxdrive/data/qml/SettingsTab.qml
+++ b/nxdrive/data/qml/SettingsTab.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 TabButton {
     id: control

--- a/nxdrive/data/qml/ShadowRectangle.qml
+++ b/nxdrive/data/qml/ShadowRectangle.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.13
+import QtQuick 2.15
 
 Rectangle {
     id: control

--- a/nxdrive/data/qml/Systray.qml
+++ b/nxdrive/data/qml/Systray.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
-import QtQuick.Window 2.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Window 2.15
 import "icon-font/Icon.js" as MdiFont
 
 Rectangle {

--- a/nxdrive/data/qml/SystrayFile.qml
+++ b/nxdrive/data/qml/SystrayFile.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 import "icon-font/Icon.js" as MdiFont
 
 Rectangle {

--- a/nxdrive/data/qml/SystrayMenu.qml
+++ b/nxdrive/data/qml/SystrayMenu.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 ShadowRectangle {
     id: control

--- a/nxdrive/data/qml/SystrayMenuItem.qml
+++ b/nxdrive/data/qml/SystrayMenuItem.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 Rectangle {
     id: control

--- a/nxdrive/data/qml/SystrayStatus.qml
+++ b/nxdrive/data/qml/SystrayStatus.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 import "icon-font/Icon.js" as MdiFont
 
 HoverRectangle {

--- a/nxdrive/data/qml/SystrayTransfer.qml
+++ b/nxdrive/data/qml/SystrayTransfer.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 import "icon-font/Icon.js" as MdiFont
 
 Rectangle {

--- a/nxdrive/data/qml/TransferItem.qml
+++ b/nxdrive/data/qml/TransferItem.qml
@@ -1,8 +1,7 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
-import QtQuick.Window 2.13
-import QtQuick.Controls.Styles 1.4
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Window 2.15
 import "icon-font/Icon.js" as MdiFont
 
 Rectangle {


### PR DESCRIPTION
QML import for `QtQuick` should be `2.x` where `x` is the Qt minor version. See https://doc.qt.io/qt-5/qtquickcontrols-index.html.

One exception is `QtQuick.Layouts` which use `1.x`. There is another exception: `QtQuick.Dialogs` which use an unknown versioning semantic.

I also removed `QtQuick.Controls.Styles` which was unused and is actually deprecated since Qt 5.12.