### PR TITLE
NXDRIVE-2487: Always enable Sentry on alpha versions or when the app …

### DIFF
--- a/docs/changes/5.0.0.md
+++ b/docs/changes/5.0.0.md
@@ -38,4 +38,5 @@ Release date: `2021-xx-xx`
 
 ## Technical Changes
 
-- Add `Options.is_alpha`
+- Added `Options.is_alpha`
+- Added options.py::`validate_use_sentry()`

--- a/docs/changes/5.0.0.md
+++ b/docs/changes/5.0.0.md
@@ -38,4 +38,4 @@ Release date: `2021-xx-xx`
 
 ## Technical Changes
 
--
+- Add `Options.is_alpha`

--- a/docs/changes/5.0.0.md
+++ b/docs/changes/5.0.0.md
@@ -4,6 +4,7 @@ Release date: `2021-xx-xx`
 
 ## Core
 
+- [NXDRIVE-2487](https://jira.nuxeo.com/browse/NXDRIVE-2487): Always enable Sentry on alpha versions or when the app is ran from sources
 - [NXDRIVE-2508](https://jira.nuxeo.com/browse/NXDRIVE-2508): Fix mypy issues following the update to mypy 0.800
 
 ### Direct Edit

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -1293,15 +1293,11 @@ class Application(QApplication):
     def show_release_notes(self, version: str, /) -> None:
         """ Display release notes of a given version. """
 
-        if "CI" in os.environ:
+        if "CI" in os.environ or Options.is_alpha:
             return
 
         channel = self.manager.get_update_channel()
-        log.info(f"Showing release notes, version={version!r} channel={channel}")
-
-        if version.count(".") != 2:  # Alpha version
-            return
-
+        log.info(f"Showing release notes, {version=} {channel=}")
         self.display_info(
             Translator.get("RELEASE_NOTES_TITLE", values=[APP_NAME]),
             "RELEASE_NOTES_MSG",

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -1833,9 +1833,6 @@ class Application(QApplication):
         em_analytics = QCheckBox(tr("SHARE_METRICS_ERROR_REPORTING"))
         em_analytics.setChecked(True)
         em_analytics.stateChanged.connect(errors_choice)
-        # Sentry must be enabled on alpha versions or when the app is ran from sources
-        if not (Options.is_frozen and self.manager.version.count(".") == 2):
-            em_analytics.setEnabled(False)
         layout.addWidget(em_analytics)
 
         cb_analytics = QCheckBox(tr("SHARE_METRICS_ANALYTICS"))

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -1833,6 +1833,9 @@ class Application(QApplication):
         em_analytics = QCheckBox(tr("SHARE_METRICS_ERROR_REPORTING"))
         em_analytics.setChecked(True)
         em_analytics.stateChanged.connect(errors_choice)
+        # Sentry must be enabled on alpha versions or when the app is ran from sources
+        if not (Options.is_frozen and self.manager.version.count(".") == 2):
+            em_analytics.setEnabled(False)
         layout.addWidget(em_analytics)
 
         cb_analytics = QCheckBox(tr("SHARE_METRICS_ANALYTICS"))

--- a/nxdrive/manager.py
+++ b/nxdrive/manager.py
@@ -287,9 +287,7 @@ class Manager(QObject):
         state_file = Options.nxdrive_home / "metrics.state"
         if state_file.is_file():
             lines = state_file.read_text(encoding="utf-8").splitlines()
-            # Sentry must be enabled on alpha versions or when the app is ran from sources
-            if Options.is_frozen and self.version.count(".") == 2:
-                Options.use_sentry = "sentry" in lines
+            Options.use_sentry = "sentry" in lines
             Options.use_analytics = "analytics" in lines
             self.preferences_metrics_chosen = True
 

--- a/nxdrive/manager.py
+++ b/nxdrive/manager.py
@@ -287,7 +287,9 @@ class Manager(QObject):
         state_file = Options.nxdrive_home / "metrics.state"
         if state_file.is_file():
             lines = state_file.read_text(encoding="utf-8").splitlines()
-            Options.use_sentry = "sentry" in lines
+            # Sentry must be enabled on alpha versions or when the app is ran from sources
+            if Options.is_frozen and self.version.count(".") == 2:
+                Options.use_sentry = "sentry" in lines
             Options.use_analytics = "analytics" in lines
             self.preferences_metrics_chosen = True
 

--- a/nxdrive/options.py
+++ b/nxdrive/options.py
@@ -49,6 +49,7 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Set, Tuple, Union
 
+from . import __version__
 from .feature import DisabledFeatures, Feature
 
 __all__ = ("Options",)
@@ -245,6 +246,7 @@ class MetaOptions(type):
         "ignored_files": (__files, "default"),
         "ignored_prefixes": (__prefixes, "default"),
         "ignored_suffixes": (__suffixes, "default"),
+        "is_alpha": (__version__.count(".") != 2, "default"),
         "is_frozen": (_get_frozen_state(), "default"),
         "locale": ("en", "default"),
         "log_level_console": ("WARNING", "default"),
@@ -563,6 +565,14 @@ def validate_client_version(value: str, /) -> str:
     )
 
 
+def validate_use_sentry(value: bool, /) -> bool:
+    if Options.is_frozen and not Options.is_alpha:
+        return value
+    raise ValueError(
+        "Sentry is forcibly enabled on alpha versions or when the app is ran from sources"
+    )
+
+
 def validate_tmp_file_limit(value: Union[int, float], /) -> float:
     if value > 0:
         return float(value)
@@ -576,4 +586,5 @@ for feature in vars(Feature).keys():
 Options.checkers["chunk_limit"] = validate_chunk_limit
 Options.checkers["chunk_size"] = validate_chunk_size
 Options.checkers["client_version"] = validate_client_version
+Options.checkers["use_sentry"] = validate_use_sentry
 Options.checkers["tmp_file_limit"] = validate_tmp_file_limit


### PR DESCRIPTION
…is ran from sources