### PR TITLE
NXDRIVE-2909: Set container title when defining the Folder type from Document Type Selection using Direct Transfer

### DIFF
--- a/docs/changes/5.5.1.md
+++ b/docs/changes/5.5.1.md
@@ -12,6 +12,7 @@ Release date: `2024-xx-xx`
 
 ### Direct Transfer
 
+- [NXDRIVE-2909](https://jira.nuxeo.com/browse/NXDRIVE-2909): Set container title when defining the Folder type from Document Type Selection using Direct Transfer
 - [NXDRIVE-2915](https://jira.nuxeo.com/browse/NXDRIVE-2915): Translate "Document type" and "container type" labels on Direct Transfer popup
 
 ### Task Management

--- a/nxdrive/client/uploader/direct_transfer.py
+++ b/nxdrive/client/uploader/direct_transfer.py
@@ -90,7 +90,9 @@ class DirectTransferUploader(BaseUploader):
                         "entity-type": "document",
                         "name": doc_pair.local_name,
                         "type": doc_pair.doc_type,
-                        "properties{'dc:title'}": doc_pair.local_name,
+                        "properties": {
+                            "dc:title": doc_pair.local_name,
+                        },
                     }
                     item = self.remote.upload_folder_type(
                         doc_pair.remote_parent_path,


### PR DESCRIPTION
NXDRIVE-2909: Set container title when defining the Folder type from Document Type Selection using Direct Transfer

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhance the Direct Transfer feature by setting the container title when defining the Folder type from Document Type Selection, and update the release notes to document this change.

Enhancements:
- Set the container title when defining the Folder type from Document Type Selection using Direct Transfer.

Documentation:
- Document the change for setting the container title in the Direct Transfer section of the release notes.

<!-- Generated by sourcery-ai[bot]: end summary -->