### PR TITLE
NXDRIVE-2408: Add debugging logs to help understanding the issue

### DIFF
--- a/tests/old_functional/test_local_share_move_folders.py
+++ b/tests/old_functional/test_local_share_move_folders.py
@@ -14,8 +14,8 @@ class TestLocalShareMoveFolders(TwoUsersTest):
 
     def setUp(self):
         """
-        1. Create folder a1 in Nuxeo Drive Test Workspace sycn root
-        2. Create folder a2 in Nuxeo Drive Test Workspace sycn root
+        1. Create folder a1 in Nuxeo Drive Test Workspace sync root
+        2. Create folder a2 in Nuxeo Drive Test Workspace sync root
         3. Add 10 image files in a1
         """
 

--- a/tests/old_functional/test_synchronization.py
+++ b/tests/old_functional/test_synchronization.py
@@ -4,9 +4,10 @@ from pathlib import Path
 from unittest.mock import patch
 
 from nuxeo.exceptions import HTTPError, Unauthorized
+from requests import ConnectionError
+
 from nxdrive.constants import ROOT, WINDOWS
 from nxdrive.utils import safe_filename
-from requests import ConnectionError
 
 from .. import ensure_no_exception
 from . import LocalTest
@@ -832,7 +833,7 @@ class TestSynchronization(OneUserTest):
         engine.start()
 
         # Create the folder
-        root_name = "Été indien"
+        root_name = "Été indian"
         root = remote.make_folder(self.workspace, root_name)
         self.wait_sync(wait_for_async=True)
         assert local.exists("/" + root_name)


### PR DESCRIPTION
Before the upcoming release, I wanted to add debug logs into the extenstion server startup code to help catching/understanding what is the issue on macOS when it would not start because of a local address set to `None`.