### PR TITLE
NXDRIVE-2694: Review handling of sync roots

### DIFF
--- a/docs/changes/5.2.5.md
+++ b/docs/changes/5.2.5.md
@@ -4,6 +4,7 @@ Release date: `2021-xx-xx`
 
 ## Core
 
+- [NXDRIVE-2694](https://jira.nuxeo.com/browse/NXDRIVE-2694): Review handling of sync roots
 - [NXDRIVE-2703](https://jira.nuxeo.com/browse/NXDRIVE-2703): Forward proxy settings to the OAuth2 subclient
 - [NXDRIVE-2721](https://jira.nuxeo.com/browse/NXDRIVE-2721): [Windows] Correctly handle `WinError` 32
 
@@ -38,4 +39,8 @@ Release date: `2021-xx-xx`
 
 ## Technical Changes
 
+- Added `Options.sync_root_max_level`
+- Added `Remote.expand_sync_root_name()`
+- Added `Remote.is_sync_root()`
 - Added utils.py::`find_suitable_direct_edit_dir()`
+- Added utils.py::`shortify()`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -520,6 +520,35 @@ Launch the synchronization and then exit the application.
 
 * * *
 
+#### `sync-root-max-level`
+
+Fetch up to `N` sync root parents' names to generate the local folder name to prevent duplicates errors when multiple sync roots have the same name.
+Where `N` must be between `0` and `4` (inclusive).
+
+Example with that hierarchy:
+
+- Project A
+    - Project's documents
+        - Specifications
+        - Mockups
+        - Screenshots  <--- sync root enabled
+ - Project B
+    - Project's documents
+        - Specifications
+        - Mockups
+        - Screenshots  <--- sync root enabled
+
+When Drive will synchronize them, it will create those folders:
+
+- Nuxeo Drive
+    - `Project A - Project's documents - Screenshots`
+    - `Project B - Project's documents - Screenshots`
+
+- Default value (int): `2`
+- Version added: 5.2.5
+
+* * *
+
 #### `synchronization-enabled`
 
 Synchronization features are enabled.

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -606,7 +606,7 @@ class Remote(Nuxeo):
         remote_item = RemoteFileInfo.from_dict(fs_item)
 
         # Special handling of sync roots
-        if self.is_sync_root(remote_item.parent_uid):
+        if self.is_sync_root(remote_item):
             remote_item = self.expand_sync_root_name(remote_item)
 
         return remote_item

--- a/nxdrive/client/remote_client.py
+++ b/nxdrive/client/remote_client.py
@@ -1,6 +1,7 @@
 import json
 import os
 import socket
+import unicodedata
 from contextlib import suppress
 from logging import getLogger
 from pathlib import Path
@@ -33,6 +34,7 @@ from ..constants import (
     APP_NAME,
     BATCH_SIZE,
     FILE_BUFFER_SIZE,
+    SYNC_ROOT,
     TIMEOUT,
     TOKEN_PERMISSION,
     TX_TIMEOUT,
@@ -63,6 +65,7 @@ from ..utils import (
     compute_digest,
     get_current_locale,
     lock_path,
+    shortify,
     sizeof_fmt,
     unlock_path,
 )
@@ -554,13 +557,59 @@ class Remote(Nuxeo):
         with suppress(Exception):
             batch.cancel()
 
+    def is_sync_root(self, item: RemoteFileInfo) -> bool:
+        """Return True when the given *item* is a sync root."""
+        return item.parent_uid == SYNC_ROOT[1:]
+
+    def expand_sync_root_name(self, sync_root: RemoteFileInfo) -> RemoteFileInfo:
+        """Given a *sync_root* object, expand its *name* with its parents' names.
+        See NXDRIVE-2694 for details.
+        """
+        glue = " - "
+        level = 0
+        limit = 50 - len(glue)
+        uid = sync_root.uid.split("#")[-1]
+
+        # Be sure the current name is shortened
+        sync_root.name = shortify(sync_root.name, limit=limit)
+
+        myself = True
+        while "can level up":
+            if level >= Options.sync_root_max_level:
+                break
+
+            try:
+                doc = self.documents.get(uid=uid)
+                name = unicodedata.normalize("NFC", doc.properties["dc:title"])
+                uid = doc.parentRef
+            except Exception:
+                break
+
+            if myself:
+                myself = False
+                continue
+
+            # Adapt the sync root name (used to create the local folder)
+            name = shortify(name, limit=limit)
+            sync_root.name = f"{name}{glue}{sync_root.name}"
+            level += 1
+
+        return sync_root
+
     def get_fs_info(
         self, fs_item_id: str, /, *, parent_fs_item_id: str = None
     ) -> RemoteFileInfo:
         fs_item = self.get_fs_item(fs_item_id, parent_fs_item_id=parent_fs_item_id)
         if fs_item is None:
             raise NotFound(f"Could not find {fs_item_id!r} on {self.client.host!r}")
-        return RemoteFileInfo.from_dict(fs_item)
+
+        remote_item = RemoteFileInfo.from_dict(fs_item)
+
+        # Special handling of sync roots
+        if self.is_sync_root(remote_item.parent_uid):
+            remote_item = self.expand_sync_root_name(remote_item)
+
+        return remote_item
 
     def get_filesystem_root_info(self) -> RemoteFileInfo:
         toplevel_folder = self.execute(command="NuxeoDrive.GetTopLevelFolder")

--- a/nxdrive/engine/watcher/remote_watcher.py
+++ b/nxdrive/engine/watcher/remote_watcher.py
@@ -908,6 +908,10 @@ class RemoteWatcher(EngineWorker):
                         # Perform a regular document update on a document
                         # that has been updated, renamed or moved
 
+                        # Keep the sync root name format as expected
+                        if self.engine.remote.is_sync_root(new_info):
+                            self.engine.remote.expand_sync_root_name(new_info)
+
                         if doc_pair.remote_state != "created" and any(
                             (
                                 new_info.digest != doc_pair.remote_digest,

--- a/nxdrive/engine/watcher/remote_watcher.py
+++ b/nxdrive/engine/watcher/remote_watcher.py
@@ -1047,12 +1047,10 @@ class RemoteWatcher(EngineWorker):
         sorted_deleted = sorted(delete_queue, key=attrgetter("local_path"))
         delete_processed: DocPairs = []
         for delete_pair in sorted_deleted:
-            # Mark as deleted
-            skip = False
-            for processed_pair in delete_processed:
-                if processed_pair.local_path in delete_pair.local_path.parents:
-                    skip = True
-                    break
+            skip = any(
+                processed_pair.local_path in delete_pair.local_path.parents
+                for processed_pair in delete_processed
+            )
 
             if skip:
                 continue

--- a/nxdrive/options.py
+++ b/nxdrive/options.py
@@ -271,6 +271,7 @@ class MetaOptions(type):
         "ssl_no_verify": (False, "default"),
         "startup_page": ("drive_login.jsp", "default"),
         "sync_and_quit": (False, "default"),
+        "sync_root_max_level": (2, "default"),
         "synchronization_enabled": (False, "default"),
         "system_wide": (_is_system_wide(), "default"),
         "theme": ("ui5", "default"),
@@ -621,6 +622,12 @@ def validate_tmp_file_limit(value: Union[int, float], /) -> float:
     raise ValueError("Temporary file limit must be above 0")
 
 
+def validate_sync_root_max_level_limits(value: int, /) -> int:
+    if 0 <= value <= 4:
+        return int(value)
+    raise ValueError("'sync_root_max_level' must be between 0 and 4 (inclusive).")
+
+
 def _callback_synchronization_enabled(new_value: bool) -> None:
     log.warning(
         "The option is deprecated since 5.2.0 and will be removed in a future release."
@@ -644,6 +651,7 @@ Options.checkers["chunk_size"] = validate_chunk_size
 Options.checkers["client_version"] = validate_client_version
 Options.checkers["deletion_behavior"] = _validate_deletion_behavior
 Options.checkers["use_sentry"] = validate_use_sentry
+Options.checkers["sync_root_max_level"] = validate_sync_root_max_level_limits
 Options.checkers["tmp_file_limit"] = validate_tmp_file_limit
 Options.checkers["ca_bundle"] = validate_ca_bundle_path
 Options.checkers["cert_file"] = validate_cert_path

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -1021,8 +1021,17 @@ def short_name(name: Union[bytes, str], /) -> str:
     """
     name = force_decode(name)
     if len(name) > 70:
-        name = f"{name[:30]}…{name[-40:]}"
+        name = shortify(name, limit=70)
     return name
+
+
+def shortify(text: str, /, *, limit: int = 50) -> str:
+    """Shorten a given `text` to fit in exactly or less `limit` characters.
+    Ellipsis are included in the middle when the text was altered.
+    """
+    if len(text) > limit:
+        text = f"{text[:limit // 2 - 1]}…{text[-limit // 2:]}"
+    return text
 
 
 class PidLockFile:

--- a/tests/functional/test_remote_client.py
+++ b/tests/functional/test_remote_client.py
@@ -2,7 +2,11 @@ import pytest
 from nuxeo.models import Document
 
 from nxdrive.metrics.constants import GLOBAL_METRICS
+from nxdrive.objects import RemoteFileInfo
 from nxdrive.options import Options
+from nxdrive.utils import shortify
+
+from .. import env
 
 
 @pytest.mark.parametrize(
@@ -72,3 +76,89 @@ def test_custom_metrics_global_headers(manager_factory):
         assert '"feature.direct_edit": 0' in headers[GLOBAL_METRICS]
 
     Options.feature_direct_edit = True
+
+
+@Options.mock()
+@pytest.mark.parametrize("option", list(range(7)))
+def test_expand_sync_root_name_levels(option, manager_factory, obj_factory):
+    manager, engine = manager_factory()
+    remote = engine.remote
+
+    with manager:
+        # Create (sub)folders
+        parent = env.WS_DIR
+        potential_names = []
+        for num in range(option + 1):
+            title = f"folder {num}"
+            potential_names.append(shortify(title))
+            doc = obj_factory(title=title, parent=parent, user=remote.user_id)
+            parent = doc.path
+
+        # *doc* is the latest created folder, craft the awaited object for next steps
+        sync_root = RemoteFileInfo.from_dict(
+            {
+                "id": doc.uid,
+                "name": doc.title,
+                "parentId": doc.parentRef,
+                "path": doc.path,
+                "folderish": True,
+            }
+        )
+
+        # Finally, let's guess its final name
+        Options.sync_root_max_level = option
+        sync_root = remote.expand_sync_root_name(sync_root)
+
+        if option != Options.sync_root_max_level:
+            # Typically the option was outside bounds, here it is "7".
+            # We shrink the posibble folder names to ease code for checking the final
+            # name
+            potential_names = potential_names[option - Options.sync_root_max_level :]
+
+        # Check
+        final_name = " - ".join(potential_names[: Options.sync_root_max_level + 1])
+        assert sync_root.name == final_name
+
+
+@Options.mock()
+@pytest.mark.parametrize("option", list(range(7)))
+def test_expand_sync_root_name_length(option, manager_factory, obj_factory):
+    manager, engine = manager_factory()
+    remote = engine.remote
+
+    with manager:
+        # Create (sub)folders
+        parent = env.WS_DIR
+        potential_names = []
+        for num in range(option + 1):
+            title = "folde" + "r" * 50 + f" {num}"  # > 50 chars
+            potential_names.append(shortify(title, limit=47))
+            doc = obj_factory(title=title, parent=parent, user=remote.user_id)
+            parent = doc.path
+
+        # *doc* is the latest created folder, craft the awaited object for next steps
+        sync_root = RemoteFileInfo.from_dict(
+            {
+                "id": doc.uid,
+                "name": doc.title,
+                "parentId": doc.parentRef,
+                "path": doc.path,
+                "folderish": True,
+            }
+        )
+
+        # Finally, let's guess its final name
+        Options.sync_root_max_level = option
+        sync_root = remote.expand_sync_root_name(sync_root)
+
+        if option != Options.sync_root_max_level:
+            # Typically the option was outside bounds, here it is "7".
+            # We shrink the posibble folder names to ease code for checking the final
+            # name
+            potential_names = potential_names[option - Options.sync_root_max_level :]
+
+        # Check
+        final_name = " - ".join(potential_names[: Options.sync_root_max_level + 1])
+        assert sync_root.name == final_name
+        assert sync_root.name.count("…") == Options.sync_root_max_level or 1
+        assert len(sync_root.name) <= 250

--- a/tests/functional/test_remote_client.py
+++ b/tests/functional/test_remote_client.py
@@ -131,7 +131,7 @@ def test_expand_sync_root_name_length(option, manager_factory, obj_factory):
         parent = env.WS_DIR
         potential_names = []
         for num in range(option + 1):
-            title = "folde" + "r" * 50 + f" {num}"  # > 50 chars
+            title = "folder" + "r" * 50 + f" {num}"  # > 50 chars
             potential_names.append(shortify(title, limit=47))
             doc = obj_factory(title=title, parent=parent, user=remote.user_id)
             parent = doc.path

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -339,8 +339,7 @@ def test_disabled_features(caplog):
         (2, 2),
         (3, 3),
         (4, 4),
-        (5, 5),
-        (6, 2),
+        (5, 2),
     ],
 )
 def test_sync_root_max_level_validator_good(value_set, final_value):

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -327,3 +327,22 @@ def test_disabled_features(caplog):
     record = caplog.records[0]
     assert record.levelname == "WARNING"
     assert record.message == "'feature_auto_update' cannot be changed."
+
+
+@Options.mock()
+@pytest.mark.parametrize(
+    "value_set, final_value",
+    [
+        (-1, 2),
+        (0, 0),
+        (1, 1),
+        (2, 2),
+        (3, 3),
+        (4, 4),
+        (5, 5),
+        (6, 2),
+    ],
+)
+def test_sync_root_max_level_validator_good(value_set, final_value):
+    Options.sync_root_max_level = value_set
+    assert Options.sync_root_max_level == final_value

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1262,3 +1262,19 @@ def test_url_bad_ssl():
 
     with pytest.raises(InvalidSSLCertificate):
         nxdrive.utils.test_url(f"https://{BAD_HOSTNAMES[2]}/nuxeo")
+
+
+@pytest.mark.parametrize(
+    "text, shortened",
+    [
+        ["a" * 49, False],
+        ["a" * 50, False],
+        ["a" * 51, True],
+        ["a" * 52, True],
+    ],
+)
+def test_shortify(text, shortened):
+    new_text = nxdrive.utils.shortify(text)
+    if shortened:
+        assert "…" in new_text
+        assert len(new_text) == 50


### PR DESCRIPTION
Sync roots will be renamed according to their `N` parents' names. `N` defaults to 2 and can be controled through the `sync_root_max_level` option.
The option can get up to 4 levels or hierarchy. Set it to 0 to disable the new behavior.

Sync root names are also always shortened to 47 chars (ellipsis will be included in the middle when it was altered).