### PR TITLE
NXDRIVE-2433: Ignore data from shadow items on transfers refresh

### DIFF
--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -1688,14 +1688,15 @@ class Application(QApplication):
             if not items:
                 self.direct_transfer_model.set_items(transfers)
             else:
-                # Finalizing needs to be added from the previous items
-                uid_finalizing = {
+                # Finalizing status is not stored in the database so it must be updated from the previous list
+                # The previous items list may contain shadow items that must be ignored
+                pair_finalizing = {
                     item["doc_pair"]: item["finalizing"]
                     for item in items
-                    if "finalizing" in item
+                    if "finalizing" in item and "shadow" not in item
                 }
                 for transfer in transfers:
-                    if transfer["doc_pair"] in uid_finalizing:
+                    if transfer["doc_pair"] in pair_finalizing:
                         transfer["finalizing"] = True
                 self.direct_transfer_model.update_items(transfers)
 


### PR DESCRIPTION
The finalizing status from shadow items is now ignored when refreshing the transfers list.