### PR TITLE
[Direct Transfer] Remove pause button on the monitoring tab

### DIFF
--- a/docs/changes/4.5.0.md
+++ b/docs/changes/4.5.0.md
@@ -39,6 +39,7 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2331](https://jira.nuxeo.com/browse/NXDRIVE-2331): Check for ignored patterns against lowercased names
 - [NXDRIVE-2341](https://jira.nuxeo.com/browse/NXDRIVE-2341): Non-chunked uploads must be put in pause when the session is paused
 - [NXDRIVE-2432](https://jira.nuxeo.com/browse/NXDRIVE-2432): Only display chunked transfers into the Monitoring tab
+- [NXDRIVE-2433](https://jira.nuxeo.com/browse/NXDRIVE-2433): Remove pause button on the monitoring tab
 
 ## GUI
 

--- a/nxdrive/client/uploader/__init__.py
+++ b/nxdrive/client/uploader/__init__.py
@@ -221,7 +221,6 @@ class BaseUploader:
         if transfer.status is TransferStatus.PAUSED:
             raise UploadPaused(transfer.uid or -1)
         elif transfer.status is TransferStatus.CANCELLED:
-            self.dao.remove_transfer("upload", transfer.path, is_direct_transfer=True)
             raise UploadCancelled(transfer.uid or -1)
 
     def upload_chunks(self, transfer: Upload, blob: FileBlob, chunked: bool) -> None:
@@ -277,11 +276,8 @@ class BaseUploader:
 
                     # Handle status changes every time a chunk is sent
                     _transfer = self.get_upload(transfer.path)
-                    if _transfer and _transfer.status not in (
-                        TransferStatus.ONGOING,
-                        TransferStatus.DONE,
-                    ):
-                        raise UploadPaused(transfer.uid or -1)
+                    if _transfer:
+                        self._handle_transfer_status(_transfer)
             else:
                 uploader.upload()
 

--- a/nxdrive/data/qml/SessionItem.qml
+++ b/nxdrive/data/qml/SessionItem.qml
@@ -128,7 +128,12 @@ Rectangle {
                         tooltip: qsTr("CANCEL") + tl.tr
                         iconColor: "red"
                         onClicked: {
-                            application.confirm_cancel_session(engine, uid, remote_path, total - uploaded)
+                            enabled = false
+                            try {
+                                application.confirm_cancel_session(engine, uid, remote_path, total - uploaded)
+                            } finally {
+                                enabled = true
+                            }
                         }
                     }
                 }

--- a/nxdrive/data/qml/TransferItem.qml
+++ b/nxdrive/data/qml/TransferItem.qml
@@ -6,7 +6,6 @@ import "icon-font/Icon.js" as MdiFont
 
 Rectangle {
     id: control
-    property bool paused: status == "PAUSED" || status == "SUSPENDED"
     visible: !shadow
     width: parent ? parent.width : 0
     height: shadow ? 0: 55
@@ -67,29 +66,19 @@ Rectangle {
                     }
                 }
 
-                // Pause/Resume icon
-                IconLabel {
-                    enabled: !finalizing
-                    icon: paused ? MdiFont.Icon.play : MdiFont.Icon.pause
-                    iconColor: nuxeoBlue
-                    tooltip: qsTr(paused ? "RESUME" : "SUSPEND") + tl.tr
-                    onClicked: {
-                        if (paused) {
-                            api.resume_transfer("upload", engine, uid, true)
-                        } else {
-                            api.pause_transfer("upload", engine, uid, progress, true)
-                        }
-                    }
-                }
-
                 // Stop icon
                 IconLabel {
-                    enabled: paused
                     icon: MdiFont.Icon.close
                     tooltip: qsTr("CANCEL") + tl.tr
                     iconColor: "red"
+                    enabled: !finalizing
                     onClicked: {
-                        application.confirm_cancel_transfer(engine, uid, name)
+                        enabled = false
+                        try {
+                            application.confirm_cancel_transfer(engine, uid, name)
+                        } finally {
+                            enabled = !finalizing
+                        }
                     }
                 }
             }

--- a/nxdrive/engine/dao/sqlite.py
+++ b/nxdrive/engine/dao/sqlite.py
@@ -2369,6 +2369,7 @@ class EngineDAO(ConfigurationDAO):
                 "status": TransferStatus(res.status),
                 "engine": res.engine,
                 "progress": res.progress or 0.0,
+                "doc_pair": res.doc_pair,
                 "remote_parent_path": res.remote_parent_path,
                 "remote_parent_ref": res.remote_parent_ref,
             }

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -1682,6 +1682,15 @@ class Application(QApplication):
             if not items:
                 self.direct_transfer_model.set_items(transfers)
             else:
+                # Finalizing needs to be added from the previous items
+                uid_finalizing = {
+                    item["doc_pair"]: item["finalizing"]
+                    for item in items
+                    if "finalizing" in item
+                }
+                for transfer in transfers:
+                    if transfer["doc_pair"] in uid_finalizing:
+                        transfer["finalizing"] = True
                 self.direct_transfer_model.update_items(transfers)
 
     @pyqtSlot(object)


### PR DESCRIPTION
Remove the possibilty to pause transfers displayed on the monitoring tab. It is now possible to cancel an ongoing transfer.