### PR TITLE
NXDRIVE-2444: Use Qt scoped enums

### DIFF
--- a/docs/changes/4.5.1.md
+++ b/docs/changes/4.5.1.md
@@ -5,6 +5,7 @@ Release date: `2021-xx-xx`
 ## Core
 
 - [NXDRIVE-1768](https://jira.nuxeo.com/browse/NXDRIVE-1768): Use positional-only parameters
+- [NXDRIVE-2444](https://jira.nuxeo.com/browse/NXDRIVE-2444): Use Qt scoped enums
 
 ### Direct Edit
 
@@ -43,3 +44,4 @@ Release date: `2021-xx-xx`
 - Added `doc_pair` keyword argument to `FileAction.__init__()`
 - Added `doc_pair` keyword argument to `LinkingAction.__init__()`
 - Added `doc_pair` argument to `UploadAction.__init__()`
+- Added `qt_constants.py`

--- a/docs/manual_init.md
+++ b/docs/manual_init.md
@@ -6,10 +6,10 @@ Usually Nuxeo Drive is automatically initialized at first startup. This includes
 - Creation of the local folder: `~/.Nuxeo Drive`
 - Initialization of the SQLite database: `~/.nuxeo-drive/nxdrive.db`
 
-You might want to do this initialization manually, for example to preset the Nuxeo server URL and proxy configuration before launching Nuxeo Drive the first time.  
-This can be useful for the deployment of Nuxeo Drive on a large set of desktops, allowing end users to work on a preconfigured instance, only needing to provide their credentials at first startup. 
+You might want to do this initialization manually, for example to preset the Nuxeo server URL and proxy configuration before launching Nuxeo Drive the first time.
+This can be useful for the deployment of Nuxeo Drive on a large set of desktops, allowing end users to work on a preconfigured instance, only needing to provide their credentials at first startup.
 
-Please note that we only provide UNIX command lines in the following process, they can easily be adapted for Windows.  
+Please note that we only provide UNIX command lines in the following process, they can easily be adapted for Windows.
 Of course all this can be scripted.
 
 ## Configuration folder and SQLite database file creation

--- a/ftest/README.md
+++ b/ftest/README.md
@@ -25,7 +25,7 @@ Uses the [ant-assembly-maven-plugin](https://github.com/nuxeo/ant-assembly-maven
 ## Run tests with Maven
 
     mvn clean verify
-    
+
 If you are at the root of the [nuxeo-drive](https://github.com/nuxeo/nuxeo-drive/) repository, run:
 
     mvn clean verify -f ftest/pom.xml

--- a/nxdrive/commandline.py
+++ b/nxdrive/commandline.py
@@ -601,6 +601,8 @@ class CliHandler:
         from PyQt5.QtCore import QByteArray
         from PyQt5.QtNetwork import QLocalSocket
 
+        from .qt_constants import ConnectedState
+
         named_pipe = f"{BUNDLE_IDENTIFIER}.protocol.{pid}"
         log.debug(
             f"Opening a local socket to the running instance on {named_pipe} "
@@ -617,7 +619,7 @@ class CliHandler:
             client.write(QByteArray(payload))
             client.waitForBytesWritten()
             client.disconnectFromServer()
-            if client.state() == QLocalSocket.ConnectedState:
+            if client.state() == ConnectedState:
                 client.waitForDisconnected()
         finally:
             del client

--- a/nxdrive/data/qml/icon-font/license.txt
+++ b/nxdrive/data/qml/icon-font/license.txt
@@ -22,7 +22,7 @@ with others.
 
 The OFL allows the licensed fonts to be used, studied, modified and
 redistributed freely as long as they are not sold by themselves. The
-fonts, including any derivative works, can be bundled, embedded, 
+fonts, including any derivative works, can be bundled, embedded,
 redistributed and/or sold with any software provided that any reserved
 names are not used by derivative works. The fonts and derivatives,
 however, cannot be released under any other type of license. The

--- a/nxdrive/fatal_error.py
+++ b/nxdrive/fatal_error.py
@@ -17,6 +17,7 @@ def check_executable_path_error_qt(path: Path, /) -> None:
     from PyQt5.QtGui import QPixmap
     from PyQt5.QtWidgets import QApplication, QMessageBox
 
+    from nxdrive.qt_constants import AcceptRole
     from nxdrive.translator import Translator
     from nxdrive.utils import find_icon, find_resource
 
@@ -33,14 +34,14 @@ def check_executable_path_error_qt(path: Path, /) -> None:
     msg.setIconPixmap(icon)
     msg.setText(content)
     msg.setWindowTitle(APP_NAME)
-    msg.addButton(Translator.get("QUIT"), QMessageBox.AcceptRole)
+    msg.addButton(Translator.get("QUIT"), AcceptRole)
     msg.exec_()
 
 
 def fatal_error_qt(exc_formatted: str, /) -> None:
     """Display a "friendly" dialog box on fatal error using Qt."""
 
-    from PyQt5.QtCore import Qt, QUrl
+    from PyQt5.QtCore import QUrl
     from PyQt5.QtGui import QDesktopServices, QIcon
     from PyQt5.QtWidgets import (
         QApplication,
@@ -51,6 +52,13 @@ def fatal_error_qt(exc_formatted: str, /) -> None:
         QVBoxLayout,
     )
 
+    from nxdrive.qt_constants import (
+        ActionRole,
+        AlignHCenter,
+        AlignVCenter,
+        FixedPixelWidth,
+        Ok,
+    )
     from nxdrive.translator import Translator
     from nxdrive.utils import find_icon, find_resource
 
@@ -74,14 +82,14 @@ def fatal_error_qt(exc_formatted: str, /) -> None:
 
     # Display a little message to apologize
     info = QLabel(tr("FATAL_ERROR_MSG", values=[APP_NAME, COMPANY]))
-    info.setAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
+    info.setAlignment(AlignHCenter | AlignVCenter)
     layout.addWidget(info)
 
     # Display CLI arguments
     if sys.argv[1:]:
         text = tr("FATAL_ERROR_CLI_ARGS")
         label_cli = QLabel(text)
-        label_cli.setAlignment(Qt.AlignVCenter)
+        label_cli.setAlignment(AlignVCenter)
         cli_args = QTextEdit()
         cli_args.setStyleSheet(css)
         cli_args.setReadOnly(True)
@@ -95,7 +103,7 @@ def fatal_error_qt(exc_formatted: str, /) -> None:
     # Display the exception
     text = tr("FATAL_ERROR_EXCEPTION")
     label_exc = QLabel(text)
-    label_exc.setAlignment(Qt.AlignVCenter)
+    label_exc.setAlignment(AlignVCenter)
     exception = QTextEdit()
     exception.setStyleSheet(css)
     exception.setReadOnly(True)
@@ -116,14 +124,14 @@ def fatal_error_qt(exc_formatted: str, /) -> None:
             text = tr("FATAL_ERROR_LOGS")
             label_log = QLabel(text)
             details.append(section(text, lines))
-            label_log.setAlignment(Qt.AlignVCenter)
+            label_log.setAlignment(AlignVCenter)
             layout.addWidget(label_log)
 
             logs = QTextEdit()
             logs.setStyleSheet(css)
             logs.setReadOnly(True)
             logs.setLineWrapColumnOrWidth(4096)
-            logs.setLineWrapMode(QTextEdit.FixedPixelWidth)
+            logs.setLineWrapMode(FixedPixelWidth)
             logs.setText(lines)
             layout.addWidget(logs)
 
@@ -142,11 +150,9 @@ def fatal_error_qt(exc_formatted: str, /) -> None:
 
     # Buttons
     buttons = QDialogButtonBox()
-    buttons.setStandardButtons(QDialogButtonBox.Ok)
+    buttons.setStandardButtons(Ok)
     buttons.accepted.connect(dialog.close)
-    update_button = buttons.addButton(
-        tr("FATAL_ERROR_UPDATE_BTN"), QDialogButtonBox.ActionRole
-    )
+    update_button = buttons.addButton(tr("FATAL_ERROR_UPDATE_BTN"), ActionRole)
     update_button.setToolTip(tr("FATAL_ERROR_UPDATE_TOOLTIP", values=[APP_NAME]))
     update_button.clicked.connect(open_update_site)
     layout.addWidget(buttons)
@@ -161,9 +167,7 @@ def fatal_error_qt(exc_formatted: str, /) -> None:
         from nxdrive.osi import AbstractOSIntegration
 
         osi = AbstractOSIntegration.get(None)
-        copy_paste = buttons.addButton(
-            tr("FATAL_ERROR_DETAILS_COPY"), QDialogButtonBox.ActionRole
-        )
+        copy_paste = buttons.addButton(tr("FATAL_ERROR_DETAILS_COPY"), ActionRole)
         copy_paste.clicked.connect(copy)
 
     dialog.setLayout(layout)

--- a/nxdrive/gui/api.py
+++ b/nxdrive/gui/api.py
@@ -11,7 +11,6 @@ from urllib.parse import urlencode, urlparse, urlsplit, urlunsplit
 import requests
 from nuxeo.exceptions import HTTPError, Unauthorized
 from PyQt5.QtCore import QObject, QUrl, pyqtSignal, pyqtSlot
-from PyQt5.QtWidgets import QMessageBox
 from urllib3.exceptions import LocationParseError
 
 from ..client.proxy import get_proxy
@@ -37,6 +36,7 @@ from ..feature import Feature
 from ..notification import Notification
 from ..objects import Binder, DocPair
 from ..options import Options
+from ..qt_constants import AcceptRole, RejectRole
 from ..translator import Translator
 from ..updater.constants import Login
 from ..utils import (
@@ -740,8 +740,8 @@ class QMLDriveApi(QObject):
                     "ROOT_USED_WITH_OTHER_BINDING", values=[e.username, e.url]
                 ),
             )
-            msg.addButton(Translator.get("CONTINUE"), QMessageBox.AcceptRole)
-            cancel = msg.addButton(Translator.get("CANCEL"), QMessageBox.RejectRole)
+            msg.addButton(Translator.get("CONTINUE"), AcceptRole)
+            cancel = msg.addButton(Translator.get("CANCEL"), RejectRole)
             msg.exec_()
             if msg.clickedButton() == cancel:
                 self.setMessage.emit("FOLDER_USED", "error")

--- a/nxdrive/gui/folders_dialog.py
+++ b/nxdrive/gui/folders_dialog.py
@@ -20,6 +20,19 @@ from PyQt5.QtWidgets import (
 from ..constants import APP_NAME
 from ..engine.engine import Engine
 from ..options import Options
+from ..qt_constants import (
+    ActionRole,
+    AlignHCenter,
+    AlignVCenter,
+    Cancel,
+    Checked,
+    Horizontal,
+    Ok,
+    RichText,
+    Unchecked,
+    WA_DeleteOnClose,
+    WindowStaysOnTopHint,
+)
 from ..translator import Translator
 from ..utils import get_tree_list, sizeof_fmt
 from .folders_model import FilteredDocuments, FoldersOnly
@@ -42,7 +55,7 @@ class DialogMixin(QDialog):
         super().__init__(None)
 
         # Customize the window
-        self.setAttribute(Qt.WA_DeleteOnClose)
+        self.setAttribute(WA_DeleteOnClose)
         self.setWindowIcon(application.icon)
         self.setWindowTitle(Translator.get(self.title_label, values=[APP_NAME]))
 
@@ -50,7 +63,7 @@ class DialogMixin(QDialog):
         # so after the login in the browser, we open the filters window with
         # the "stay on top" hint to make sure it comes back to the front
         # instead of just having a blinking icon in the taskbar.
-        self.setWindowFlags(Qt.WindowStaysOnTopHint)
+        self.setWindowFlags(WindowStaysOnTopHint)
 
         self.engine = engine
         self.application = application
@@ -61,7 +74,7 @@ class DialogMixin(QDialog):
 
         # Buttons
         self.button_box: QDialogButtonBox = QDialogButtonBox(self)
-        self.button_box.setOrientation(Qt.Horizontal)
+        self.button_box.setOrientation(Horizontal)
         self.button_box.setStandardButtons(self.get_buttons())
         self.button_box.accepted.connect(self.accept)
         self.button_box.rejected.connect(self.reject)
@@ -71,7 +84,7 @@ class DialogMixin(QDialog):
 
     def get_buttons(self) -> QDialogButtonBox.StandardButtons:
         """Create the buttons to display at the bottom of the window."""
-        return QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+        return Ok | Cancel
 
 
 class DocumentsDialog(DialogMixin):
@@ -99,11 +112,11 @@ class DocumentsDialog(DialogMixin):
             Translator.get("SELECT_ALL"),
         )
 
-        buttons = QDialogButtonBox.Ok
+        buttons = Ok
         if not self.engine.is_syncing():
-            buttons |= QDialogButtonBox.Cancel
+            buttons |= Cancel
             self.select_all_button = self.button_box.addButton(
-                self.select_all_text[self.select_all_state], QDialogButtonBox.ActionRole
+                self.select_all_text[self.select_all_state], ActionRole
             )
             self.select_all_button.clicked.connect(self._select_unselect_all_roots)
         return buttons
@@ -115,7 +128,7 @@ class DocumentsDialog(DialogMixin):
         if self.engine.is_syncing():
             label = QLabel(Translator.get("FILTERS_DISABLED"))
             label.setMargin(15)
-            label.setAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
+            label.setAlignment(AlignHCenter | AlignVCenter)
             return label
 
         self.resize(491, 443)
@@ -141,7 +154,7 @@ class DocumentsDialog(DialogMixin):
         label.setWordWrap(True)
         label.setVisible(False)
         label.setOpenExternalLinks(True)
-        label.setAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
+        label.setAlignment(AlignHCenter | AlignVCenter)
         return label
 
     def _handle_no_roots(self) -> None:
@@ -166,11 +179,11 @@ class DocumentsDialog(DialogMixin):
         items = sorted(self.tree_view.dirty_items, key=lambda x: x.get_path())
         for item in items:
             path = item.get_path()
-            if item.state == Qt.Unchecked:
+            if item.state == Unchecked:
                 self.engine.add_filter(path)
-            elif item.state == Qt.Checked:
+            elif item.state == Checked:
                 self.engine.remove_filter(path)
-            elif item.old_state == Qt.Unchecked:
+            elif item.old_state == Unchecked:
                 # Now partially checked and was before a filter
 
                 # Remove current parent filter and need to commit to enable the add
@@ -179,7 +192,7 @@ class DocumentsDialog(DialogMixin):
                 # We need to browse every child and create a filter for
                 # unchecked as they are not dirty but has become root filter
                 for child in item.get_children():
-                    if child.state == Qt.Unchecked:
+                    if child.state == Unchecked:
                         self.engine.add_filter(child.get_path())
 
         if not self.engine.is_started():
@@ -187,7 +200,7 @@ class DocumentsDialog(DialogMixin):
 
     def _select_unselect_all_roots(self, _: Qt.CheckState, /) -> None:
         """The Select/Unselect all roots button."""
-        state = Qt.Checked if self.select_all_state else Qt.Unchecked
+        state = Checked if self.select_all_state else Unchecked
 
         roots = sorted(self.tree_view.client.roots, key=lambda x: x.get_path())
         for num, root in enumerate(roots):
@@ -311,7 +324,7 @@ class FoldersDialog(DialogMixin):
         """Add a sub-group for the duplicates behavior option."""
         label = QLabel(Translator.get("DUPLICATE_BEHAVIOR", values=[DOC_URL]))
         label.setToolTip(Translator.get("DUPLICATE_BEHAVIOR_TOOLTIP"))
-        label.setTextFormat(Qt.RichText)
+        label.setTextFormat(RichText)
         label.setOpenExternalLinks(True)
         layout.addWidget(label)
 
@@ -346,7 +359,7 @@ class FoldersDialog(DialogMixin):
         # Required criteria:
         #   - at least 1 local path
         #   - a selected remote path
-        self.button_box.button(QDialogButtonBox.Ok).setEnabled(
+        self.button_box.button(Ok).setEnabled(
             bool(self.paths) and bool(self.remote_folder.text())
         )
 

--- a/nxdrive/gui/folders_loader.py
+++ b/nxdrive/gui/folders_loader.py
@@ -2,9 +2,10 @@
 from logging import getLogger
 from typing import TYPE_CHECKING, List, Optional
 
-from PyQt5.QtCore import QRunnable, Qt, QVariant
+from PyQt5.QtCore import QRunnable, QVariant
 from PyQt5.QtGui import QStandardItem, QStandardItemModel
 
+from ..qt_constants import UserRole
 from ..translator import Translator
 from .folders_model import Doc, Documents, FilteredDoc
 
@@ -27,7 +28,7 @@ class ContentLoaderMixin(QRunnable):
         self.item = item or self.tree.model().invisibleRootItem()
         self.info: Optional[Documents] = None
         if item:
-            self.info = self.item.data(Qt.UserRole)
+            self.info = self.item.data(UserRole)
 
     def run(self) -> None:
         """Fetch children of a given item."""
@@ -104,7 +105,7 @@ class DocumentContentLoader(ContentLoaderMixin):
         subitem.setEnabled(child.enable())
         subitem.setSelectable(child.selectable())
         subitem.setEditable(False)
-        subitem.setData(QVariant(child), Qt.UserRole)
+        subitem.setData(QVariant(child), UserRole)
         return subitem
 
 
@@ -119,5 +120,5 @@ class FolderContentLoader(ContentLoaderMixin):
         subitem.setEnabled(child.enable())
         subitem.setSelectable(child.selectable())
         subitem.setEditable(False)
-        subitem.setData(QVariant(child), Qt.UserRole)
+        subitem.setData(QVariant(child), UserRole)
         return subitem

--- a/nxdrive/gui/folders_model.py
+++ b/nxdrive/gui/folders_model.py
@@ -9,6 +9,7 @@ from PyQt5.QtCore import QObject, Qt
 from ..client.remote_client import Remote
 from ..objects import Filters, RemoteFileInfo
 from ..options import Options
+from ..qt_constants import Checked, PartiallyChecked, Unchecked
 from ..translator import Translator
 
 __all__ = ("Documents", "FileInfo", "FilteredDocuments", "FilteredDoc")
@@ -185,13 +186,13 @@ class FilteredDocuments:
 
         if path.startswith(self.filters):
             # The document is filtered
-            return Qt.Unchecked
+            return Unchecked
         elif any(filter_path.startswith(path) for filter_path in self.filters):
             # The document has a child that is filtered
-            return Qt.PartiallyChecked
+            return PartiallyChecked
 
         # The document is not filtered at all
-        return Qt.Checked
+        return Checked
 
     def get_top_documents(self) -> Iterator["Documents"]:
         """Fetch all sync roots."""

--- a/nxdrive/gui/folders_treeview.py
+++ b/nxdrive/gui/folders_treeview.py
@@ -1,13 +1,7 @@
 # coding: utf-8
 from typing import TYPE_CHECKING, List, Union
 
-from PyQt5.QtCore import (
-    QItemSelection,
-    QModelIndex,
-    QObject,
-    QThreadPool,
-    pyqtSignal,
-)
+from PyQt5.QtCore import QItemSelection, QModelIndex, QObject, QThreadPool, pyqtSignal
 from PyQt5.QtGui import QStandardItemModel
 from PyQt5.QtWidgets import QTreeView
 

--- a/nxdrive/gui/folders_treeview.py
+++ b/nxdrive/gui/folders_treeview.py
@@ -5,13 +5,13 @@ from PyQt5.QtCore import (
     QItemSelection,
     QModelIndex,
     QObject,
-    Qt,
     QThreadPool,
     pyqtSignal,
 )
 from PyQt5.QtGui import QStandardItemModel
 from PyQt5.QtWidgets import QTreeView
 
+from ..qt_constants import BusyCursor, Checked, PartiallyChecked, UserRole
 from .folders_loader import DocumentContentLoader, FolderContentLoader
 from .folders_model import FilteredDocuments, FoldersOnly
 
@@ -67,7 +67,7 @@ class TreeViewMixin(QTreeView):
         """
         try:
             if busy:
-                self.setCursor(Qt.BusyCursor)
+                self.setCursor(BusyCursor)
             else:
                 self.unsetCursor()
         except RuntimeError:
@@ -98,7 +98,7 @@ class DocumentTreeView(TreeViewMixin):
         """Append the item the the *.dirty_items* dict.
         That dict will be used by DocumentsDialog.apply_filters() tp update the view.
         """
-        fs_info = item.data(Qt.UserRole)
+        fs_info = item.data(UserRole)
 
         # Fake children have no data attached
         if not fs_info:
@@ -116,12 +116,12 @@ class DocumentTreeView(TreeViewMixin):
     def item_check_parent(self, item: QObject, /) -> None:
         """Retrieve the state of all children to update its own state accordingly."""
         sum_states = sum(
-            item.child(idx).checkState() == Qt.Checked for idx in range(item.rowCount())
+            item.child(idx).checkState() == Checked for idx in range(item.rowCount())
         )
         if sum_states == item.rowCount():
-            item.setCheckState(Qt.Checked)
+            item.setCheckState(Checked)
         else:
-            item.setCheckState(Qt.PartiallyChecked)
+            item.setCheckState(PartiallyChecked)
         self.resolve_item_up_changed(item)
 
     def resolve_item_down_changed(self, item: QObject, /) -> None:
@@ -141,7 +141,7 @@ class DocumentTreeView(TreeViewMixin):
         if not (parent and parent.isCheckable()):
             return
 
-        parent.setCheckState(Qt.PartiallyChecked)
+        parent.setCheckState(PartiallyChecked)
         self.update_item_changed(parent)
         self.item_check_parent(parent)
 
@@ -184,7 +184,7 @@ class FolderTreeView(TreeViewMixin):
             path_ref = ""
         else:
             # Get the selected folder's path
-            item = self.model().itemFromIndex(index).data(Qt.UserRole)
+            item = self.model().itemFromIndex(index).data(UserRole)
             path = item.get_path()
             path_ref = item.get_id()
 

--- a/nxdrive/gui/systray.py
+++ b/nxdrive/gui/systray.py
@@ -4,9 +4,18 @@ from typing import TYPE_CHECKING
 
 from PyQt5.QtCore import QEvent
 from PyQt5.QtQuick import QQuickView
-from PyQt5.QtWidgets import QApplication, QMenu, QStyle, QSystemTrayIcon
+from PyQt5.QtWidgets import QApplication, QMenu, QSystemTrayIcon
 
 from ..constants import MAC
+from ..qt_constants import (
+    SP_DialogCloseButton,
+    SP_FileDialogInfoView,
+    SP_MessageBoxQuestion,
+    FocusOut,
+    MiddleClick,
+    MouseButtonPress,
+    Trigger,
+)
 from ..translator import Translator
 
 if TYPE_CHECKING:
@@ -42,14 +51,14 @@ class DriveSystrayIcon(QSystemTrayIcon):
 
         Note: only the left click is detected on macOS.
         """
-        if reason == QSystemTrayIcon.Trigger:
+        if reason == Trigger:
             # On left click, open the usual menu with engines and sync files
             # If it is already open, we close it
             if self.application.systray_window.isVisible():
                 self.application.hide_systray()
             else:
                 self.application.show_systray()
-        elif reason == QSystemTrayIcon.MiddleClick:
+        elif reason == MiddleClick:
             # On middle click, open settings.  Yeah, it rocks!
             self.application.show_settings("General")
 
@@ -65,19 +74,19 @@ class DriveSystrayIcon(QSystemTrayIcon):
         style = QApplication.style()
         menu = QMenu()
         menu.addAction(
-            style.standardIcon(QStyle.SP_FileDialogInfoView),
+            style.standardIcon(SP_FileDialogInfoView),
             Translator.get("SETTINGS"),
             self.application.show_settings,
         )
         menu.addSeparator()
         menu.addAction(
-            style.standardIcon(QStyle.SP_MessageBoxQuestion),
+            style.standardIcon(SP_MessageBoxQuestion),
             Translator.get("HELP"),
             self.application.open_help,
         )
         menu.addSeparator()
         menu.addAction(
-            style.standardIcon(QStyle.SP_DialogCloseButton),
+            style.standardIcon(SP_DialogCloseButton),
             Translator.get("QUIT"),
             self.application.exit_app,
         )
@@ -87,8 +96,8 @@ class DriveSystrayIcon(QSystemTrayIcon):
 
 class SystrayWindow(QQuickView):
     def event(self, event: QEvent, /) -> bool:
-        if event.type() == QEvent.FocusOut or (
-            event.type() == QEvent.MouseButtonPress
+        if event.type() == FocusOut or (
+            event.type() == MouseButtonPress
             and not self.geometry().contains(event.screenPos().toPoint())
         ):
             # The click was outside of the systray

--- a/nxdrive/gui/systray.py
+++ b/nxdrive/gui/systray.py
@@ -8,12 +8,12 @@ from PyQt5.QtWidgets import QApplication, QMenu, QSystemTrayIcon
 
 from ..constants import MAC
 from ..qt_constants import (
-    SP_DialogCloseButton,
-    SP_FileDialogInfoView,
-    SP_MessageBoxQuestion,
     FocusOut,
     MiddleClick,
     MouseButtonPress,
+    SP_DialogCloseButton,
+    SP_FileDialogInfoView,
+    SP_MessageBoxQuestion,
     Trigger,
 )
 from ..translator import Translator

--- a/nxdrive/gui/view.py
+++ b/nxdrive/gui/view.py
@@ -14,6 +14,7 @@ from PyQt5.QtCore import (
 )
 
 from ..constants import DT_ACTIVE_SESSIONS_MAX_ITEMS, DT_MONITORING_MAX_ITEMS
+from ..qt_constants import ItemIsEditable, ItemIsEnabled, ItemIsSelectable, UserRole
 from ..translator import Translator
 from ..utils import force_decode, get_date_from_sqlite, sizeof_fmt
 
@@ -30,13 +31,13 @@ class EngineModel(QAbstractListModel):
     uiChanged = pyqtSignal()
     authChanged = pyqtSignal()
 
-    UID_ROLE = Qt.UserRole + 1
-    TYPE_ROLE = Qt.UserRole + 2
-    FOLDER_ROLE = Qt.UserRole + 3
-    URL_ROLE = Qt.UserRole + 4
-    UI_ROLE = Qt.UserRole + 5
-    FORCE_UI_ROLE = Qt.UserRole + 6
-    ACCOUNT_ROLE = Qt.UserRole + 7
+    UID_ROLE = UserRole + 1
+    TYPE_ROLE = UserRole + 2
+    FOLDER_ROLE = UserRole + 3
+    URL_ROLE = UserRole + 4
+    UI_ROLE = UserRole + 5
+    FORCE_UI_ROLE = UserRole + 6
+    ACCOUNT_ROLE = UserRole + 7
 
     def __init__(
         self, application: "Application", /, *, parent: QObject = None
@@ -142,15 +143,15 @@ class EngineModel(QAbstractListModel):
 class TransferModel(QAbstractListModel):
     fileChanged = pyqtSignal()
 
-    ID = Qt.UserRole + 1
-    NAME = Qt.UserRole + 2
-    STATUS = Qt.UserRole + 3
-    PROGRESS = Qt.UserRole + 4
-    TYPE = Qt.UserRole + 5
-    ENGINE = Qt.UserRole + 6
-    IS_DIRECT_EDIT = Qt.UserRole + 7
-    FINALIZING = Qt.UserRole + 8
-    PROGRESS_METRICS = Qt.UserRole + 9
+    ID = UserRole + 1
+    NAME = UserRole + 2
+    STATUS = UserRole + 3
+    PROGRESS = UserRole + 4
+    TYPE = UserRole + 5
+    ENGINE = UserRole + 6
+    IS_DIRECT_EDIT = UserRole + 7
+    FINALIZING = UserRole + 8
+    PROGRESS_METRICS = UserRole + 9
 
     def __init__(self, translate: Callable, /, *, parent: QObject = None) -> None:
         super().__init__(parent)
@@ -254,24 +255,24 @@ class TransferModel(QAbstractListModel):
                 self.setData(idx, True, role=self.FINALIZING)
 
     def flags(self, index: QModelIndex, /) -> Qt.ItemFlags:
-        return Qt.ItemIsEditable | Qt.ItemIsEnabled | Qt.ItemIsSelectable
+        return ItemIsEditable | ItemIsEnabled | ItemIsSelectable
 
 
 class DirectTransferModel(QAbstractListModel):
     fileChanged = pyqtSignal()
 
-    ID = Qt.UserRole + 1
-    NAME = Qt.UserRole + 2
-    STATUS = Qt.UserRole + 3
-    PROGRESS = Qt.UserRole + 4
-    ENGINE = Qt.UserRole + 5
-    FINALIZING = Qt.UserRole + 6
-    SIZE = Qt.UserRole + 7
-    TRANSFERRED = Qt.UserRole + 8
-    REMOTE_PARENT_PATH = Qt.UserRole + 9
-    REMOTE_PARENT_REF = Qt.UserRole + 10
-    SHADOW = Qt.UserRole + 11  # Tell the interface if the row should be visible or not
-    DOC_PAIR = Qt.UserRole + 12
+    ID = UserRole + 1
+    NAME = UserRole + 2
+    STATUS = UserRole + 3
+    PROGRESS = UserRole + 4
+    ENGINE = UserRole + 5
+    FINALIZING = UserRole + 6
+    SIZE = UserRole + 7
+    TRANSFERRED = UserRole + 8
+    REMOTE_PARENT_PATH = UserRole + 9
+    REMOTE_PARENT_REF = UserRole + 10
+    SHADOW = UserRole + 11  # Tell the interface if the row should be visible or not
+    DOC_PAIR = UserRole + 12
 
     def __init__(self, translate: Callable, /, *, parent: QObject = None) -> None:
         super().__init__(parent)
@@ -394,18 +395,18 @@ class DirectTransferModel(QAbstractListModel):
 class ActiveSessionModel(QAbstractListModel):
     sessionChanged = pyqtSignal()
 
-    UID = Qt.UserRole + 1
-    STATUS = Qt.UserRole + 2
-    REMOTE_REF = Qt.UserRole + 3
-    REMOTE_PATH = Qt.UserRole + 4
-    UPLOADED = Qt.UserRole + 5
-    TOTAL = Qt.UserRole + 6
-    ENGINE = Qt.UserRole + 7
-    CREATED_ON = Qt.UserRole + 8
-    COMPLETED_ON = Qt.UserRole + 9
-    DESCRIPTION = Qt.UserRole + 10
-    PROGRESS = Qt.UserRole + 11
-    SHADOW = Qt.UserRole + 12  # Tell the interface if the row should be visible or not
+    UID = UserRole + 1
+    STATUS = UserRole + 2
+    REMOTE_REF = UserRole + 3
+    REMOTE_PATH = UserRole + 4
+    UPLOADED = UserRole + 5
+    TOTAL = UserRole + 6
+    ENGINE = UserRole + 7
+    CREATED_ON = UserRole + 8
+    COMPLETED_ON = UserRole + 9
+    DESCRIPTION = UserRole + 10
+    PROGRESS = UserRole + 11
+    SHADOW = UserRole + 12  # Tell the interface if the row should be visible or not
 
     def __init__(self, translate: Callable, /, *, parent: QObject = None) -> None:
         super().__init__(parent)
@@ -546,18 +547,18 @@ class ActiveSessionModel(QAbstractListModel):
 class CompletedSessionModel(QAbstractListModel):
     sessionChanged = pyqtSignal()
 
-    UID = Qt.UserRole + 1
-    STATUS = Qt.UserRole + 2
-    REMOTE_REF = Qt.UserRole + 3
-    REMOTE_PATH = Qt.UserRole + 4
-    UPLOADED = Qt.UserRole + 5
-    TOTAL = Qt.UserRole + 6
-    ENGINE = Qt.UserRole + 7
-    CREATED_ON = Qt.UserRole + 8
-    COMPLETED_ON = Qt.UserRole + 9
-    DESCRIPTION = Qt.UserRole + 10
-    PROGRESS = Qt.UserRole + 11
-    SHADOW = Qt.UserRole + 12
+    UID = UserRole + 1
+    STATUS = UserRole + 2
+    REMOTE_REF = UserRole + 3
+    REMOTE_PATH = UserRole + 4
+    UPLOADED = UserRole + 5
+    TOTAL = UserRole + 6
+    ENGINE = UserRole + 7
+    CREATED_ON = UserRole + 8
+    COMPLETED_ON = UserRole + 9
+    DESCRIPTION = UserRole + 10
+    PROGRESS = UserRole + 11
+    SHADOW = UserRole + 12
 
     def __init__(self, translate: Callable, /, *, parent: QObject = None) -> None:
         super().__init__(parent)
@@ -654,21 +655,21 @@ class CompletedSessionModel(QAbstractListModel):
 class FileModel(QAbstractListModel):
     fileChanged = pyqtSignal()
 
-    ID = Qt.UserRole + 1
-    DETAILS = Qt.UserRole + 2
-    FOLDERISH = Qt.UserRole + 3
-    LAST_CONTRIBUTOR = Qt.UserRole + 4
-    LAST_ERROR = Qt.UserRole + 5
-    LAST_REMOTE_UPDATE = Qt.UserRole + 6
-    LAST_SYNC_DATE = Qt.UserRole + 7
-    LAST_TRANSFER = Qt.UserRole + 8
-    LOCAL_PARENT_PATH = Qt.UserRole + 9
-    LOCAL_PATH = Qt.UserRole + 10
-    NAME = Qt.UserRole + 11
-    REMOTE_NAME = Qt.UserRole + 12
-    REMOTE_REF = Qt.UserRole + 13
-    STATE = Qt.UserRole + 14
-    SIZE = Qt.UserRole + 15
+    ID = UserRole + 1
+    DETAILS = UserRole + 2
+    FOLDERISH = UserRole + 3
+    LAST_CONTRIBUTOR = UserRole + 4
+    LAST_ERROR = UserRole + 5
+    LAST_REMOTE_UPDATE = UserRole + 6
+    LAST_SYNC_DATE = UserRole + 7
+    LAST_TRANSFER = UserRole + 8
+    LOCAL_PARENT_PATH = UserRole + 9
+    LOCAL_PATH = UserRole + 10
+    NAME = UserRole + 11
+    REMOTE_NAME = UserRole + 12
+    REMOTE_REF = UserRole + 13
+    STATE = UserRole + 14
+    SIZE = UserRole + 15
 
     def __init__(self, translate: Callable, /, *, parent: QObject = None) -> None:
         super().__init__(parent)
@@ -733,12 +734,12 @@ class FileModel(QAbstractListModel):
         return self.rowCount()
 
     def flags(self, index: QModelIndex, /) -> Qt.ItemFlags:
-        return Qt.ItemIsEditable | Qt.ItemIsEnabled | Qt.ItemIsSelectable
+        return ItemIsEditable | ItemIsEnabled | ItemIsSelectable
 
 
 class LanguageModel(QAbstractListModel):
-    NAME_ROLE = Qt.UserRole + 1
-    TAG_ROLE = Qt.UserRole + 2
+    NAME_ROLE = UserRole + 1
+    TAG_ROLE = UserRole + 2
 
     def __init__(self, *, parent: QObject = None) -> None:
         super().__init__(parent)

--- a/nxdrive/osi/extension.py
+++ b/nxdrive/osi/extension.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Callable, Dict, Optional
 
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtNetwork import (
-    QAbstractSocket,
     QHostAddress,
     QHostInfo,
     QTcpServer,
@@ -17,6 +16,7 @@ from PyQt5.QtNetwork import (
 
 from ..engine.engine import Engine
 from ..objects import DocPair
+from ..qt_constants import ConnectedState, IPv4Protocol
 from ..utils import force_decode, force_encode
 
 if TYPE_CHECKING:
@@ -94,7 +94,7 @@ class ExtensionListener(QTcpServer):
             log.debug(
                 f"Found {PROTO[address.protocol()]} address: {address.toString()!r}"
             )
-            if address.protocol() == QAbstractSocket.IPv4Protocol:
+            if address.protocol() == IPv4Protocol:
                 return address
         log.debug("No address found, the server will likely fail to start!")
 
@@ -137,7 +137,7 @@ class ExtensionListener(QTcpServer):
                     con.write(self._format_response(response))
 
         con.disconnectFromHost()
-        if con.state() == QTcpSocket.ConnectedState:
+        if con.state() == ConnectedState:
             con.waitForDisconnected()
         del con
 

--- a/nxdrive/osi/extension.py
+++ b/nxdrive/osi/extension.py
@@ -7,12 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Dict, Optional
 
 from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtNetwork import (
-    QHostAddress,
-    QHostInfo,
-    QTcpServer,
-    QTcpSocket,
-)
+from PyQt5.QtNetwork import QHostAddress, QHostInfo, QTcpServer, QTcpSocket
 
 from ..engine.engine import Engine
 from ..objects import DocPair

--- a/nxdrive/qt_constants.py
+++ b/nxdrive/qt_constants.py
@@ -1,0 +1,56 @@
+from PyQt5.QtCore import Qt, QEvent
+from PyQt5.QtGui import QIcon
+from PyQt5.QtNetwork import QAbstractSocket, QLocalServer
+from PyQt5.QtWidgets import (
+    QDialogButtonBox,
+    QLineEdit,
+    QMessageBox,
+    QStyle,
+    QSystemTrayIcon,
+    QTextEdit,
+)
+
+AA_EnableHighDpiScaling = Qt.ApplicationAttribute.AA_EnableHighDpiScaling
+AcceptRole = QMessageBox.ButtonRole.AcceptRole
+ActionRole = QDialogButtonBox.ButtonRole.ActionRole
+AlignCenter = Qt.AlignmentFlag.AlignCenter
+AlignHCenter = Qt.AlignmentFlag.AlignHCenter
+AlignVCenter = Qt.AlignmentFlag.AlignVCenter
+Apply = QDialogButtonBox.StandardButton.Apply
+BusyCursor = Qt.CursorShape.BusyCursor
+Cancel = QDialogButtonBox.StandardButton.Cancel
+Checked = Qt.CheckState.Checked
+ConnectedState = QAbstractSocket.SocketState.ConnectedState
+Critical = QMessageBox.Icon.Critical
+Drawer = Qt.WindowType.Drawer
+FixedPixelWidth = QTextEdit.LineWrapMode.FixedPixelWidth
+FocusOut = QEvent.Type.FocusOut
+FramelessWindowHint = Qt.WindowType.FramelessWindowHint
+Horizontal = Qt.Orientation.Horizontal
+IPv4Protocol = QAbstractSocket.NetworkLayerProtocol.IPv4Protocol
+Information = QMessageBox.Icon.Information
+ItemIsEditable = Qt.ItemFlag.ItemIsEditable
+ItemIsEnabled = Qt.ItemFlag.ItemIsEnabled
+ItemIsSelectable = Qt.ItemFlag.ItemIsSelectable
+LeftToRight = Qt.LayoutDirection.LeftToRight
+MiddleClick = QSystemTrayIcon.ActivationReason.MiddleClick
+MouseButtonPress = QEvent.Type.MouseButtonPress
+Ok = QDialogButtonBox.StandardButton.Ok
+PartiallyChecked = Qt.CheckState.PartiallyChecked
+Password = QLineEdit.EchoMode.Password
+Popup = Qt.WindowType.Popup
+Question = QMessageBox.Icon.Question
+RejectRole = QMessageBox.ButtonRole.RejectRole
+RichText = Qt.TextFormat.RichText
+SP_DialogCloseButton = QStyle.StandardPixmap.SP_DialogCloseButton
+SP_FileDialogInfoView = QStyle.StandardPixmap.SP_FileDialogInfoView
+SP_MessageBoxQuestion = QStyle.StandardPixmap.SP_MessageBoxQuestion
+Selected = QIcon.Mode.Selected
+Trigger = QSystemTrayIcon.ActivationReason.Trigger
+Unchecked = Qt.CheckState.Unchecked
+UserRole = Qt.ItemDataRole.UserRole
+WA_DeleteOnClose = Qt.WidgetAttribute.WA_DeleteOnClose
+WaitCursor = Qt.CursorShape.WaitCursor
+Warning = QSystemTrayIcon.MessageIcon.Warning
+WindowStaysOnTopHint = Qt.WindowType.WindowStaysOnTopHint
+WorldAccessOption = QLocalServer.SocketOption.WorldAccessOption

--- a/nxdrive/qt_constants.py
+++ b/nxdrive/qt_constants.py
@@ -1,4 +1,4 @@
-from PyQt5.QtCore import Qt, QEvent
+from PyQt5.QtCore import QEvent, Qt
 from PyQt5.QtGui import QIcon
 from PyQt5.QtNetwork import QAbstractSocket, QLocalServer
 from PyQt5.QtWidgets import (

--- a/tests/functional/test_tracker.py
+++ b/tests/functional/test_tracker.py
@@ -1,6 +1,7 @@
 from time import monotonic_ns
 
 import pytest
+
 from nxdrive.engine.tracker import Tracker
 from nxdrive.options import Options
 

--- a/tests/integration/windows/_test_installer.py
+++ b/tests/integration/windows/_test_installer.py
@@ -5,6 +5,7 @@ from glob import glob
 from logging import getLogger
 
 import pytest
+
 from nxdrive.constants import WINDOWS
 
 from ... import env

--- a/tests/integration/windows/test_cli.py
+++ b/tests/integration/windows/test_cli.py
@@ -1,6 +1,7 @@
 from logging import getLogger
 
 import pytest
+
 from nxdrive.constants import WINDOWS
 
 from .utils import fatal_error_dlg, main_window, share_metrics_dlg

--- a/tests/integration/windows/utils.py
+++ b/tests/integration/windows/utils.py
@@ -60,6 +60,7 @@ def get_opened_url() -> str:
     # https://pypi.org/project/selenium/, Drivers section
     # Let's say the binary is at the root of the repository:
     import os
+
     from selenium import webdriver
 
     os.environ["PATH"] = os.environ["PATH"] + ":" + os.getcwd()

--- a/tests/old_functional/test_local_creations.py
+++ b/tests/old_functional/test_local_creations.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 from nuxeo.exceptions import Unauthorized
+
 from nxdrive.constants import MAC, WINDOWS
 
 from .. import ensure_no_exception

--- a/tests/old_functional/test_synchronization_suspend.py
+++ b/tests/old_functional/test_synchronization_suspend.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import pytest
+
 from nxdrive.constants import LINUX, WINDOWS
 
 from .common import SYNC_ROOT_FAC_ID, OneUserTest

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,6 +5,7 @@ from typing import Optional
 from uuid import uuid4
 
 import pytest
+
 from nxdrive.engine.dao.sqlite import EngineDAO
 from nxdrive.objects import DocPair
 from nxdrive.utils import normalized_path

--- a/tests/unit/test_autolock.py
+++ b/tests/unit/test_autolock.py
@@ -6,8 +6,9 @@ from pathlib import Path
 from typing import List, Tuple
 from unittest.mock import Mock, patch
 
-import nxdrive.autolocker
 import pytest
+
+import nxdrive.autolocker
 from nxdrive.engine.dao.sqlite import ManagerDAO
 
 from .. import ensure_no_exception

--- a/tests/unit/test_blacklist_queue.py
+++ b/tests/unit/test_blacklist_queue.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from time import sleep
 
 import pytest
+
 from nxdrive.engine.blocklist_queue import BlocklistItem, BlocklistQueue
 
 

--- a/tests/unit/test_extension_listener.py
+++ b/tests/unit/test_extension_listener.py
@@ -3,9 +3,10 @@ from collections import namedtuple
 from unittest.mock import patch
 
 import pytest
-from PyQt5.QtNetwork import QAbstractSocket, QHostAddress
+from PyQt5.QtNetwork import QHostAddress
 
 from nxdrive.osi.extension import ExtensionListener, Status, get_formatted_status
+from nxdrive.qt_constants import IPv4Protocol
 
 DocPair = namedtuple(
     "DocPair",
@@ -24,7 +25,7 @@ def test_host_to_addr_bad(host):
 def test_host_to_addr_good():
     address = ExtensionListener.host_to_addr("localhost")
     assert isinstance(address, QHostAddress)
-    assert address.protocol() == QAbstractSocket.IPv4Protocol
+    assert address.protocol() == IPv4Protocol
     assert address.toString() == "127.0.0.1"
 
 

--- a/tests/unit/test_objects.py
+++ b/tests/unit/test_objects.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Any, Dict
 
 import pytest
+
 from nxdrive.exceptions import DriveError, UnknownDigest
 from nxdrive.objects import Blob, NuxeoDocumentInfo, RemoteFileInfo
 

--- a/tools/linux/nautilus/contextual_menu.py
+++ b/tools/linux/nautilus/contextual_menu.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 import subprocess
 from urllib import unquote
-from urlparse import urlparse
+from urllib.parse import urlparse
 
 from gi.repository import GObject, Nautilus
 


### PR DESCRIPTION
Thanks for the work done on https://github.com/qutebrowser/qutebrowser/issues/5904, I used the provided `enums.txt` with that script in order to find Qt enums used accross the project:

```python
from pathlib import Path


def get_enums():
    file = Path.home() / "downloads" / "enums.txt"
    lines = file.read_text().splitlines()
    return [line.strip().split() for line in lines]


def get_files():
    for file in Path("nxdrive").glob("**/*.py"):
        yield file, file.read_text().splitlines()


def find(old, new, file, contents):
    for lineno, line in enumerate(contents, 1):
        if f"{old}." in line:
            print(f"{file}:{lineno} {old} -> {new}")


def main():
    files = list(get_files())
    lines = get_enums()

    for file, content in files:
        for old, new in lines:
            find(old, new, file, content)


main()
```