### PR TITLE
NXDRIVE-2479: Improve S3 class import

### DIFF
--- a/nxdrive/client/uploader/__init__.py
+++ b/nxdrive/client/uploader/__init__.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 from botocore.exceptions import ClientError
 from nuxeo.exceptions import HTTPError
 from nuxeo.handlers.default import Uploader
+from nuxeo.handlers.s3 import UploaderS3  # noqa; fix lazy import error
 from nuxeo.models import Batch, FileBlob
 
 from ...constants import TX_TIMEOUT, TransferStatus

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -380,9 +380,8 @@ class Processor(EngineWorker):
                 else:
                     error = f"{handler_name}_http_error_{exc.status}"
                     self._handle_pair_handler_exception(doc_pair, error, exc)
-            except UploadError as exc:
-                log.info(exc)
-                log.warning("Delaying failed upload")
+            except UploadError:
+                log.warning("Delaying failed upload", exc_info=True)
                 self._postpone_pair(doc_pair, "Upload")
             except (DownloadPaused, UploadPaused) as exc:
                 nature = "download" if isinstance(exc, DownloadPaused) else "upload"


### PR DESCRIPTION
Prevent that error when the import will be made lazily:

    ImportError: cannot import name 'UploaderS3' from partially initialized module 'nuxeo.handlers.s3' (most likely due to a circular import)

Also log the cause of an upload error to help debug.