### PR TITLE
NXDRIVE-2433: Fix cancel button become disabled after transfer removal

### DIFF
--- a/docs/changes/4.5.0.md
+++ b/docs/changes/4.5.0.md
@@ -124,7 +124,6 @@ Release date: `2020-xx-xx`
 - Changed `AbstractOSIntegration.register_startup()` return type from `bool` to `None`
 - Changed `AbstractOSIntegration.unregister_startup()` return type from `bool` to `None`
 - Added `Application.confirm_cancel_session()`
-- Changed the return type of `Application.confirm_cancel_transfer()` from `None` to `bool`
 - Added `Application.question()`
 - Added `Application.refresh_active_sessions_items()`
 - Added `Application.refresh_completed_sessions_items()`

--- a/nxdrive/data/qml/TransferItem.qml
+++ b/nxdrive/data/qml/TransferItem.qml
@@ -71,11 +71,9 @@ Rectangle {
                     icon: MdiFont.Icon.close
                     tooltip: qsTr("CANCEL") + tl.tr
                     iconColor: "red"
-                    enabled: !finalizing
+                    enabled: !(status == "CANCELLED" || finalizing)
                     onClicked: {
-                        enabled = false
-                        var confirmed = application.confirm_cancel_transfer(engine, uid, name)
-                        enabled = !(confirmed || finalizing)
+                        application.confirm_cancel_transfer(engine, uid, name)
                     }
                 }
             }

--- a/nxdrive/engine/dao/sqlite.py
+++ b/nxdrive/engine/dao/sqlite.py
@@ -2869,6 +2869,7 @@ class EngineDAO(ConfigurationDAO):
                 f"UPDATE {table} SET status = ? WHERE uid = ?",
                 (transfer.status.value, transfer.uid),
             )
+            self.directTransferUpdated.emit()
 
     def remove_transfer(
         self, nature: str, path: Path, is_direct_transfer: bool = False

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -850,14 +850,13 @@ class Application(QApplication):
         """Close the Direct Transfer window."""
         self.direct_transfer_window.close()
 
-    @pyqtSlot(str, int, str, result=bool)
+    @pyqtSlot(str, int, str)
     def confirm_cancel_transfer(
         self, engine_uid: str, transfer_uid: int, name: str
-    ) -> bool:
+    ) -> None:
         """
         Show a dialog to confirm the given transfer cancel.
         Cancel transfer on validation.
-        Return True if the cancel was confirmed.
         """
         msg = self.question(
             Translator.get("DIRECT_TRANSFER_CANCEL_HEADER"),
@@ -870,11 +869,9 @@ class Application(QApplication):
         if msg.clickedButton() == continued:
             engine = self.manager.engines.get(engine_uid)
             if not engine:
-                return True
+                return
             engine.decrease_session_planned_items(transfer_uid)
             engine.cancel_upload(transfer_uid)
-            return True
-        return False
 
     @pyqtSlot(str, int, str, int, result=bool)
     def confirm_cancel_session(
@@ -1693,7 +1690,7 @@ class Application(QApplication):
                 pair_finalizing = {
                     item["doc_pair"]: item["finalizing"]
                     for item in items
-                    if "finalizing" in item and "shadow" not in item
+                    if item.get("finalizing", False) and "shadow" not in item
                 }
                 for transfer in transfers:
                     if transfer["doc_pair"] in pair_finalizing:

--- a/nxdrive/gui/view.py
+++ b/nxdrive/gui/view.py
@@ -304,6 +304,7 @@ class DirectTransferModel(QAbstractListModel):
             # Copy the first element from items and use it as shadow_item
             self.shadow_item = items[0].copy()
             self.shadow_item["shadow"] = True
+            self.shadow_item["finalizing"] = False
 
         # Create the items list with real datas from items.
         for n_item in items:
@@ -373,6 +374,8 @@ class DirectTransferModel(QAbstractListModel):
     def edit_item(self, row: int, n_item: Dict[str, Any]) -> None:
         """Replace an existing item with *n_item*."""
         idx = self.index(row, 0)
+        if "finalizing" not in n_item:
+            n_item["finalizing"] = False
         self.items[row] = n_item
         self.dataChanged.emit(idx, idx, self.roleNames())
 


### PR DESCRIPTION
When cancelling a transfer in the Monitoring tab, the
next transfer that will replace him will have it's button
disabled.