### PR TITLE
NXDRIVE-2397: Small improvement for non-chunked uploads

### DIFF
--- a/docs/changes/4.4.6.md
+++ b/docs/changes/4.4.6.md
@@ -22,6 +22,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2375](https://jira.nuxeo.com/browse/NXDRIVE-2375): Remove usages of the deprecated `Blob.batch_id` attribute for `batchId`
 - [NXDRIVE-2377](https://jira.nuxeo.com/browse/NXDRIVE-2377): Force database commit before application exit
 - [NXDRIVE-2385](https://jira.nuxeo.com/browse/NXDRIVE-2385): Ignore Arabic translations until fully ready
+- [NXDRIVE-2397](https://jira.nuxeo.com/browse/NXDRIVE-2397): Small improvement for non-chunked uploads
 
 ### Direct Edit
 
@@ -99,8 +100,10 @@ Release date: `2020-xx-xx`
 - Added `Application.question()`
 - Added `Application.refresh_active_sessions_items()`
 - Added `Application.refresh_completed_sessions_items()`
+- Added `chunked` argument to `BaseUploader.link_blob_to_doc()`
 - Added `transfer` argument to `BaseUploader.link_blob_to_doc()`
 - Added `blob` argument to `BaseUploader.upload_chunks()`
+- Added `chunked` argument to `BaseUploader.upload_chunks()`
 - Added `transfer` argument to `BaseUploader.upload_chunks()`
 - Removed `file_path` argument from `BaseUploader.upload_chunks()`. Use `transfer.path` instead.
 - Removed `filename` keyword argument from `BaseUploader.upload_chunks()`


### PR DESCRIPTION
With NXDRIVE-2298, we made use of the `X-Batch-No-Drop` HTTP header when finalizing an upload. And then, the `batchId` had to be removed manually, doing one HTTP call for that.

That is useful for large uploads but the HTTP call can be saved for non-chunked uploads.