### PR TITLE
NXDRIVE-2623: Ignore RuntimeError: wrapped C/C++ object of type Queue…

### DIFF
--- a/docs/changes/5.1.2.md
+++ b/docs/changes/5.1.2.md
@@ -15,6 +15,7 @@ Release date: `2021-xx-xx`
 - [NXDRIVE-2619](https://jira.nuxeo.com/browse/NXDRIVE-2619): Remove `Engine` databases on failed account addition
 - [NXDRIVE-2620](https://jira.nuxeo.com/browse/NXDRIVE-2620): Ignore `RuntimeError: wrapped C/C++ object of type LinkingAction has been deleted` in `Action.finish()`
 - [NXDRIVE-2622](https://jira.nuxeo.com/browse/NXDRIVE-2622): Fix parsing of paths in local configuration file
+- [NXDRIVE-2623](https://jira.nuxeo.com/browse/NXDRIVE-2623): Ignore `RuntimeError: wrapped C/C++ object of type QueueManager has been deleted` in `QueueManager.push_error()`
 
 ### Direct Edit
 

--- a/nxdrive/engine/queue_manager.py
+++ b/nxdrive/engine/queue_manager.py
@@ -274,7 +274,12 @@ class QueueManager(QObject):
         if emit_sig:
             with self._error_lock:
                 self._on_error_queue[doc_pair.id] = doc_pair
-                self.newError.emit(doc_pair.id)
+                try:
+                    self.newError.emit(doc_pair.id)
+                except RuntimeError:
+                    # RuntimeError: wrapped C/C++ object of type QueueManager has been deleted
+                    # Happens on Windows when running old functional tests
+                    pass
 
     def _get_local_folder(self) -> Optional[DocPair]:
         if self._local_folder_queue.empty():


### PR DESCRIPTION
…Manager has been deleted in QueueManager.push_error()

Co-authored-by: Mickaël Schoentgen <mschoentgen@nuxeo.com>