### PR TITLE
NXDRIVE-2380: [Direct Edit] Fix a regression when the provided digest…

### DIFF
--- a/nxdrive/objects.py
+++ b/nxdrive/objects.py
@@ -157,13 +157,13 @@ class Blob:
         """ Convert Dict to Blob object. """
         name = blob["name"]
         digest = blob.get("digest") or ""
-        digest_algorithm = blob.get("digestAlgorithm", "")
+        digest_algorithm = blob.get("digestAlgorithm") or ""
         size = int(blob.get("length", 0))
-        mimetype = blob.get("mime-type", "")
-        data = blob.get("data", "")
+        mimetype = blob.get("mime-type") or ""
+        data = blob.get("data") or ""
 
-        if digest_algorithm:
-            digest_algorithm = get_digest_algorithm(digest_algorithm) or ""
+        if digest and not digest_algorithm:
+            digest_algorithm = get_digest_algorithm(digest) or ""
         if digest_algorithm:
             digest_algorithm = digest_algorithm.lower().replace("-", "")
 

--- a/tests/old_functional/test_direct_edit.py
+++ b/tests/old_functional/test_direct_edit.py
@@ -587,8 +587,8 @@ class MixinTests(DirectEditSetup):
 
         def from_dict(blob: Dict[str, Any]) -> Blob:
             # Alter digest stuff
-            blob.pop("digest", None)
-            blob.pop("digestAlgorithm", None)
+            blob["digest"] = None
+            blob["digestAlgorithm"] = None
             return from_dict_orig(blob)
 
         filename = "picture-digestless.png"


### PR DESCRIPTION
…Algorithm is None

    AttributeError: 'NoneType' object has no attribute 'encode'
      File "nxdrive/direct_edit.py", line 552, in edit
      File "nxdrive/direct_edit.py", line 530, in _prepare_edit

Also:

- Fixed potential similar issues with `mime-type` and `data`.
- Fixed the code guessing the digest from the algo that was using the algo itself.