### PR TITLE
NXDRIVE-2330: [Windows] Do not alter boot start state from the instal…

### DIFF
--- a/docs/changes/4.5.0.md
+++ b/docs/changes/4.5.0.md
@@ -116,6 +116,9 @@ Release date: `2020-xx-xx`
 
 ## Technical Changes
 
+- Added `AbstractOSIntegration.startup_enabled()`
+- Changed `AbstractOSIntegration.register_startup()` return type from `bool` to `None`
+- Changed `AbstractOSIntegration.unregister_startup()` return type from `bool` to `None`
 - Added `Application.confirm_cancel_session()`
 - Added `Application.question()`
 - Added `Application.refresh_active_sessions_items()`
@@ -133,6 +136,9 @@ Release date: `2020-xx-xx`
 - Removed `mime_type` keyword argument from `BaseUploader.upload_impl()`
 - Removed `kwargs` keyword arguments from `BaseUploader.upload_chunks()`
 - Added `ConfigurationDAO.force_commit()`
+- Added `DarwinIntegration.startup_enabled()`
+- Changed `DarwinIntegration.register_startup()` return type from `bool` to `None`
+- Changed `DarwinIntegration.unregister_startup()` return type from `bool` to `None`
 - Removed `mime_type` keyword argument from `DirectTransferUploader.upload()`
 - Added `Engine.cancel_session()`
 - Added `Engine.decrease_session_planned_items()`
@@ -149,6 +155,7 @@ Release date: `2020-xx-xx`
 - Added `EngineDAO.get_completed_sessions_raw()`
 - Added `EngineDAO.pause_session()`
 - Added `EngineDAO.sessionUpdated`
+- Changed `Manager.set_auto_start()` return type from `bool` to `None`
 - Added `Options.disallowed_types_for_dt`
 - Removed `mime_type` keyword argument from  `Remote.stream_file()`
 - Added `Session.completed_on`
@@ -166,9 +173,13 @@ Release date: `2020-xx-xx`
 - Added `QMLDriveApi.open_server_folders()`
 - Added `QMLDriveApi.pause_session()`
 - Added `QMLDriveApi.resume_session()`
+- Changed `QMLDriveApi.set_auto_start()` return type from `bool` to `None`
 - Removed `QMLDriveApi.get_dt_items_count()`
 - Added `TransferStatus.CANCELLED`
 - Added `Upload.batch_obj`
+- Added `WindowsIntegration.startup_enabled()`
+- Changed `WindowsIntegration.register_startup()` return type from `bool` to `None`
+- Changed `WindowsIntegration.unregister_startup()` return type from `bool` to `None`
 - Removed `cls` keyword argument from utils.py::`normalized_path()`
 - Added constants.py::`DT_ACTIVE_SESSIONS_MAX_ITEMS`
 - Added constants.py::`DT_MONITORING_MAX_ITEMS`

--- a/docs/changes/4.5.0.md
+++ b/docs/changes/4.5.0.md
@@ -59,6 +59,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2312](https://jira.nuxeo.com/browse/NXDRIVE-2312): Upgrade Python from 3.7.9 to 3.8.6
 - [NXDRIVE-2314](https://jira.nuxeo.com/browse/NXDRIVE-2314): Remove more files from the final package
 - [NXDRIVE-2315](https://jira.nuxeo.com/browse/NXDRIVE-2315): Do not show the progress bar on module installation
+- [NXDRIVE-2330](https://jira.nuxeo.com/browse/NXDRIVE-2230): [Windows] Do not alter boot start state from the installer when auto-updating the app
 - [NXDRIVE-2347](https://jira.nuxeo.com/browse/NXDRIVE-2347): Fix packaging following the sentry-sdk upgrade to 0.19.0
 - [NXDRIVE-2370](https://jira.nuxeo.com/browse/NXDRIVE-2370): Allow dependabot to check GitHub actions monthly
 - [NXDRIVE-2390](https://jira.nuxeo.com/browse/NXDRIVE-2390): Improve the final package clean-up script

--- a/nxdrive/data/qml/GeneralTab.qml
+++ b/nxdrive/data/qml/GeneralTab.qml
@@ -17,11 +17,16 @@ Rectangle {
 
         NuxeoSwitch {
             text: qsTr("AUTOSTART") + tl.tr
-            enabled: isFrozen && !LINUX
-            checked: manager.get_auto_start() && !LINUX
+            enabled: isFrozen
+            checked: manager.get_auto_start()
             onClicked: {
-                var success = manager.set_auto_start(checked)
-                if (!success) { checked = !checked }
+                enabled = false
+                try {
+                    manager.set_auto_start(checked)
+                    checked = manager.get_auto_start()
+                } finally {
+                    enabled = true
+                }
             }
             Layout.leftMargin: -5
         }

--- a/nxdrive/gui/api.py
+++ b/nxdrive/gui/api.py
@@ -343,9 +343,9 @@ class QMLDriveApi(QObject):
             result.append([title, feature, translation_key])
         return result
 
-    @pyqtSlot(bool, result=bool)
-    def set_auto_start(self, value: bool) -> bool:
-        return self._manager.set_auto_start(value)
+    @pyqtSlot(bool)
+    def set_auto_start(self, value: bool) -> None:
+        self._manager.set_auto_start(value)
 
     @pyqtSlot(result=bool)
     def get_auto_start(self) -> bool:

--- a/nxdrive/osi/__init__.py
+++ b/nxdrive/osi/__init__.py
@@ -35,11 +35,15 @@ class AbstractOSIntegration(QObject):
         """
         pass
 
-    def register_startup(self) -> bool:
+    def startup_enabled(self) -> bool:
+        """Return True if the application is registered to boot at machine startup."""
         return False
 
-    def unregister_startup(self) -> bool:
-        return False
+    def register_startup(self) -> None:
+        pass
+
+    def unregister_startup(self) -> None:
+        pass
 
     @staticmethod
     def is_partition_supported(folder: Path) -> bool:

--- a/nxdrive/osi/windows/windows.py
+++ b/nxdrive/osi/windows/windows.py
@@ -198,15 +198,24 @@ class WindowsIntegration(AbstractOSIntegration):
         self._get_folder_link(path.name).unlink(missing_ok=True)
 
     @if_frozen
-    def register_startup(self) -> bool:
-        return registry.write(
+    def startup_enabled(self) -> bool:
+        values = registry.read("Software\\Microsoft\\Windows\\CurrentVersion\\Run")
+        return bool(values and APP_NAME in values)
+
+    @if_frozen
+    def register_startup(self) -> None:
+        if self.startup_enabled():
+            return
+        registry.write(
             "Software\\Microsoft\\Windows\\CurrentVersion\\Run",
             {APP_NAME: sys.executable},
         )
 
     @if_frozen
-    def unregister_startup(self) -> bool:
-        return registry.delete_value(
+    def unregister_startup(self) -> None:
+        if not self.startup_enabled():
+            return
+        registry.delete_value(
             "Software\\Microsoft\\Windows\\CurrentVersion\\Run", APP_NAME
         )
 


### PR DESCRIPTION
…ler when auto-updating the app

I also reworked the auto start handling.

There is now a clear separation between the setter and getter. This introduces a small change for macOS users: by default the app will not be startup on boot. The feature must be selected from the settings window.