### PR TITLE
NXDRIVE-2543: Fix test_file_action_with_values() to finish the action

### DIFF
--- a/docs/changes/5.0.1.md
+++ b/docs/changes/5.0.1.md
@@ -29,7 +29,7 @@ Release date: `2021-xx-xx`
 
 ## Tests
 
-- [NXDRIVE-2](https://jira.nuxeo.com/browse/NXDRIVE-2):
+- [NXDRIVE-2543](https://jira.nuxeo.com/browse/NXDRIVE-2543): Fix `test_file_action_with_values()` to finish the action
 
 ## Docs
 

--- a/tests/unit/test_action.py
+++ b/tests/unit/test_action.py
@@ -159,6 +159,8 @@ def test_file_action_with_values():
     assert details["progress"] == 100.0
     assert details["uploaded"]
 
+    Action.finish_action()
+
 
 def test_file_action_signals():
     """Try to mimic QThread signals to test ._connect_reporter()."""


### PR DESCRIPTION
`test_file_action_with_values()` was leaking its action and it was making `test_tooltip()` to fail on macOS.