### PR TITLE
NXDRIVE-2700: Prevent 'Comparison between bytes and string' warning

### DIFF
--- a/docs/changes/5.2.2.md
+++ b/docs/changes/5.2.2.md
@@ -23,6 +23,7 @@ Release date: `2021-0x-xx`
 - [NXDRIVE-2686](https://jira.nuxeo.com/browse/NXDRIVE-2686): Fix backward compatibility checks handling the synchronization feature
 - [NXDRIVE-2687](https://jira.nuxeo.com/browse/NXDRIVE-2687): Fix new errors found by codespell 2.1.0
 - [NXDRIVE-2698](https://jira.nuxeo.com/browse/NXDRIVE-2698): Specify the UFT-8 encoding when reading/writing text files
+- [NXDRIVE-2700](https://jira.nuxeo.com/browse/NXDRIVE-2700): Prevent `Comparison between bytes and string` warning
 
 ### Direct Edit
 

--- a/nxdrive/engine/engine.py
+++ b/nxdrive/engine/engine.py
@@ -945,7 +945,7 @@ class Engine(QObject):
             return
         stored_token = json.dumps(token) if isinstance(token, dict) else token
         key = f"{self.remote_user}{self.server_url}"
-        secure_token = encrypt(stored_token, key)
+        secure_token = force_decode(encrypt(stored_token, key))
         self.dao.update_config("remote_token", secure_token)
 
     def _load_configuration(self) -> None:


### PR DESCRIPTION
Co-authored-by: Mickaël Schoentgen <mschoentgen@nuxeo.com>