### PR TITLE
NXDRIVE-2438: Use a more specific NXQL query with the mixinType

### DIFF
--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -229,15 +229,16 @@ class Remote(Nuxeo):
         query = f"SELECT * FROM Document WHERE {id_prop} = '{ref}' {trash} AND ecm:isVersion = 0"
         return bool(self.query(query)["totalSize"])
 
-    def exists_in_parent(self, parent_ref: str, name: str, /) -> bool:
+    def exists_in_parent(self, parent_ref: str, name: str, folderish: bool, /) -> bool:
         """
         Fetch a document based on its parent's UID and document's name.
         Return True if such document exists.
         """
         name = self._escape(name)
+        mixin_type = f"ecm:mixinType {'=' if folderish else '<>'} 'Folderish'"
         query = (
             "SELECT * FROM Document"
-            f" WHERE ecm:parentId = '{parent_ref}' AND dc:title = '{name}'"
+            f" WHERE ecm:parentId = '{parent_ref}' AND dc:title = '{name}' AND {mixin_type}"
             " AND ecm:isProxy = 0"
             " AND ecm:isVersion = 0"
             " AND ecm:isTrashed = 0"

--- a/nxdrive/client/uploader/direct_transfer.py
+++ b/nxdrive/client/uploader/direct_transfer.py
@@ -59,7 +59,7 @@ class DirectTransferUploader(BaseUploader):
         )
 
         if doc_pair.duplicate_behavior == "ignore" and self.remote.exists_in_parent(
-            doc_pair.remote_parent_ref, file_path.name
+            doc_pair.remote_parent_ref, file_path.name, doc_pair.folderish
         ):
             msg = f"Ignoring the transfer as a document already has the name {file_path.name!r} on the server"
             log.debug(msg)

--- a/nxdrive/gui/folders_dialog.py
+++ b/nxdrive/gui/folders_dialog.py
@@ -391,20 +391,22 @@ class FoldersDialog(DialogMixin):
 
     def _find_folders_duplicates(self) -> List[str]:
         """Return a list of duplicate folder(s) found on the remote path."""
-        all_paths = self.paths.keys()
         parent = self.remote_folder_ref
+
         new_folder = self.new_folder.text()
         if bool(new_folder):
-            if self.engine.remote.exists_in_parent(parent, new_folder):
+            if self.engine.remote.exists_in_parent(parent, new_folder, True):
                 return [new_folder]
             return []
+
+        all_paths = self.paths.keys()
         return [
             path.name
             for path in all_paths
             if (
                 path.parent not in all_paths
                 and path.is_dir()
-                and self.engine.remote.exists_in_parent(parent, path.name)
+                and self.engine.remote.exists_in_parent(parent, path.name, True)
             )
         ]
 


### PR DESCRIPTION
Without that patch, it would be impossible to upload a folder named "test" if a remote non-folderish document already exists with the same name.

The same applies for the reverse check (local file "test" -> remote folder "tests").