### PR TITLE
Fix missing colorama requirement on Windows

### DIFF
--- a/tools/deps/requirements-pip.txt
+++ b/tools/deps/requirements-pip.txt
@@ -6,6 +6,10 @@ click==8.0.0 \
     --hash=sha256:e90e62ced43dc8105fb9a26d62f0d9340b5c8db053a814e25d95c19873ae87db \
     --hash=sha256:7d8c289ee437bcb0316820ccee14aefcb056e58d31830ecab8e47eda6540e136
     # via pip-tools
+colorama==0.4.4 ; sys_platform == "win32" \
+    --hash=sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2 \
+    --hash=sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b
+    # via click
 pep517==0.10.0 \
     --hash=sha256:eba39d201ef937584ad3343df3581069085bacc95454c80188291d5b3ac7a249 \
     --hash=sha256:ac59f3f6b9726a49e15a649474539442cf76e0697e39df4869d25e68e880931b


### PR DESCRIPTION
Following adba459d404629908f9349504a188287a3f70e0c.