### PR TITLE
NXDRIVE-2395: [Windows] Upgrade Inno Setup from 6.0.5 to 6.1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ jobs:
     name: Windows [.exe]
     os: windows
     env:
-      - INNO_SETUP_VERSION="6.0.5"  # XXX_INNO_SETUP
+      - INNO_SETUP_VERSION="6.1.2"  # XXX_INNO_SETUP
       - MSBUILD_PATH="C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin"
       - SIGNING_ID="Nuxeo"
       - SIGNTOOL_PATH="C:\Program Files (x86)\Windows Kits\10\bin\x86"

--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -57,6 +57,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2370](https://jira.nuxeo.com/browse/NXDRIVE-2370): Allow dependabot to check GitHub actions monthly
 - [NXDRIVE-2390](https://jira.nuxeo.com/browse/NXDRIVE-2390): Improve the final package clean-up script
 - [NXDRIVE-2391](https://jira.nuxeo.com/browse/NXDRIVE-2391): [macOS] Add required entitlement for Apple events
+- [NXDRIVE-2395](https://jira.nuxeo.com/browse/NXDRIVE-2395): [Windows] Upgrade `Inno Setup` from 6.0.5 to 6.1.2
 
 ## Tests
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -23,6 +23,7 @@ Check the [supported OS](https://doc.nuxeo.com/client-apps/nuxeo-drive-faq/#what
 
 History:
 
+- `2019-11-xx` (v4.4.6): dropped support for Windows 7 without SP1
 - `2019-11-14` (v4.3.0): dropped support for macOS 10.11
 - `2019-09-26` (v4.2.0): added support for GNU/Linux
 - `2018-06-11` (v3.1.1): dropped support for macOS 10.10

--- a/tools/windows/setup-addons.iss
+++ b/tools/windows/setup-addons.iss
@@ -25,7 +25,6 @@ SetupIconFile=app_icon.ico
 WizardImageFile=wizard.bmp
 WizardSmallImageFile=wizard-small.bmp
 WizardStyle=modern
-MinVersion=6.1.7600
 
 ; Overlays
 #include "setup-overlay.iss"

--- a/tools/windows/setup-common.iss
+++ b/tools/windows/setup-common.iss
@@ -34,10 +34,6 @@ WizardSmallImageFile=wizard-small.bmp
 ; Use a modern look
 WizardStyle=modern
 
-; Minimum Windows version required
-; http://www.jrsoftware.org/ishelp/index.php?topic=winvernotes
-MinVersion=6.1.7600
-
 ; Other
 Compression=lzma
 SolidCompression=yes


### PR DESCRIPTION
That means:

- We do not support anymore Windows 7 without SP1.
- The minimum Windows version required is Windows 7 SP1.