### PR TITLE
NXDRIVE-2704: Do not send metrics on postponed actions

### DIFF
--- a/nxdrive/engine/processor.py
+++ b/nxdrive/engine/processor.py
@@ -767,7 +767,6 @@ class Processor(EngineWorker):
         self.engine.queue_manager.push_error(
             doc_pair, exception=exception, interval=interval
         )
-        self.engine.send_metric("sync", "error", reason)
 
     def _synchronize_locally_resolved(self, doc_pair: DocPair, /) -> None:
         """NXDRIVE-766: processes a locally resolved conflict."""

--- a/nxdrive/engine/queue_manager.py
+++ b/nxdrive/engine/queue_manager.py
@@ -271,15 +271,17 @@ class QueueManager(QObject):
         doc_pair.error_next_try = interval + int(time.time())
 
         log.info(f"Temporary ignore pair for {interval}s: {doc_pair!r}")
-        if emit_sig:
-            with self._error_lock:
-                self._on_error_queue[doc_pair.id] = doc_pair
-                try:
-                    self.newError.emit(doc_pair.id)
-                except RuntimeError:
-                    # RuntimeError: wrapped C/C++ object of type QueueManager has been deleted
-                    # Happens on Windows when running old functional tests
-                    pass
+        if not emit_sig:
+            return
+
+        with self._error_lock:
+            self._on_error_queue[doc_pair.id] = doc_pair
+            try:
+                self.newError.emit(doc_pair.id)
+            except RuntimeError:
+                # RuntimeError: wrapped C/C++ object of type QueueManager has been deleted
+                # Happens on Windows when running old functional tests
+                pass
 
     def _get_local_folder(self) -> Optional[DocPair]:
         if self._local_folder_queue.empty():


### PR DESCRIPTION
Also minor refactoring of `QueueManager.push_error()`.