### PR TITLE
NXDRIVE-2434: [macOS] Fix 'NSError' object has no attribute 'utf8Valu…

### DIFF
--- a/docs/changes/4.5.0.md
+++ b/docs/changes/4.5.0.md
@@ -78,6 +78,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2345](https://jira.nuxeo.com/browse/NXDRIVE-2345): Fix `test_site_update_url()`
 - [NXDRIVE-2348](https://jira.nuxeo.com/browse/NXDRIVE-2348): Fix `test_updater.py`
 - [NXDRIVE-2376](https://jira.nuxeo.com/browse/NXDRIVE-2376): Use the dedicated test server whenever possible
+- [NXDRIVE-2434](https://jira.nuxeo.com/browse/NXDRIVE-2434): [macOS] Fix `NSError` object has no attribute `utf8ValueSafe`
 
 ## Docs
 

--- a/tests/old_functional/local_client_darwin.py
+++ b/tests/old_functional/local_client_darwin.py
@@ -62,4 +62,7 @@ class MacLocalClient(LocalTest):
     def _process_result(result):
         ok, err = result
         if not ok:
-            raise OSError(err.utf8ValueSafe())
+            error = (
+                f"{err.localizedDescription()} (cause: {err.localizedFailureReason()})"
+            )
+            raise OSError(error)


### PR DESCRIPTION
…eSafe'