### PR TITLE
NXDRIVE-2270: [macOS] Big Sur support

### DIFF
--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -4,6 +4,7 @@ Release date: `2020-xx-xx`
 
 ## Core
 
+- [NXDRIVE-2270](https://jira.nuxeo.com/browse/NXDRIVE-2270): [macOS] Big Sur support
 - [NXDRIVE-2311](https://jira.nuxeo.com/browse/NXDRIVE-2311): Add an option to control doc types where Direct Transfer is disallowed
 - [NXDRIVE-2319](https://jira.nuxeo.com/browse/NXDRIVE-2319): Do not use the undocumented and unreliable `Path.absolute()` method
 - [NXDRIVE-2322](https://jira.nuxeo.com/browse/NXDRIVE-2322): Do not retry a HTTP call that failed on 500 error

--- a/nxdrive/__main__.py
+++ b/nxdrive/__main__.py
@@ -12,13 +12,31 @@ from contextlib import suppress
 from types import FrameType
 from typing import Any, Set
 
-from nxdrive.constants import APP_NAME
+from nxdrive.constants import APP_NAME, MAC
 from nxdrive.fatal_error import (
     check_executable_path,
     check_os_version,
     show_critical_error,
 )
 from nxdrive.options import Options
+
+if MAC:
+    # NXDRIVE-2270: this envar is required in order to support Big Sur.
+    #
+    # From Tor Arne Vestbø, a Qt core-dev:
+    #
+    #   macOS nowadays (10.14 and above) defaults to apps using CoreAnimation layers for their views,
+    #   if the app was built using Xcode 10 or above, to opt in to this behavior.
+    #
+    #   The legacy code path, surface-backed views, appears to have regressed in macOS Big Sur.
+    #   It may be an issue in Qt's use of this mode, or a regression in macOS, or both, but
+    #   investigating it is not a high priority.
+    #
+    #   The QT_MAC_WANTS_LAYER environment variable tells Qt to use layers even if it's not
+    #   automatically enabled by macOS based on the Xcode version you used to build.
+    #
+    #   Clarification: Layer-backed views are not a problem on newer macOS, surface-backed views are.
+    os.environ["QT_MAC_WANTS_LAYER"] = "1"
 
 
 def before_send(event: Any, _hint: Any) -> Any:


### PR DESCRIPTION
This is a commit ahead of the time: it will make sens only when we will be using Python 3.8.6+ and PyInstaller 4.1+.

But it has been verified that using those versions + this patch make the app working on macOS Big Sur.

Note: we still can't use Big Sur as a development machine due to issues on other modules (`packaging`), Python and Qt.