### PR TITLE
NXDRIVE-2433: [Direct Transfer] Do not enable back the cancel button …

### DIFF
--- a/docs/changes/4.5.0.md
+++ b/docs/changes/4.5.0.md
@@ -124,6 +124,7 @@ Release date: `2020-xx-xx`
 - Changed `AbstractOSIntegration.register_startup()` return type from `bool` to `None`
 - Changed `AbstractOSIntegration.unregister_startup()` return type from `bool` to `None`
 - Added `Application.confirm_cancel_session()`
+- Changed the return type of `Application.confirm_cancel_transfer()` from `None` to `bool`
 - Added `Application.question()`
 - Added `Application.refresh_active_sessions_items()`
 - Added `Application.refresh_completed_sessions_items()`

--- a/nxdrive/data/qml/SessionItem.qml
+++ b/nxdrive/data/qml/SessionItem.qml
@@ -98,39 +98,35 @@ Rectangle {
 
                     // Pause/Resume icon
                     IconLabel {
-                        id: pause_resume_button
                         icon: paused ? MdiFont.Icon.play : MdiFont.Icon.pause
                         iconColor: nuxeoBlue
                         tooltip: qsTr(paused ? "RESUME" : "SUSPEND") + tl.tr
                         onClicked: {
-                            if (paused) {
-                                try {
-                                    pause_resume_button.enabled = false
+                            enabled = false
+                            try {
+                                if (paused) {
                                     api.resume_session(engine, uid)
-                                } finally {
-                                    pause_resume_button.enabled = true
-                                }
-                            } else {
-                                try {
-                                    pause_resume_button.enabled = false
+                                    cancel_button.enabled = false
+                                } else {
                                     api.pause_session(engine, uid)
-                                } finally {
-                                    pause_resume_button.enabled = true
+                                    cancel_button.enabled = true
                                 }
+                            } finally {
+                                enabled = true
                             }
                         }
                     }
 
                     // Stop icon
                     IconLabel {
+                        id: cancel_button
                         enabled: paused
                         icon: MdiFont.Icon.close
                         tooltip: qsTr("CANCEL") + tl.tr
                         iconColor: "red"
                         onClicked: {
                             enabled = false
-                            var confirmed = application.confirm_cancel_session(engine, uid, remote_path, total - uploaded)
-                            enabled = !(confirmed || paused)
+                            enabled = !application.confirm_cancel_session(engine, uid, remote_path, total - uploaded)
                         }
                     }
                 }

--- a/nxdrive/data/qml/SessionItem.qml
+++ b/nxdrive/data/qml/SessionItem.qml
@@ -129,11 +129,8 @@ Rectangle {
                         iconColor: "red"
                         onClicked: {
                             enabled = false
-                            try {
-                                application.confirm_cancel_session(engine, uid, remote_path, total - uploaded)
-                            } finally {
-                                enabled = true
-                            }
+                            var confirmed = application.confirm_cancel_session(engine, uid, remote_path, total - uploaded)
+                            enabled = !(confirmed || paused)
                         }
                     }
                 }

--- a/nxdrive/data/qml/TransferItem.qml
+++ b/nxdrive/data/qml/TransferItem.qml
@@ -74,11 +74,8 @@ Rectangle {
                     enabled: !finalizing
                     onClicked: {
                         enabled = false
-                        try {
-                            application.confirm_cancel_transfer(engine, uid, name)
-                        } finally {
-                            enabled = !finalizing
-                        }
+                        var confirmed = application.confirm_cancel_transfer(engine, uid, name)
+                        enabled = !(confirmed || finalizing)
                     }
                 }
             }

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -850,13 +850,14 @@ class Application(QApplication):
         """Close the Direct Transfer window."""
         self.direct_transfer_window.close()
 
-    @pyqtSlot(str, int, str)
+    @pyqtSlot(str, int, str, result=bool)
     def confirm_cancel_transfer(
         self, engine_uid: str, transfer_uid: int, name: str
-    ) -> None:
+    ) -> bool:
         """
         Show a dialog to confirm the given transfer cancel.
         Cancel transfer on validation.
+        Return True if the cancel was confirmed.
         """
         msg = self.question(
             Translator.get("DIRECT_TRANSFER_CANCEL_HEADER"),
@@ -869,17 +870,20 @@ class Application(QApplication):
         if msg.clickedButton() == continued:
             engine = self.manager.engines.get(engine_uid)
             if not engine:
-                return
+                return True
             engine.decrease_session_planned_items(transfer_uid)
             engine.cancel_upload(transfer_uid)
+            return True
+        return False
 
-    @pyqtSlot(str, int, str, int)
+    @pyqtSlot(str, int, str, int, result=bool)
     def confirm_cancel_session(
         self, engine_uid: str, session_uid: int, destination: str, pending_files: int
-    ) -> None:
+    ) -> bool:
         """
         Show a dialog to confirm the given session cancel.
         Cancel the session on validation.
+        Return True if the cancel was confirmed.
         """
         msg = self.question(
             Translator.get("SESSION_CANCEL_HEADER"),
@@ -891,6 +895,8 @@ class Application(QApplication):
         msg.exec_()
         if msg.clickedButton() == continued:
             self.api.cancel_session(engine_uid, session_uid)
+            return True
+        return False
 
     @pyqtSlot(str, object)
     def open_authentication_dialog(


### PR DESCRIPTION
…on confirmation

- Fix cancel button state on sessions. It was not possible to cancel an ongoing session.
- Also a small refactoring in the pause/resume QML code.

