### PR TITLE
NXDRIVE-2391: [macOS] Add required entitlement for Apple events

### DIFF
--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -53,6 +53,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2347](https://jira.nuxeo.com/browse/NXDRIVE-2347): Fix packaging following the sentry-sdk upgrade to 0.19.0
 - [NXDRIVE-2370](https://jira.nuxeo.com/browse/NXDRIVE-2370): Allow dependabot to check GitHub actions monthly
 - [NXDRIVE-2390](https://jira.nuxeo.com/browse/NXDRIVE-2390): Improve the final package clean-up script
+- [NXDRIVE-2391](https://jira.nuxeo.com/browse/NXDRIVE-2391): [macOS] Add required entitlement for Apple events
 
 ## Tests
 

--- a/tools/osx/entitlements.plist
+++ b/tools/osx/entitlements.plist
@@ -5,5 +5,7 @@
     <!-- These are required for binaries built by PyInstaller -->
 	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
 	<true/>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
This is required for the upcoming PyInstaller version that will allow to handle Apple events.