### PR TITLE
NXDRIVE-2550: Prevent Sentry flooding

### DIFF
--- a/docs/changes/5.0.1.md
+++ b/docs/changes/5.0.1.md
@@ -10,6 +10,7 @@ Release date: `2021-xx-xx`
 - [NXDRIVE-2530](https://jira.nuxeo.com/browse/NXDRIVE-2530): Add logs for the deletion behavior state
 - [NXDRIVE-2538](https://jira.nuxeo.com/browse/NXDRIVE-2538): Take into account the deletion behavior when handling deleted files at startup
 - [NXDRIVE-2539](https://jira.nuxeo.com/browse/NXDRIVE-2539): Fix endless synchronization on permission error when setting the remote ID on a file
+- [NXDRIVE-2550](https://jira.nuxeo.com/browse/NXDRIVE-2550): Prevent Sentry flooding
 
 ### Direct Edit
 
@@ -53,3 +54,6 @@ Release date: `2021-xx-xx`
 - Added `QMLDriveAPI.generate_csv()`
 - Removed `QMLDriveAPI.open_report()`. Use `.open_in_explorer()` instead.
 - Added session_csv.py
+- Added tracing.py
+- Removed \_\_main\_\_.py::`before_send()`. Use tracing.py::`before_send()` instead.
+- Removed \_\_main\_\_.py::`setup_sentry()`. Use tracing.py::`setup_sentry()` instead.

--- a/nxdrive/tracing.py
+++ b/nxdrive/tracing.py
@@ -1,0 +1,78 @@
+import os
+from typing import Any, Dict, Set
+
+from .options import Options
+
+# From sentry_sdk._types
+_Event = Dict[str, Any]
+_Hint = Dict[str, Any]
+
+# Sentry events already sent
+_EVENTS: Set[int] = set()
+
+
+def should_ignore(event: _Event) -> bool:
+    """Return False if the event can be sent to Sentry."""
+    # Sentry may have been disabled later, via a CLI argument or GUI parameter
+    if not Options.use_sentry:
+        return True
+
+    # Compute a "fingerprint" of the stacktrace. Peusdo-code:
+    # hash(
+    #     "nxdrive/engine/activity.py:262",
+    #     "nxdrive/engine/watcher/local_watcher.py:99",
+    #     "nxdrive/engine/watcher/local_watcher.py:275",
+    #     "nxdrive/engine/watcher/local_watcher.py:283",
+    #     "nxdrive/engine/workers.py:196",
+    # )
+    fingerprint = hash(
+        tuple(
+            sorted(
+                f"{err['filename']}:{err['lineno']}"
+                for err in event["exception"]["values"][0]["stacktrace"]["frames"]
+            )
+        )
+    )
+    if fingerprint in _EVENTS:
+        return True
+    _EVENTS.add(fingerprint)
+
+    return False
+
+
+def before_send(event: _Event, _: _Hint, /) -> Any:
+    """Alter an event before sending to the Sentry server."""
+    if should_ignore(event):
+        # The event will not be sent if None is returned
+        return None
+
+    return event
+
+
+def setup_sentry() -> None:
+    """Setup Sentry."""
+
+    if os.getenv("SKIP_SENTRY", "0") == "1":
+        return
+
+    sentry_dsn: str = os.getenv(
+        "SENTRY_DSN",
+        "https://c4daa72433b443b08bd25e0c523ecef5@o223531.ingest.sentry.io/1372714",
+    )
+    if not sentry_dsn:
+        return
+
+    import sentry_sdk
+
+    from . import __version__
+
+    sentry_sdk.init(
+        dsn=sentry_dsn,
+        environment=os.getenv("SENTRY_ENV", "production"),
+        release=__version__,
+        attach_stacktrace=True,
+        before_send=before_send,
+        # Set traces_sample_rate to 1.0 to capture 100%
+        # of transactions for performance monitoring.
+        traces_sample_rate=1.0,
+    )

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -1,0 +1,76 @@
+import pytest
+from sentry_sdk import Client, Hub, Transport, capture_exception
+
+import nxdrive.tracing
+
+#
+# Start Sentry internals.
+# See https://github.com/getsentry/sentry-python/blob/0.20.3/tests/conftest.py
+#
+# This is OK because we need to test Event objects and not the Transport or Hub, or whatever.
+#
+
+
+class CustomTransport(Transport):
+    def __init__(self):
+        super().__init__()
+        self._queue = None
+
+
+@pytest.fixture
+def sentry_init(monkeypatch):
+    def inner(*a, **kw):
+        hub = Hub.current
+        client = Client(*a, **kw)
+        hub.bind_client(client)
+        monkeypatch.setattr(Hub.current.client, "transport", CustomTransport())
+
+    yield inner
+
+
+#
+# End Sentry internals.
+#
+
+
+def test_flooding_prevention(sentry_init):
+    """Ensure that an infinite synchronization due to a unhandled error
+    will not explode the Sentry quota.
+    """
+
+    def whoopsy():
+        """Problematic function ... """
+        try:
+            raise ValueError("Mock'ed error")
+        except Exception:
+            capture_exception()
+
+    def whoopsy2():
+        """Problematic function ... """
+        try:
+            raise ValueError("Mock'ed error")
+        except Exception:
+            capture_exception()
+
+    sentry_init(before_send=nxdrive.tracing.before_send)
+
+    # Ensure there is no event by default
+    assert not nxdrive.tracing._EVENTS
+
+    # The first event of an error should be sent
+    whoopsy()
+    assert len(nxdrive.tracing._EVENTS) == 1
+
+    # Further events on the same error should not be sent
+    whoopsy()
+    whoopsy()
+    assert len(nxdrive.tracing._EVENTS) == 1
+
+    # A new error happens
+    whoopsy2()
+    assert len(nxdrive.tracing._EVENTS) == 2
+
+    # Again and again ...
+    whoopsy2()
+    whoopsy2()
+    assert len(nxdrive.tracing._EVENTS) == 2


### PR DESCRIPTION
Added a simple filter to ignore already sent events.

I also removed the sensitive data redaction as it was not working and Sentry already provides such mechanism by default.