### PR TITLE
NXDRIVE-2684: [macOS] Fix opened documents retrieval not interating-safe

### DIFF
--- a/docs/changes/5.2.2.md
+++ b/docs/changes/5.2.2.md
@@ -17,6 +17,7 @@ Release date: `2021-0x-xx`
 - [NXDRIVE-2676](https://jira.nuxeo.com/browse/NXDRIVE-2676): Do not retry to send asynchronous metrics on error
 - [NXDRIVE-2682](https://jira.nuxeo.com/browse/NXDRIVE-2682): Fix mypy issues following the update to mypy 0.901
 - [NXDRIVE-2683](https://jira.nuxeo.com/browse/NXDRIVE-2683): Ignore incomplete custom protocol URL token requests
+- [NXDRIVE-2684](https://jira.nuxeo.com/browse/NXDRIVE-2684): [macOS] Fix opened documents retrieval not interating-safe
 
 ### Direct Edit
 

--- a/nxdrive/osi/darwin/files.py
+++ b/nxdrive/osi/darwin/files.py
@@ -48,7 +48,7 @@ def _get_opened_files_adobe_cc(identifier: str, /) -> Iterator[Item]:
 
     try:
         documents = list(app.documents())
-    except AttributeError:
+    except (AttributeError, IndexError):
         return
     if not documents:
         return


### PR DESCRIPTION
Co-authored-by: Romain Grasland <rgrasland@nuxeo.com>