### PR TITLE
NXDRIVE-2409: [Direct Edit] Handle document unlock error when it is already locked by someone else

### DIFF
--- a/docs/changes/4.5.1.md
+++ b/docs/changes/4.5.1.md
@@ -11,7 +11,7 @@ Release date: `2021-xx-xx`
 
 ### Direct Edit
 
-- [NXDRIVE-](https://jira.nuxeo.com/browse/NXDRIVE-):
+- [NXDRIVE-2409](https://jira.nuxeo.com/browse/NXDRIVE-2409): Handle document unlock error when it is already locked by someone else
 
 ### Direct Transfer
 

--- a/nxdrive/direct_edit.py
+++ b/nxdrive/direct_edit.py
@@ -652,9 +652,11 @@ class DirectEdit(Worker):
         except NotFound:
             return True
         except HTTPError as exc:
-            if exc.status is codes.INTERNAL_SERVER_ERROR:
+            if exc.status == codes.INTERNAL_SERVER_ERROR:
                 # INTERNAL_SERVER_ERROR is raised on double lock.
-                return True
+                locked = re.findall(r"Document already locked by", exc.message)
+                if locked:
+                    return True
             raise exc
         else:
             # Document unlocked ! No need to purge

--- a/nxdrive/direct_edit.py
+++ b/nxdrive/direct_edit.py
@@ -645,6 +645,21 @@ class DirectEdit(Worker):
 
         return False
 
+    def _unlock(self, remote: Remote, uid: str, /) -> bool:
+        """Unlock a document. Return True if purge is needed."""
+        try:
+            remote.unlock(uid)
+        except NotFound:
+            return True
+        except HTTPError as exc:
+            if exc.status is codes.INTERNAL_SERVER_ERROR:
+                # INTERNAL_SERVER_ERROR is raised on double lock.
+                return True
+            raise exc
+        else:
+            # Document unlocked ! No need to purge
+            return False
+
     def _handle_lock_queue(self) -> None:
         errors = []
 
@@ -670,12 +685,7 @@ class DirectEdit(Worker):
                     self.autolock.documentLocked.emit(ref.name)
                     continue
 
-                try:
-                    remote.unlock(uid)
-                except NotFound:
-                    purge = True
-                else:
-                    purge = False
+                purge = self._unlock(remote, uid)
 
                 if purge or action == "unlock_orphan":
                     path = self.local.abspath(ref)

--- a/nxdrive/direct_edit.py
+++ b/nxdrive/direct_edit.py
@@ -653,7 +653,7 @@ class DirectEdit(Worker):
             return True
         except HTTPError as exc:
             if exc.status == codes.INTERNAL_SERVER_ERROR:
-                # INTERNAL_SERVER_ERROR is raised on double lock.
+                # INTERNAL_SERVER_ERROR is raised if the lock was acquired by someone else.
                 if "Document already locked by" in exc.message:
                     return True
             raise exc

--- a/nxdrive/direct_edit.py
+++ b/nxdrive/direct_edit.py
@@ -654,8 +654,7 @@ class DirectEdit(Worker):
         except HTTPError as exc:
             if exc.status == codes.INTERNAL_SERVER_ERROR:
                 # INTERNAL_SERVER_ERROR is raised on double lock.
-                locked = re.findall(r"Document already locked by", exc.message)
-                if locked:
+                if "Document already locked by" in exc.message:
                     return True
             raise exc
         else:

--- a/tests/old_functional/test_direct_edit.py
+++ b/tests/old_functional/test_direct_edit.py
@@ -1009,6 +1009,15 @@ class TestDirectEditLock(TwoUsersTest, DirectEditSetup):
         # Lock the document with user 1
         assert self.direct_edit._lock(self.remote, doc_id)
 
-        # Try to unlock with user 2, should return True for purge
-        with pytest.raises(HTTPError):
+        def unlock(*_, **__):
+            """
+            Patch Remote.unlock() so that it raises
+            a specific HTTPError.
+            """
+            raise HTTPError(
+                status=500, message="Document already locked by {self.user_1!r}"
+            )
+
+        with patch.object(self.remote_2, "unlock", new=unlock):
+            # Try to unlock with user 2, should return True for purge
             assert self.direct_edit._unlock(self.remote_2, doc_id)

--- a/tests/old_functional/test_direct_edit.py
+++ b/tests/old_functional/test_direct_edit.py
@@ -1015,9 +1015,9 @@ class TestDirectEditLock(TwoUsersTest, DirectEditSetup):
             a specific HTTPError.
             """
             raise HTTPError(
-                status=500, message="Document already locked by {self.user_1!r}"
+                status=500, message=f"Document already locked by {self.user_1!r}"
             )
 
-        with patch.object(self.remote_2, "unlock", new=unlock):
+        with patch.object(self.remote_2, "unlock", new=unlock), ensure_no_exception():
             # Try to unlock with user 2, should return True for purge
             assert self.direct_edit._unlock(self.remote_2, doc_id)

--- a/tests/old_functional/test_direct_edit.py
+++ b/tests/old_functional/test_direct_edit.py
@@ -1000,3 +1000,15 @@ class TestDirectEditLock(TwoUsersTest, DirectEditSetup):
         with pytest.raises(DocumentAlreadyLocked) as exc:
             self.direct_edit._lock(self.remote_2, doc_id)
         assert str(exc.value) == f"Document already locked by {self.user_1!r}"
+
+    def test_unlock_different_user(self):
+        filename = "test_unlock_different_user.txt"
+        doc_id = self.remote.make_file_with_no_blob("/", filename)
+        self.remote.attach_blob(doc_id, b"Some content.", filename)
+
+        # Lock the document with user 1
+        assert self.direct_edit._lock(self.remote, doc_id)
+
+        # Try to unlock with user 2, should return True for purge
+        with pytest.raises(HTTPError):
+            assert self.direct_edit._unlock(self.remote_2, doc_id)


### PR DESCRIPTION
Exception is now catched and orphan is purged when the error is encountered.

A tests have been added.