### PR TITLE
NXDRIVE-2681: [Direct Edit] Handle HTTP 502 (Bad Gateway), 503 (Servi…

### DIFF
--- a/docs/changes/5.2.2.md
+++ b/docs/changes/5.2.2.md
@@ -19,6 +19,7 @@ Release date: `2021-0x-xx`
 ### Direct Edit
 
 - [NXDRIVE-2658](https://jira.nuxeo.com/browse/NXDRIVE-2658): Handle invalid data returned by the server when retrieving file infos
+- [NXDRIVE-2681](https://jira.nuxeo.com/browse/NXDRIVE-2681): Handle HTTP 502 (Bad Gateway), 503 (Service Unavailable) and 504 (Gateway Time-out) errors during unlock
 
 ### Direct Transfer
 

--- a/nxdrive/direct_edit.py
+++ b/nxdrive/direct_edit.py
@@ -756,6 +756,15 @@ class DirectEdit(Worker):
                     exc_info=True,
                 )
                 errors.append(item)
+            except HTTPError as exc:
+                if exc.status not in (502, 503, 504):
+                    raise
+                # Try again in 30s
+                log.warning(
+                    f"Server error while trying to {action} document {ref!r}",
+                    exc_info=True,
+                )
+                errors.append(item)
             except Exception:
                 log.exception(f"Cannot {action} document {ref!r}")
                 self.directEditLockError.emit(action, ref.name, uid)

--- a/tests/old_functional/test_direct_edit.py
+++ b/tests/old_functional/test_direct_edit.py
@@ -527,7 +527,7 @@ class MixinTests(DirectEditSetup):
         ), ensure_no_exception():
             self.direct_edit._handle_lock_queue()
 
-        # The unlock queue should not be empty after now
+        # The unlock queue should not be empty as the file is in error
         assert not self.direct_edit._lock_queue.empty()
 
         # Ensure there zere no handled exception

--- a/tests/old_functional/test_direct_edit.py
+++ b/tests/old_functional/test_direct_edit.py
@@ -504,6 +504,42 @@ class MixinTests(DirectEditSetup):
         # Ensure there zere no handled exception
         assert not any(log.levelno >= ERROR for log in self._caplog.records)
 
+    def test_unlock_in_lock_queue_error_503(self):
+        filename = "file.txt"
+        doc_id = self.remote.make_file_with_blob("/", filename, b"Initial content.")
+        local_path = Path(f"{doc_id}_file-content/{filename}")
+
+        def unlock(*args, **kwargs):
+            msg = "(Mock'ed) <html><body><b>Http/1.1 Service Unavailable</b></body> </html>"
+            raise HTTPError(status=503, message=msg)
+
+        self.direct_edit._prepare_edit(self.nuxeo_url, doc_id)
+
+        # Ensure that lock queue is filled with an lock item
+        assert self.direct_edit._lock_queue.empty()
+        self.direct_edit._lock_queue.put((local_path, "unlock"))
+        assert not self.direct_edit._lock_queue.empty()
+
+        with patch.object(
+            self.manager_1, "open_local_file", new=open_local_file
+        ), patch.object(
+            self.engine_1.remote, "unlock", new=unlock
+        ), ensure_no_exception():
+            self.direct_edit._handle_lock_queue()
+
+        # The unlock queue should not be empty after now
+        assert not self.direct_edit._lock_queue.empty()
+
+        # Ensure there zere no handled exception
+        assert not any(log.levelno >= ERROR for log in self._caplog.records)
+
+        # Retry the unlock
+        with ensure_no_exception():
+            self.direct_edit._handle_lock_queue()
+
+        # The unlock queue should be empty after now
+        assert self.direct_edit._lock_queue.empty()
+
     def test_direct_edit_version(self):
         from nuxeo.models import BufferBlob
 


### PR DESCRIPTION
…ce Unavailable) and 504 (Gateway Time-out) errors during unlock

Co-authored-by: Romain Grasland <rgrasland@nuxeo.com>