### PR TITLE
NXDRIVE-2595: Restart transfer from the ground when resuming with an …

### DIFF
--- a/docs/changes/5.1.1.md
+++ b/docs/changes/5.1.1.md
@@ -13,6 +13,7 @@ Release date: `2021-xx-xx`
 - [NXDRIVE-2588](https://jira.nuxeo.com/browse/NXDRIVE-2588): Handle `parent_remotely_deleted` state in the local watcher
 - [NXDRIVE-2589](https://jira.nuxeo.com/browse/NXDRIVE-2589): Lower logging level of installer integrity check failure
 - [NXDRIVE-2590](https://jira.nuxeo.com/browse/NXDRIVE-2590): Restart upload on still outdated refreshed AWS credentials
+- [NXDRIVE-2595](https://jira.nuxeo.com/browse/NXDRIVE-2595): Restart transfer from the ground when resuming with an invalid batch ID
 - [NXDRIVE-2597](https://jira.nuxeo.com/browse/NXDRIVE-2597): Use a LRU cache for translation strings
 
 ### Direct Edit


### PR DESCRIPTION
The situation was badly fixed with NXDRIVE-2183. As the batchId is used in the upload process to craft AWS credentials
and to store chunks in the transient store, there is no way an ongoing upload could use a different batchId than the initial one.
Thus such uploads are now completely restarted from the ground.

To prevent such issue, transient store TTLs must be set to higher values, see https://doc.nuxeo.com/nxdoc/transient-store/#configuration.