### PR TITLE
NXDRIVE-2485: Use os.path.realpath() instead of abspath()

### DIFF
--- a/docs/changes/4.5.1.md
+++ b/docs/changes/4.5.1.md
@@ -10,6 +10,7 @@ Release date: `2021-xx-xx`
 - [NXDRIVE-2459](https://jira.nuxeo.com/browse/NXDRIVE-2459): Move PyQt imports to one file
 - [NXDRIVE-2472](https://jira.nuxeo.com/browse/NXDRIVE-2472): Fix a security issue when retrieving a SSL certificate
 - [NXDRIVE-2482](https://jira.nuxeo.com/browse/NXDRIVE-2482): Prevent upgrading from Windows 7
+- [NXDRIVE-2485](https://jira.nuxeo.com/browse/NXDRIVE-2485): Use `os.path.realpath()` instead of `abspath()`
 
 ### Direct Edit
 

--- a/nxdrive/client/local/base.py
+++ b/nxdrive/client/local/base.py
@@ -564,9 +564,9 @@ class LocalClientMixin:
 
     def get_path(self, target: Path, /) -> Path:
         """ Relative path to the local client from an absolute OS path. """
-        # NXDRIVE-2319: using os.path.abspath() instead of Path.resolve and Path.absolute().
+        # NXDRIVE-2485: using os.path.realpath() instead of Path.resolve() and Path.absolute().
         try:
-            return Path(os.path.abspath(target)).relative_to(self.base_folder)
+            return Path(os.path.realpath(target)).relative_to(self.base_folder)
         except ValueError:
             # From the Path.relative_to() doc: if the operation is not possible
             # (because this is not a subpath of the other path), raise ValueError.

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -460,8 +460,8 @@ def normalized_path(path: Union[bytes, str, Path], /) -> Path:
     """
     if not isinstance(path, Path):
         path = Path(os.fsdecode(path))
-    # NXDRIVE-2319: using os.path.abspath() instead of Path.resolve and Path.absolute().
-    return Path(os.path.abspath(path.expanduser()))
+    # NXDRIVE-2485: using os.path.realpath() instead of Path.resolve() and Path().absolute().
+    return Path(os.path.realpath(path.expanduser()))
 
 
 def normalize_and_expand_path(path: str, /) -> Path:


### PR DESCRIPTION
`realpath()` will resolve symbolic links and return an absolute path.