### PR TITLE
NXDRIVE-2360: Fix os.chmod() to conserve other permissions

### DIFF
--- a/nxdrive/updater/linux.py
+++ b/nxdrive/updater/linux.py
@@ -36,7 +36,7 @@ class Updater(BaseUpdater):
         shutil.move(filename, new_executable)
 
         log.debug(f"Adjusting execution rights on {new_executable!r}")
-        os.chmod(new_executable, stat.S_IXUSR)
+        os.chmod(new_executable, os.stat(new_executable).st_mode | stat.S_IXUSR)
 
         self._restart(new_executable)
 

--- a/tools/scripts/check_update_process.py
+++ b/tools/scripts/check_update_process.py
@@ -99,7 +99,7 @@ def download_last_ga_release(output_dir, version):
         dst.write(req.content)
 
     # Adjust execution rights
-    os.chmod(output, stat.S_IXUSR)
+    os.chmod(output, os.stat(output).st_mode | stat.S_IXUSR)
 
     return output
 


### PR DESCRIPTION
The old `os.chmod()` was destructive, in the sense that it reset all other permission bits.