### PR TITLE
NXDRIVE-2524: [GNU/Linux] WAL journal mode cause manager database corruption

### DIFF
--- a/docs/changes/5.0.0.md
+++ b/docs/changes/5.0.0.md
@@ -14,6 +14,7 @@ Release date: `2021-xx-xx`
 - [NXDRIVE-2513](https://jira.nuxeo.com/browse/NXDRIVE-2513): Always enable DEBUG log level on alpha versions or when the app is ran from sources
 - [NXDRIVE-2515](https://jira.nuxeo.com/browse/NXDRIVE-2515): Log the previous version when displaying release notes
 - [NXDRIVE-2518](https://jira.nuxeo.com/browse/NXDRIVE-2518): Drop support for macOS 10.12 (Sierra)
+- [NXDRIVE-2524](https://jira.nuxeo.com/browse/NXDRIVE-2524): [GNU/Linux] WAL journal mode cause manager database corruption
 - [NXDRIVE-2525](https://jira.nuxeo.com/browse/NXDRIVE-2525): Do not try to list parts when an upload was already completed on S3
 
 ### Direct Edit

--- a/nxdrive/engine/dao/sqlite.py
+++ b/nxdrive/engine/dao/sqlite.py
@@ -444,9 +444,9 @@ class ConfigurationDAO(QObject):
 class ManagerDAO(ConfigurationDAO):
 
     _state_factory = EngineDef
-    _journal_mode: str = (
-        "DELETE"  # WAL not needed as we write less often (NXDRIVE-2524).
-    )
+
+    # WAL not needed as we write less often and it may have issues on GNU/Linux (NXDRIVE-2524)
+    _journal_mode: str = "DELETE"
 
     def get_schema_version(self) -> int:
         return 2


### PR DESCRIPTION
The DELETE journal mode is now user for the manager database instead of WAL.