### PR TITLE
NXDRIVE-2714: Can't start on macOS when the OS locale is english

### DIFF
--- a/docs/changes/5.2.3.md
+++ b/docs/changes/5.2.3.md
@@ -9,6 +9,7 @@ Release date: `2021-xx-xx`
 - [NXDRIVE-2708](https://jira.nuxeo.com/browse/NXDRIVE-2708): Handle removed folder when dequeuing local folder scan
 - [NXDRIVE-2709](https://jira.nuxeo.com/browse/NXDRIVE-2709): Handle unauthorized error when adding the top-level sync root
 - [NXDRIVE-2710](https://jira.nuxeo.com/browse/NXDRIVE-2710): Fix fatal error when guessing the copy-share link of a unsynced document
+- [NXDRIVE-2714](https://jira.nuxeo.com/browse/NXDRIVE-2714): Can't start on macOS when the OS locale is english
 
 ### Direct Edit
 

--- a/nxdrive/__main__.py
+++ b/nxdrive/__main__.py
@@ -41,7 +41,11 @@ def main() -> int:
             raise RuntimeError(f"{APP_NAME} requires Python 3.9.1+")
 
         # NXDRIVE-2230: Ensure the OS locale will be respected through the application
-        locale.setlocale(locale.LC_TIME, "")
+        try:
+            locale.setlocale(locale.LC_TIME, "")
+        except locale.Error as exc:
+            # NXDRIVE-2714: Not a big deal, let's not make the app crashing
+            print('[ERROR] locale.setlocale(locale.LC_TIME, ""):', exc)
 
         if not (check_executable_path() and check_os_version()):
             return 1


### PR DESCRIPTION
The issue is probably more global as I was able to reproduce on Linux until the version 4.2.0.
I did not tested older versions but they should fail too.