### PR TITLE
Revert "Bump idna from 2.10 to 3.1 in /tools/deps"

### DIFF
--- a/docs/changes/4.5.1.md
+++ b/docs/changes/4.5.1.md
@@ -35,7 +35,6 @@ Release date: `2021-xx-xx`
 ## Minor Changes
 
 - Upgraded `chardet` from 3.0.4 to 4.0.0
-- Upgraded `idna` from 2.10 to 3.1
 - Upgraded `psutil` from 5.7.3 to 5.8.0
 - Upgraded `pyinstaller-hooks-contrib` from 2020.10 to 2020.11
 - Upgraded `pyobjc-core` from 7.0.1 to 7.1

--- a/tools/deps/requirements.txt
+++ b/tools/deps/requirements.txt
@@ -86,9 +86,9 @@ dukpy==0.2.3 \
     --hash=sha256:770c0795cbe5c41b604b12f372d2905587035f2f83489d2e1c36b88d50f9b175 \
     --hash=sha256:cc8dd158326f95231d320da80be6e6a1d72bbaad9de2569eaffb6af736f45e6b
     # via pypac
-idna==3.1 \
-    --hash=sha256:5205d03e7bcbb919cc9c19885f9920d622ca52448306f2377daede5cf3faac16 \
-    --hash=sha256:c5b02147e01ea9920e6b0a3f1f7bb833612d507592c837a6c49552768f4054e1
+idna==2.10 \
+    --hash=sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0 \
+    --hash=sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6
     # via requests
 jmespath==0.10.0 \
     --hash=sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f \


### PR DESCRIPTION
Reverts nuxeo/nuxeo-drive#2349 until https://github.com/psf/requests/pull/5711 is merged.