### PR TITLE
NXDRIVE-2319: [Windows] Fix double long path prefix

### DIFF
--- a/nxdrive/client/local/base.py
+++ b/nxdrive/client/local/base.py
@@ -549,9 +549,9 @@ class LocalClientMixin:
 
     def get_path(self, target: Path) -> Path:
         """ Relative path to the local client from an absolute OS path. """
-        # NXDRIVE-2319: using os.path.abspath() instead of .resolve and .absolute().
+        # NXDRIVE-2319: using os.path.abspath() instead of Path.resolve and Path.absolute().
         try:
-            return Path(os.path.abspath(str(target))).relative_to(self.base_folder)
+            return Path(os.path.abspath(target)).relative_to(self.base_folder)
         except ValueError:
             # From the Path.relative_to() doc: if the operation is not possible
             # (because this is not a subpath of the other path), raise ValueError.

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -337,6 +337,10 @@ class Remote(Nuxeo):
             # Download finished!
             download.status = TransferStatus.DONE
             self.dao.set_transfer_status("download", download)
+        except CorruptedFile:
+            log.info("Removing the temporary file as it seems it is now untrustable")
+            file_out.unlink(missing_ok=True)
+            raise
         finally:
             if chunked:
                 DownloadAction.finish_action()

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -457,10 +457,9 @@ def normalized_path(path: Union[bytes, str, Path]) -> Path:
     Note: this function cannot be decorated with lru_cache().
     """
     if not isinstance(path, Path):
-        path = force_decode(path)
-    expanded = Path(path).expanduser()
-    # NXDRIVE-2319: using os.path.abspath() instead of .resolve and .absolute().
-    return Path(os.path.abspath(str(expanded)))
+        path = Path(os.fsdecode(path))
+    # NXDRIVE-2319: using os.path.abspath() instead of Path.resolve and Path.absolute().
+    return Path(os.path.abspath(path.expanduser()))
 
 
 def normalize_and_expand_path(path: str) -> Path:
@@ -565,7 +564,10 @@ def safe_long_path(path: Path) -> Path:
         https://bugs.python.org/issue18199#msg260122
     """
     if WINDOWS:
-        path = Path(f"\\\\?\\{normalized_path(path)}")
+        if path.parts[0].startswith("\\\\?\\"):
+            path = normalized_path(path)
+        else:
+            path = Path(f"\\\\?\\{normalized_path(path)}")
     return path
 
 


### PR DESCRIPTION
Also some improvements:
- Remove useless `str()` cast for `os.path.abspath()`.
- Use `os.fsdecode()` instead of `str.decode()`.

---

Also NXDRIVE-2448: Remove the temporary file on `CorruptedFile` error

If we do not do the clean-up, the file will grow up to file size * N (where N is the download count).