### PR TITLE
NXDRIVE-2363: [macOS] Fix auto-update issues 

### DIFF
--- a/nxdrive/updater/linux.py
+++ b/nxdrive/updater/linux.py
@@ -44,8 +44,10 @@ class Updater(BaseUpdater):
         """
         Restart the current application to take into account the new version.
         """
+
         cmd = f'sleep 5 ; "{executable}"&'
         log.info(f"Launching the new {APP_NAME} version in 5 seconds ...")
+        log.debug(f"Full command line: {cmd}")
         subprocess.Popen(cmd, shell=True, close_fds=True)
 
         # Trigger the application exit

--- a/nxdrive/updater/windows.py
+++ b/nxdrive/updater/windows.py
@@ -33,6 +33,7 @@ class Updater(BaseUpdater):
         # Using ping instead of timeout to wait 5 seconds (see NXDRIVE-1890)
         cmd = f'ping 127.0.0.1 -n 6 > nul && "{filename}" /verysilent /start=auto'
         log.info("Launching the auto-updater in 5 seconds ...")
+        log.debug(f"Full command line: {cmd}")
         subprocess.Popen(cmd, shell=True, close_fds=True)
 
         # Trigger the application exit


### PR DESCRIPTION
- Fixed the `SIGKILL:9` error when unmounting the volume. This was due to the xattr modification on the new folder. I am not sure why, but skipping that step fixed the issue.

- Fixed the `SIGKILL:9` error when unloading the Finder extenstion. This was due to the fact that the extension was stopped twice. The second time ended on error.

- Removed the code looking for the FinderSync PID that was not working. The information is not really useful though.

- Use the `plistlib` module to find the volume mount point, more reliable and future proof.