### PR TITLE
NXDRIVE-2321: Fix file name escaping when checking for document exist…

### DIFF
--- a/docs/changes/5.2.2.md
+++ b/docs/changes/5.2.2.md
@@ -20,7 +20,7 @@ Release date: `2021-0x-xx`
 
 ### Direct Transfer
 
-- [NXDRIVE-2](https://jira.nuxeo.com/browse/NXDRIVE-2):
+- [NXDRIVE-2321](https://jira.nuxeo.com/browse/NXDRIVE-2321): Fix file name escaping when checking for document existence on the server
 
 ## GUI
 
@@ -52,6 +52,7 @@ Release date: `2021-0x-xx`
 - Added `LocalClientMixin.can_use_trash()`
 - Chanded `Engine.use_trash()`: it is no more a static method
 - Removed `Options.exec_profile`
+- Added `Remote.escape()`
 - Added utils.py::`path_is_unc_name()`
 - Removed metrics/constants.py::`EXEC_PROFILE`
 - Added dao/adapters.py

--- a/nxdrive/client/uploader/__init__.py
+++ b/nxdrive/client/uploader/__init__.py
@@ -186,7 +186,7 @@ class BaseUploader:
         # Step 0: tweak the blob
         blob = FileBlob(str(file_path))
         if filename:
-            blob.name = filename
+            blob.name = self.remote.escape(filename)
 
         # Step 0.5: retrieve or instantiate a new transfer
         transfer = self._get_transfer(file_path, blob, command, **kwargs)

--- a/tests/functional/test_remote_client.py
+++ b/tests/functional/test_remote_client.py
@@ -30,3 +30,20 @@ def test_personal_space(manager_factory, tmp, nuxeo_url, user_factory, username)
 
         folder = engine.remote.personal_space()
         assert isinstance(folder, Document)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "My \r file",
+        "ndt-bob@bar.com",
+        "ndt-éléonor",
+        "ndt-東京スカイツリー",
+    ],
+)
+def test_exists_in_parent(name, manager_factory):
+    manager, engine = manager_factory()
+    with manager:
+        method = engine.remote.exists_in_parent
+        assert not method("/", name, False)
+        assert not method("/", name, True)

--- a/tests/old_functional/__init__.py
+++ b/tests/old_functional/__init__.py
@@ -214,7 +214,7 @@ class RemoteBase(Remote):
         return self.execute(command="Document.GetChildren", input_obj=f"doc:{ref}")
 
     def get_children_info(self, ref: str) -> List[NuxeoDocumentInfo]:
-        ref = self._escape(self.check_ref(ref))
+        ref = self.escape(self.check_ref(ref))
         types = "', '".join(
             ("Note", "Workspace", "Picture", env.DOCTYPE_FILE, env.DOCTYPE_FOLDERISH)
         )


### PR DESCRIPTION
…ence on the server

The patch prevents NXQL errors to happen again when a filename contains a carriage return character.

But it will not really prevent creating duplicates because the check will be done on the local filename and a similar document would unlikely have a carriage return in its own `dc:title`. So the request is valid but the check is useless for such names.
For instance, at the time writing those lines, a document named `My \r file.patch` will be saved as `r file.patch` when using the `FileManager.Import` operation.

I am not sure how to handle those documents, and if we want to add complexity for such a corner-case.