### PR TITLE
NXDRIVE-2661: Set a higher logging level for Options changes

### DIFF
--- a/docs/changes/5.2.2.md
+++ b/docs/changes/5.2.2.md
@@ -9,6 +9,7 @@ Release date: `2021-0x-xx`
 - [NXDRIVE-2656](https://jira.nuxeo.com/browse/NXDRIVE-2656): Improve crash file handling
 - [NXDRIVE-2657](https://jira.nuxeo.com/browse/NXDRIVE-2657): Fix database `is_healthy()` check to ensure to close the connection
 - [NXDRIVE-2659](https://jira.nuxeo.com/browse/NXDRIVE-2659): [macOS] Handle unsupported command `nxdrive://trigger-watch` in protocol handler
+- [NXDRIVE-2661](https://jira.nuxeo.com/browse/NXDRIVE-2661): Set a higher logging level for `Options` changes
 
 ### Direct Edit
 

--- a/nxdrive/options.py
+++ b/nxdrive/options.py
@@ -469,7 +469,7 @@ class MetaOptions(type):
 
         MetaOptions.options[item] = new_value, setter
         log.info(f"Option {item!r} updated: {old_value!r} -> {new_value!r} [{setter}]")
-        log.debug(str(Options))
+        log.info(str(Options))
 
         # Callback for that option
         callback = MetaOptions.callbacks.get(item)


### PR DESCRIPTION
To ease debugging, `Options` changes are now logged at `INFO` level.