### PR TITLE
NXDRIVE-2463: Add support for idempotent requests

### DIFF
--- a/docs/changes/5.1.1.md
+++ b/docs/changes/5.1.1.md
@@ -5,6 +5,7 @@ Release date: `2021-xx-xx`
 ## Core
 
 - [NXDRIVE-2443](https://jira.nuxeo.com/browse/NXDRIVE-2443): Bypass all OS errors in `disk_space()`
+- [NXDRIVE-2463](https://jira.nuxeo.com/browse/NXDRIVE-2463): Add support for idempotent requests
 - [NXDRIVE-2558](https://jira.nuxeo.com/browse/NXDRIVE-2558): Add a custom metric for hard crashes
 - [NXDRIVE-2574](https://jira.nuxeo.com/browse/NXDRIVE-2574): Handle pair state deleted-moved as a remotely created
 - [NXDRIVE-2575](https://jira.nuxeo.com/browse/NXDRIVE-2575): Fix error message when `get_metadata_infos()` would likely fail
@@ -50,6 +51,8 @@ Release date: `2021-xx-xx`
 - Changed the arguments types from `Engine.directTransferSessionFinished` signal to `(str, str, str)`
 - Added `Notification.action_args`
 - Changed the arguments types from `NotificationService.triggerNotification ` signal to `(str, object)`
+- Added `Options.use_idempotent_requests`
 - Added `State.crash_details`
+- Added `Uploads.request_uid`
 - Added metrics/constants.py::`CRASHED_TRACE`
 - Added updater/\_\_init\_\_.py::`UpdateIntegrityError`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -512,6 +512,19 @@ Share anonymous usage analytics to help the developers build the best experience
 - Version added: 4.1.0
 - Version changed: 4.4.5, a minimal set of GDPR-information is sent even if set to `False` (see [NXDRIVE-2254](https://jira.nuxeo.com/browse/NXDRIVE-2254))
 
+#### `use-idempotent-requests`
+
+Control whenever specific HTTP calls should be made idempotent or not.
+
+- Default value (bool): `False`
+- Version added: 5.1.1
+
+It requires [NXP-29978](https://jira.nuxeo.com/browse/NXP-29978) on the server.
+
+If enabled, those requests will be impacted:
+- `FileManager.Import` (Direct Transfer)
+- `NuxeoDrive.CreateFile` (synchronization)
+
 * * *
 
 #### `use-sentry`

--- a/nxdrive/engine/dao/sqlite.py
+++ b/nxdrive/engine/dao/sqlite.py
@@ -946,8 +946,49 @@ class EngineDAO(ConfigurationDAO):
             self._create_transfer_tables(cursor)
 
             # Insert back old datas with up-to-date constraints
-            cursor.execute("INSERT INTO Uploads SELECT * FROM Uploads_backup;")
-            cursor.execute("INSERT INTO Downloads SELECT * FROM Downloads_backup;")
+            sql = (
+                "INSERT INTO Uploads"
+                " (uid, path, status, engine, is_direct_edit, is_direct_transfer, progress, filesize, doc_pair,"
+                "  batch, chunk_size, remote_parent_path, remote_parent_ref)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            )
+            for row in cursor.execute("SELECT * FROM Uploads_backup"):
+                upload_values = (
+                    row.uid,
+                    row.path,
+                    row.status,
+                    row.engine,
+                    row.is_direct_edit,
+                    row.is_direct_transfer,
+                    row.progress,
+                    row.filesize,
+                    row.doc_pair,
+                    row.batch,
+                    row.chunk_size,
+                    row.remote_parent_path,
+                    row.remote_parent_ref,
+                )
+                cursor.execute(sql, upload_values)
+
+            sql = (
+                "INSERT INTO Downloads"
+                " (uid, path, status, engine, is_direct_edit, progress, filesize, doc_pair, tmpname, url)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            )
+            for row in cursor.execute("SELECT * FROM Downloads_backup"):
+                download_values = (
+                    row.uid,
+                    row.path,
+                    row.status,
+                    row.engine,
+                    row.is_direct_edit,
+                    row.progress,
+                    row.filesize,
+                    row.doc_pair,
+                    row.tmpname,
+                    row.url,
+                )
+                cursor.execute(sql, download_values)
 
             # Delete the backup tables
             cursor.execute("DROP TABLE Uploads_backup;")

--- a/nxdrive/engine/dao/sqlite.py
+++ b/nxdrive/engine/dao/sqlite.py
@@ -764,8 +764,48 @@ class EngineDAO(ConfigurationDAO):
             )
 
             # Insert back old datas with up-to-date fields types
-            cursor.execute("INSERT INTO Uploads SELECT * FROM Uploads_backup;")
-            cursor.execute("INSERT INTO Downloads SELECT * FROM Downloads_backup;")
+            sql = (
+                "INSERT INTO Uploads"
+                " (uid, path, status, engine, is_direct_edit, progress, doc_pair, batch, chunk_size)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            )
+            for row in cursor.execute("SELECT * FROM Uploads_backup"):
+                upload_values = (
+                    row.uid,
+                    row.path,
+                    row.status,
+                    row.engine,
+                    row.is_direct_edit,
+                    row.is_direct_transfer,
+                    row.progress,
+                    row.filesize,
+                    row.doc_pair,
+                    row.batch,
+                    row.chunk_size,
+                    row.remote_parent_path,
+                    row.remote_parent_ref,
+                )
+                cursor.execute(sql, upload_values)
+
+            sql = (
+                "INSERT INTO Downloads"
+                " (uid, path, status, engine, is_direct_edit, progress, filesize, doc_pair, tmpname, url)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            )
+            for row in cursor.execute("SELECT * FROM Downloads_backup"):
+                download_values = (
+                    row.uid,
+                    row.path,
+                    row.status,
+                    row.engine,
+                    row.is_direct_edit,
+                    row.progress,
+                    row.filesize,
+                    row.doc_pair,
+                    row.tmpname,
+                    row.url,
+                )
+                cursor.execute(sql, download_values)
 
             # Delete the backup tables
             cursor.execute("DROP TABLE Uploads_backup;")

--- a/nxdrive/objects.py
+++ b/nxdrive/objects.py
@@ -477,6 +477,7 @@ class Upload(Transfer):
     remote_parent_path: str = ""
     remote_parent_ref: str = ""
     batch_obj: Batch = None
+    request_uid: Optional[str] = None
     is_dirty: bool = field(init=False, default=False)
 
     def token_callback(self, batch: Batch, _: Dict[str, Any]) -> None:

--- a/nxdrive/options.py
+++ b/nxdrive/options.py
@@ -288,8 +288,8 @@ class MetaOptions(type):
             "https://community.nuxeo.com/static/drive-updates",
             "default",
         ),
-        "use_sentry": (True, "default"),
         "use_analytics": (False, "default"),
+        "use_sentry": (True, "default"),
     }
 
     # Add dynamic options from Features

--- a/nxdrive/options.py
+++ b/nxdrive/options.py
@@ -289,6 +289,7 @@ class MetaOptions(type):
             "default",
         ),
         "use_analytics": (False, "default"),
+        "use_idempotent_requests": (False, "default"),
         "use_sentry": (True, "default"),
     }
 

--- a/tests/old_functional/test_synchronization.py
+++ b/tests/old_functional/test_synchronization.py
@@ -2,7 +2,7 @@ import time
 from pathlib import Path
 from unittest.mock import patch
 
-from nuxeo.exceptions import HTTPError, Unauthorized
+from nuxeo.exceptions import Conflict, HTTPError, Unauthorized
 from requests import ConnectionError
 
 from nxdrive.constants import ROOT, WINDOWS
@@ -746,7 +746,7 @@ class TestSynchronization(OneUserTest):
 
         # Simulate a server conflict on file upload
         bad_remote = self.get_bad_remote()
-        error = HTTPError(status=409, message="Mock Conflict")
+        error = Conflict(message="Mock Conflict")
         bad_remote.make_upload_raise(error)
         bad_remote.raise_on = _raise_for_second_file_only
 

--- a/tests/unit/test_engine_dao.py
+++ b/tests/unit/test_engine_dao.py
@@ -438,3 +438,15 @@ def test_migration_db_v18(engine_dao):
             if row[0].startswith("/SYNC"):
                 assert "\\" not in row[0]
                 assert "\\" not in row[1]
+
+
+def test_migration_db_v20(engine_dao):
+    """Verify Uploads.request_uid presence after v20 migration."""
+    with engine_dao("engine_migration_16.db") as dao:
+        dao._get_read_connection().row_factory = None
+        c = dao._get_read_connection().cursor()
+        rows = c.execute("SELECT request_uid FROM Uploads").fetchall()
+        assert rows
+        for row in rows:
+            # The request_uid default value is None
+            assert not row[0]


### PR DESCRIPTION
Introduced a new option, disabled by default, to enable idempotent requests: `use_idempotent_requests`.
