### PR TITLE
NXDRIVE-1359: Reduce the complexity of Processor._execute()

### DIFF
--- a/docs/changes/5.0.0.md
+++ b/docs/changes/5.0.0.md
@@ -4,6 +4,7 @@ Release date: `2021-xx-xx`
 
 ## Core
 
+- [NXDRIVE-1359](https://jira.nuxeo.com/browse/NXDRIVE-1359): Reduce the complexity of `Processor._execute()`
 - [NXDRIVE-2487](https://jira.nuxeo.com/browse/NXDRIVE-2487): Always enable Sentry on alpha versions or when the app is ran from sources
 - [NXDRIVE-2501](https://jira.nuxeo.com/browse/NXDRIVE-2501): Fix the "Open remote" action on conflicted folderish documents
 - [NXDRIVE-2508](https://jira.nuxeo.com/browse/NXDRIVE-2508): Fix mypy issues following the update to mypy 0.800


### PR DESCRIPTION
- Moved `._current_doc_pair` from class attribute to instance attribute.
- Introduced `._get_next_doc_pair()`.
- Introduced `._handle_doc_pair_dt()` and `._handle_doc_pair_sync()`.
  Mixing sync items with Direct Transfer ones was already quite tricky.
  I split the code in specific methods. It is a little bit more clear.

I am not sure we can optimize `._execute()` more, the "D" `radon` notation is because of errors handling.