### PR TITLE
NXDRIVE-2351: Fix left 'orange' color

### DIFF
--- a/nxdrive/data/qml/Systray.qml
+++ b/nxdrive/data/qml/Systray.qml
@@ -301,7 +301,7 @@ Rectangle {
                     name: "conflicted"
                     PropertyChanges {
                         target: errorState
-                        color: orange
+                        color: warningContent
                         text: qsTr("CONFLICTS_SYSTRAY").arg(ConflictsModel.count) + tl.tr
                         onClicked: api.show_conflicts_resolution(accountSelect.getRole("uid"))
                     }


### PR DESCRIPTION
    Systray.qml:304: ReferenceError: orange is not defined