### PR TITLE
NXDRIVE-2659: [macOS] Handle unsupported command 'nxdrive://trigger-w…

### DIFF
--- a/docs/changes/5.2.2.md
+++ b/docs/changes/5.2.2.md
@@ -8,6 +8,7 @@ Release date: `2021-0x-xx`
 - [NXDRIVE-2654](https://jira.nuxeo.com/browse/NXDRIVE-2654): Remove the `execution.profile` custom metric
 - [NXDRIVE-2656](https://jira.nuxeo.com/browse/NXDRIVE-2656): Improve crash file handling
 - [NXDRIVE-2657](https://jira.nuxeo.com/browse/NXDRIVE-2657): Fix database `is_healthy()` check to ensure to close the connection
+- [NXDRIVE-2659](https://jira.nuxeo.com/browse/NXDRIVE-2659): [macOS] Handle unsupported command `nxdrive://trigger-watch` in protocol handler
 
 ### Direct Edit
 

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -685,6 +685,12 @@ def parse_protocol_url(url_string: str, /) -> Optional[Dict[str, str]]:
     if not url_string.startswith("nxdrive://"):
         return None
 
+    if url_string == "nxdrive://trigger-watch":
+        log.warning(
+            f"Outdated FinderSync extension is running. Skipping {url_string!r}."
+        )
+        return None
+
     # Commands that need a path to work with
     path_cmds = ("access-online", "copy-share-link", "direct-transfer", "edit-metadata")
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -646,6 +646,12 @@ def test_parse_protocol_url_cmd_unknown():
         nxdrive.utils.parse_protocol_url(url)
 
 
+def test_parse_protocol_url_cmd_outdated():
+    """Parse an outdated command, it must not fail."""
+    url = "nxdrive://trigger-watch"
+    assert not nxdrive.utils.parse_protocol_url(url)
+
+
 def test_parse_protocol_url_edit():
     """It will also test parse_edit_protocol()."""
     url = (


### PR DESCRIPTION
…atch' in protocol handler

Co-authored-by: Mickaël Schoentgen <mschoentgen@nuxeo.com>