### PR TITLE
NXDRIVE-2429: Remove the changelog entry

### DIFF
--- a/docs/changes/4.5.0.md
+++ b/docs/changes/4.5.0.md
@@ -38,7 +38,6 @@ Release date: `2020-xx-xx`
 - [NXDRIVE-2309](https://jira.nuxeo.com/browse/NXDRIVE-2309): Implement Active Transfer sessions tab
 - [NXDRIVE-2331](https://jira.nuxeo.com/browse/NXDRIVE-2331): Check for ignored patterns against lowercased names
 - [NXDRIVE-2341](https://jira.nuxeo.com/browse/NXDRIVE-2341): Non-chunked uploads must be put in pause when the session is paused
-- [NXDRIVE-2429](https://jira.nuxeo.com/browse/NXDRIVE-2429): Fix possible transfer cancellation misbehavior
 - [NXDRIVE-2432](https://jira.nuxeo.com/browse/NXDRIVE-2432): Only display chunked transfers into the Monitoring tab
 
 ## GUI


### PR DESCRIPTION
No need for the changelog entry as the bug was introduced in the current dev release.