### PR TITLE
NXDRIVE-2549: Fix test number display

### DIFF
--- a/docs/changes/5.0.1.md
+++ b/docs/changes/5.0.1.md
@@ -31,6 +31,7 @@ Release date: `2021-xx-xx`
 ## Tests
 
 - [NXDRIVE-2543](https://jira.nuxeo.com/browse/NXDRIVE-2543): Fix `test_file_action_with_values()` to finish the action
+- [NXDRIVE-2549](https://jira.nuxeo.com/browse/NXDRIVE-2549): Fix test number display
 
 ## Docs
 

--- a/tools/posix/deploy_ci_agent.sh
+++ b/tools/posix/deploy_ci_agent.sh
@@ -254,7 +254,7 @@ launch_tests() {
         echo ">>> Launching synchronization functional tests, file by file"
         echo "    (first, run for each test file, failures are ignored to have"
         echo "     a whole picture of errors)"
-        total="$(find tests/old_functional -name "test_*.py" | wc -l)"
+        total="$(find tests/old_functional -name "test_*.py" | wc -l | tr -d '[:space:]')"
         number=1
         for test_file in $(find tests/old_functional -name "test_*.py"); do
             echo ""


### PR DESCRIPTION
On macOs, before the patch, we had those lines:

    >>> [1/      47] Testing tests/old_functional/test_special_characters.py ...

And with the patch:

    >>> [1/47] Testing tests/old_functional/test_special_characters.py ...

It is a uniformization of the display on all OSes.