### PR TITLE
NXDRIVE-2489: [Windows] Subfolder content not synced on unfiltering

### DIFF
--- a/docs/changes/4.5.1.md
+++ b/docs/changes/4.5.1.md
@@ -11,6 +11,7 @@ Release date: `2021-xx-xx`
 - [NXDRIVE-2472](https://jira.nuxeo.com/browse/NXDRIVE-2472): Fix a security issue when retrieving a SSL certificate
 - [NXDRIVE-2482](https://jira.nuxeo.com/browse/NXDRIVE-2482): Prevent upgrading from Windows 7
 - [NXDRIVE-2485](https://jira.nuxeo.com/browse/NXDRIVE-2485): Use `os.path.realpath()` instead of `abspath()`
+- [NXDRIVE-2489](https://jira.nuxeo.com/browse/NXDRIVE-2489): [Windows] Subfolder content not synced on unfiltering
 
 ### Direct Edit
 

--- a/nxdrive/engine/dao/sqlite.py
+++ b/nxdrive/engine/dao/sqlite.py
@@ -1666,7 +1666,7 @@ class EngineDAO(ConfigurationDAO):
         return res
 
     def _get_recursive_remote_condition(self, doc_pair: DocPair, /) -> str:
-        path = self._escape(f"{doc_pair.remote_parent_path}/{doc_pair.remote_name}")
+        path = self._escape(f"{doc_pair.remote_parent_path}/{doc_pair.remote_ref}")
         return (
             f" WHERE remote_parent_path LIKE '{path}/%'"
             f"    OR remote_parent_path = '{path}'"


### PR DESCRIPTION
The States table was not cleaned correctly when filtering a
remote sync root. This prevented the sub-sub-folders to
be synced again when the user unfitered the remote sync root.

All childrens of the synced root are now deleted from the States
table when applying a filter.