### PR TITLE
NXDRIVE-2636: Handle HTTP 405 (Method Not Allowed) errors

### DIFF
--- a/docs/changes/5.1.2.md
+++ b/docs/changes/5.1.2.md
@@ -21,6 +21,7 @@ Release date: `2021-xx-xx`
 - [NXDRIVE-2630](https://jira.nuxeo.com/browse/NXDRIVE-2630): [Windows] Cannot use UNC paths for the `nxdrive_home` parameter
 - [NXDRIVE-2631](https://jira.nuxeo.com/browse/NXDRIVE-2631): Refetch local configuration on `nxdrive_home` change
 - [NXDRIVE-2633](https://jira.nuxeo.com/browse/NXDRIVE-2633): Do not watch the local folder parent
+- [NXDRIVE-2636](https://jira.nuxeo.com/browse/NXDRIVE-2636): Handle HTTP 405 (Method Not Allowed) errors
 
 ### Direct Edit
 

--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -393,7 +393,7 @@ class Processor(EngineWorker):
                     with suppress(FileNotFoundError):
                         shutil.rmtree(tmp_folder)
                     self._postpone_pair(doc_pair, "Requested Range Not Satisfiable")
-                elif exc.status in (408, 500):
+                elif exc.status in (405, 408, 500):
                     self.increase_error(doc_pair, "SERVER_ERROR", exception=exc)
                 elif exc.status in (502, 503, 504):
                     log.warning("Server is unavailable", exc_info=True)


### PR DESCRIPTION
Co-authored-by: Mickaël Schoentgen <mschoentgen@nuxeo.com>