### PR TITLE
NXDRIVE-2620: Ignore RuntimeError: wrapped C/C++ object of type Linki…

### DIFF
--- a/docs/changes/5.1.2.md
+++ b/docs/changes/5.1.2.md
@@ -13,6 +13,7 @@ Release date: `2021-xx-xx`
 - [NXDRIVE-2610](https://jira.nuxeo.com/browse/NXDRIVE-2610): Remove the `TRACE` logging level, obsolete since 4.1.0
 - [NXDRIVE-2617](https://jira.nuxeo.com/browse/NXDRIVE-2617): Move to `cryptography` module for cryptography stuff
 - [NXDRIVE-2619](https://jira.nuxeo.com/browse/NXDRIVE-2619): Remove `Engine` databases on failed account addition
+- [NXDRIVE-2620](https://jira.nuxeo.com/browse/NXDRIVE-2620): Ignore `RuntimeError: wrapped C/C++ object of type LinkingAction has been deleted` in `Action.finish()`
 
 ### Direct Edit
 

--- a/nxdrive/engine/activity.py
+++ b/nxdrive/engine/activity.py
@@ -159,7 +159,12 @@ class FileAction(Action):
 
     def finish(self) -> None:
         super().finish()
-        self.done.emit(self)
+        try:
+            self.done.emit(self)
+        except RuntimeError:
+            # RuntimeError: wrapped C/C++ object of type LinkingAction has been deleted
+            # Happens on Windows when running old functional tests
+            pass
 
     def export(self) -> Dict[str, Any]:
         return {


### PR DESCRIPTION
…ngAction has been deleted in Action.finish()

Co-authored-by: Romain Grasland <rgrasland@nuxeo.com>