### PR TITLE
NXDRIVE-2523: Prevent crashes because of too many opened file descriptors

### DIFF
--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -925,8 +925,7 @@ class Engine(QObject):
     ) -> QThread:
         if worker is None:
             worker = Worker(self, name=name)
-
-        if isinstance(worker, Processor):
+        elif isinstance(worker, Processor):
             worker.pairSyncStarted.connect(self.newSyncStarted)
             worker.pairSyncEnded.connect(self.newSyncEnded)
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -36,7 +36,7 @@ class MockEngineDAO(EngineDAO):
             return None
 
         mode = f" AND last_transfer='{sync_mode}' " if sync_mode else ""
-        c = self._get_read_connection().cursor()
+        c = self._read_con.cursor()
         return c.execute(
             "SELECT *"
             "  FROM States "
@@ -56,7 +56,7 @@ class MockEngineDAO(EngineDAO):
         state = self.get_normal_state_from_remote(ref)
         if not state:
             return None
-        c = self._get_read_connection().cursor()
+        c = self._read_con.cursor()
         return c.execute(
             "SELECT *"
             "  FROM States"

--- a/tests/unit/test_engine_dao.py
+++ b/tests/unit/test_engine_dao.py
@@ -200,7 +200,7 @@ def test_conflicts(engine_dao):
 def test_corrupted_database(engine_dao):
     """ DatabaseError: database disk image is malformed. """
     with engine_dao("corrupted_database.db") as dao:
-        c = dao._get_read_connection().cursor()
+        c = dao._read_con.cursor()
         cols = c.execute("SELECT * FROM States").fetchall()
         assert len(cols) == 3
 
@@ -296,8 +296,8 @@ def test_dao_register_adapter(engine_dao):
     local_path = Path(os.path.realpath(__file__))
 
     with engine_dao("engine_migration_16.db") as dao:
-        dao._get_write_connection().row_factory = None
-        c = dao._get_write_connection().cursor()
+        dao._write_con.row_factory = None
+        c = dao._write_con.cursor()
 
         c.execute(
             "INSERT INTO States "
@@ -327,7 +327,7 @@ def test_dao_register_adapter(engine_dao):
 
 def test_migration_db_v1(engine_dao):
     with engine_dao("engine_migration.db") as dao:
-        c = dao._get_read_connection().cursor()
+        c = dao._read_con.cursor()
 
         cols = c.execute("PRAGMA table_info('States')").fetchall()
         assert len(cols) == 33
@@ -339,7 +339,7 @@ def test_migration_db_v1(engine_dao):
 def test_migration_db_v1_with_duplicates(engine_dao):
     """ Test a non empty DB. """
     with engine_dao("engine_migration_duplicate.db") as dao:
-        c = dao._get_read_connection().cursor()
+        c = dao._read_con.cursor()
         rows = c.execute("SELECT * FROM States").fetchall()
         assert not rows
 
@@ -426,8 +426,8 @@ def test_migration_db_v16(engine_dao):
 def test_migration_db_v18(engine_dao):
     """Verify States after migration from v17 to v18."""
     with engine_dao("engine_migration_18.db") as dao:
-        dao._get_write_connection().row_factory = None
-        c = dao._get_write_connection().cursor()
+        dao._read_con.row_factory = None
+        c = dao._read_con.cursor()
 
         rows = c.execute(
             "SELECT local_path, local_parent_path FROM States",


### PR DESCRIPTION
The issue was not visible quickly but when Drive was running a long
time with a lot of synchronization actions. Each thread was opening
a connection to the SQLite database file, but it was never released.

It was kind of weird to manager connections like that. Now, read/writes
cursors are well handled. It results in a slower synchronization when
it is a matter of thousands small files.
We decided to go with the stability over the velocity.