### PR TITLE
NXDRIVE-2523: Prevent crashes because of too many opened file descrip…

### DIFF
--- a/docs/changes/5.0.1.md
+++ b/docs/changes/5.0.1.md
@@ -4,6 +4,7 @@ Release date: `2021-xx-xx`
 
 ## Core
 
+- [NXDRIVE-2523](https://jira.nuxeo.com/browse/NXDRIVE-2523): Prevent crashes because of too many opened file descriptors
 - [NXDRIVE-2531](https://jira.nuxeo.com/browse/NXDRIVE-2531): Finish refactoring of `Processor._execute()` for Direct Transfer actions
 
 ### Direct Edit

--- a/tests/unit/test_engine_dao.py
+++ b/tests/unit/test_engine_dao.py
@@ -426,8 +426,8 @@ def test_migration_db_v16(engine_dao):
 def test_migration_db_v18(engine_dao):
     """Verify States after migration from v17 to v18."""
     with engine_dao("engine_migration_18.db") as dao:
-        dao._get_write_connection().row_factory = None
-        c = dao._get_write_connection().cursor()
+        dao._get_read_connection().row_factory = None
+        c = dao._get_read_connection().cursor()
 
         rows = c.execute(
             "SELECT local_path, local_parent_path FROM States",


### PR DESCRIPTION
…tors

The issue was not visible quickly but when Drive was running a long time with a lot of synchronization actions. Each thread was opening a connection to the SQLite database file, but it was never released.