### PR TITLE
NXDRIVE-2737: Fix Minimize/maximize issue on Direct Transfer screen

### DIFF
--- a/docs/changes/5.3.0.md
+++ b/docs/changes/5.3.0.md
@@ -16,7 +16,6 @@ Release date: `2021-xx-xx`
 
 ## GUI
 
-- [NXDRIVE-2](https://jira.nuxeo.com/browse/NXDRIVE-2):
 - [NXDRIVE-2737](https://jira.nuxeo.com/browse/NXDRIVE-2737): Fix Minimize/maximize issue on Direct Transfer screen
 
 ## Packaging / Build

--- a/docs/changes/5.3.0.md
+++ b/docs/changes/5.3.0.md
@@ -13,11 +13,11 @@ Release date: `2021-xx-xx`
 ### Direct Transfer
 
 - [NXDRIVE-2](https://jira.nuxeo.com/browse/NXDRIVE-2):
-- [NXDRIVE-2737](https://jira.nuxeo.com/browse/NXDRIVE-2737): Fix Minimize/maximize issue on Direct Transfer screen
 
 ## GUI
 
 - [NXDRIVE-2](https://jira.nuxeo.com/browse/NXDRIVE-2):
+- [NXDRIVE-2737](https://jira.nuxeo.com/browse/NXDRIVE-2737): Fix Minimize/maximize issue on Direct Transfer screen
 
 ## Packaging / Build
 

--- a/docs/changes/5.3.0.md
+++ b/docs/changes/5.3.0.md
@@ -13,6 +13,7 @@ Release date: `2021-xx-xx`
 ### Direct Transfer
 
 - [NXDRIVE-2](https://jira.nuxeo.com/browse/NXDRIVE-2):
+- [NXDRIVE-2737](https://jira.nuxeo.com/browse/NXDRIVE-2737): Fix Minimize/maximize issue on Direct Transfer screen
 
 ## GUI
 

--- a/nxdrive/gui/folders_dialog.py
+++ b/nxdrive/gui/folders_dialog.py
@@ -3,8 +3,6 @@ from logging import getLogger
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
-from PyQt5.QtGui import QKeyEvent
-
 from ..constants import APP_NAME, INVALID_CHARS
 from ..engine.engine import Engine
 from ..options import Options
@@ -19,6 +17,7 @@ from ..qt.imports import (
     QGroupBox,
     QHBoxLayout,
     QIcon,
+    QKeyEvent,
     QLabel,
     QLineEdit,
     QMenu,
@@ -278,6 +277,10 @@ class FoldersDialog(DialogMixin):
         self.tree_view.customContextMenuRequested.connect(self.open_menu)
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
+        """Direct Transfer Handle Esc key on Max state(NXDRIVE-2737).
+        On Esc keypress event, restoring the maximized window to normal state
+        """
+
         # Did the user press the Escape key?
         if event.key() == qt.Key_Escape:
             self.showNormal()

--- a/nxdrive/gui/folders_dialog.py
+++ b/nxdrive/gui/folders_dialog.py
@@ -277,9 +277,7 @@ class FoldersDialog(DialogMixin):
         self.tree_view.customContextMenuRequested.connect(self.open_menu)
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
-        """Direct Transfer Handle Esc key on Max state(NXDRIVE-2737).
-        On Esc keypress event, restoring the maximized window to normal state
-        """
+        """On Esc keypress event, restore the maximized window, see NXDRIVE-2737 for details."""
 
         # Did the user press the Escape key?
         if event.key() == qt.Key_Escape:

--- a/nxdrive/gui/folders_dialog.py
+++ b/nxdrive/gui/folders_dialog.py
@@ -277,7 +277,6 @@ class FoldersDialog(DialogMixin):
         self.tree_view.customContextMenuRequested.connect(self.open_menu)
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
-   
 
         # On user Esc keypress event, restore the maximized window. See NXDRIVE-2737 for details.
         if event.key() == qt.Key_Escape:

--- a/nxdrive/gui/folders_dialog.py
+++ b/nxdrive/gui/folders_dialog.py
@@ -3,6 +3,8 @@ from logging import getLogger
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
+from PyQt5.QtGui import QKeyEvent
+
 from ..constants import APP_NAME, INVALID_CHARS
 from ..engine.engine import Engine
 from ..options import Options
@@ -274,6 +276,13 @@ class FoldersDialog(DialogMixin):
 
         self.tree_view.setContextMenuPolicy(Qt.CustomContextMenu)
         self.tree_view.customContextMenuRequested.connect(self.open_menu)
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:
+        # Did the user press the Escape key?
+        if event.key() == qt.Key_Escape:
+            self.showNormal()
+        else:
+            super().keyPressEvent(event)
 
     @property
     def overall_count(self) -> int:

--- a/nxdrive/gui/folders_dialog.py
+++ b/nxdrive/gui/folders_dialog.py
@@ -277,9 +277,9 @@ class FoldersDialog(DialogMixin):
         self.tree_view.customContextMenuRequested.connect(self.open_menu)
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
-        """On Esc keypress event, restore the maximized window, see NXDRIVE-2737 for details."""
+   
 
-        # Did the user press the Escape key?
+        # On user Esc keypress event, restore the maximized window. See NXDRIVE-2737 for details.
         if event.key() == qt.Key_Escape:
             self.showNormal()
         else:


### PR DESCRIPTION
NXDRIVE-2737 In Direct Transfer, handle Esc key on Max state to restore it to Normal state