### PR TITLE
NXDRIVE-2597: Use a LRU cache for translation strings

### DIFF
--- a/docs/changes/5.1.1.md
+++ b/docs/changes/5.1.1.md
@@ -13,6 +13,7 @@ Release date: `2021-xx-xx`
 - [NXDRIVE-2588](https://jira.nuxeo.com/browse/NXDRIVE-2588): Handle `parent_remotely_deleted` state in the local watcher
 - [NXDRIVE-2589](https://jira.nuxeo.com/browse/NXDRIVE-2589): Lower logging level of installer integrity check failure
 - [NXDRIVE-2590](https://jira.nuxeo.com/browse/NXDRIVE-2590): Restart upload on still outdated refreshed AWS credentials
+- [NXDRIVE-2597](https://jira.nuxeo.com/browse/NXDRIVE-2597): Use a LRU cache for translation strings
 
 ### Direct Edit
 

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -46,7 +46,7 @@ def test_load_file():
     assert Translator.get("CONNECTION_REFUSED") == "Connection refused"
 
 
-def test_non_iniialized():
+def test_non_initialized():
     Translator.singleton = None
     with pytest.raises(RuntimeError):
         Translator.get("TEST")


### PR DESCRIPTION
Also aligned `values` kwarg of `Translator.get()` on `Translator.get_translation()`.

Co-authored-by: Romain Grasland <rgrasland@nuxeo.com>