### PR TITLE
NXDRIVE-2309: Improve the session pause behavior

### DIFF
--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -505,6 +505,12 @@ class Processor(EngineWorker):
 
     def _synchronize_direct_transfer(self, doc_pair: DocPair) -> None:
         """Direct Transfer of a local path."""
+        session = self.dao.get_session(doc_pair.session)
+        if session and session.status is TransferStatus.PAUSED:
+            # No need to repush the *doc_pair* into the queue, it will be handled when resuming the session
+            log.debug(f"The session is paused, skipping <DocPair[{doc_pair.id}]>")
+            return
+
         if WINDOWS:
             path = doc_pair.local_path
         else:


### PR DESCRIPTION
Before the patch, all items to be transferred were started and then paused when their session was paused. This was quite bad because as a transfer was initiated, a call to the server was made for at least retrieve a `batchId`. Even worse, all remaining transfers not yet handled were started _at once_; resulting in N parallel calls to the server and entries in the `Uploads` database table.

Now, when pausing a session, ongoing transfers will be finished for non-chunked ones, the others will be paused ASAP.

Another issue was fixed when starting the app and a session is paused: all its transfers were added to the queue and then filtered out by the `Processor`. The SQL query was improved to prevent pushing such pairs into the queue.

As always: less is better, let's be lazy :)