### PR TITLE
NXDRIVE-2453: [Direct Transfer] Missing label on the active sessions list

### DIFF
--- a/docs/changes/4.5.1.md
+++ b/docs/changes/4.5.1.md
@@ -16,6 +16,7 @@ Release date: `2021-xx-xx`
 
 - [NXDRIVE-2329](https://jira.nuxeo.com/browse/NXDRIVE-2329): Add a button to create a folder within the upload flow
 - [NXDRIVE-2394](https://jira.nuxeo.com/browse/NXDRIVE-2394): Handle multiple transfers on same file
+- [NXDRIVE-2453](https://jira.nuxeo.com/browse/NXDRIVE-2453): Missing label on the active sessions list
 
 ## GUI
 
@@ -50,6 +51,7 @@ Release date: `2021-xx-xx`
 
 ## Technical Changes
 
+- Added `ActiveSessionModel.count_no_shadow()`
 - Removed `DirectTransferUploader.upload_folder()`. Use `Remote.upload_folder()` instead.
 - Added `new_folder` keyword argument to `Engine.direct_transfer()`
 - Added `new_folder` keyword argument to `Engine.direct_transfer_async()`

--- a/nxdrive/data/qml/DirectTransfer.qml
+++ b/nxdrive/data/qml/DirectTransfer.qml
@@ -110,7 +110,7 @@ Rectangle {
                 anchors.fill: parent
                 horizontalAlignment: Qt.AlignHCenter
                 verticalAlignment: Qt.AlignVCenter
-                visible: !parent.count
+                visible: !ActiveSessionModel.count_no_shadow
                 text: qsTr("NO_ACTIVE_SESSION") + tl.tr
                 font.pointSize: point_size * 1.2
             }

--- a/nxdrive/gui/view.py
+++ b/nxdrive/gui/view.py
@@ -539,6 +539,10 @@ class ActiveSessionModel(QAbstractListModel):
     def count(self) -> int:
         return self.rowCount()
 
+    @pyqtProperty("int", notify=sessionChanged)
+    def count_no_shadow(self) -> int:
+        return self.row_count_no_shadow()
+
     @pyqtProperty("bool", notify=sessionChanged)
     def is_full(self) -> bool:
         return self.row_count_no_shadow() >= DT_ACTIVE_SESSIONS_MAX_ITEMS

--- a/tools/skiplist.py
+++ b/tools/skiplist.py
@@ -1,6 +1,7 @@
 # Code to ignore for Vulture.
 
 AbstractOSIntegration.cb_get  # OSI
+ActiveSessionModel.count_no_shadow  # Used in QML
 ActiveSessionModel.is_full  # Used in QML
 Application.about_to_quit  # Used in QML
 Application.close_direct_transfer_window  # Used in QML


### PR DESCRIPTION
Fixed NO_ACTIVE_SESSION label refresh.

Also changelog has been updated.