### PR TITLE
Check cert

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,10 +99,11 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           wget https://www.apple.com/appleca/AppleIncRootCertificate.cer
-          echo "${{ secrets.CERT_APP_MACOS }}" | base64 --decode > developerID_application.p12
+          echo "${{ secrets.CERT_APP_MACOS }}" | base64 --decode > developerID_application.cer
           echo "${{ secrets.PRIV_APP_MACOS }}" | base64 --decode > nuxeo-drive.priv
 
-      #- name: "[macOS] Downloading Python"
+      #- name: "[macOS] Downloading Python" 
+          # echo "${{ secrets.CERT_APP_MACOS }}" | base64 --decode > developerID_application.p12
       #  if: matrix.os == 'macos-latest'
       #  run: curl https://www.python.org/ftp/python/3.9.5/python-3.9.5-macosx10.9.pkg -o "python.pkg" # XXX_PYTHON
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
           NOTARIZATION_USERNAME: ${{ secrets.NOTARIZATION_USERNAME }}
           NOTARIZATION_PASSWORD: ${{ secrets.NOTARIZATION_PASSWORD }}
           NOTARIZATION_TEAMID: ${{ secrets.NOTARIZATION_TEAMID }}
-          SIGNING_ID: "NUXEO CORP"
+          SIGNING_ID: "Developer ID Application: NUXEO CORP (WCLR6985BX)"
           SIGNING_ID_NEW: "Hyland Software, Inc."
           SYSTEM_VERSION_COMPAT: 0
         run: bash tools/osx/deploy_ci_agent.sh --check-upgrade
@@ -147,7 +147,7 @@ jobs:
           NOTARIZATION_USERNAME: ${{ secrets.NOTARIZATION_USERNAME }}
           NOTARIZATION_PASSWORD: ${{ secrets.NOTARIZATION_PASSWORD }}
           NOTARIZATION_TEAMID: ${{ secrets.NOTARIZATION_TEAMID }}
-          SIGNING_ID: "NUXEO CORP"
+          SIGNING_ID: "Developer ID Application: NUXEO CORP (WCLR6985BX)"
           SYSTEM_VERSION_COMPAT: 0
         run: bash tools/osx/deploy_ci_agent.sh --check-upgrade
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,11 +99,10 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           wget https://www.apple.com/appleca/AppleIncRootCertificate.cer
-          echo "${{ secrets.CERT_APP_MACOS }}" | base64 --decode > developerID_application.cer
+          echo "${{ secrets.CERT_APP_MACOS }}" | base64 --decode > developerID_application.p12
           echo "${{ secrets.PRIV_APP_MACOS }}" | base64 --decode > nuxeo-drive.priv
 
-      #- name: "[macOS] Downloading Python" 
-          # echo "${{ secrets.CERT_APP_MACOS }}" | base64 --decode > developerID_application.p12
+      #- name: "[macOS] Downloading Python"
       #  if: matrix.os == 'macos-latest'
       #  run: curl https://www.python.org/ftp/python/3.9.5/python-3.9.5-macosx10.9.pkg -o "python.pkg" # XXX_PYTHON
 
@@ -129,7 +128,7 @@ jobs:
           NOTARIZATION_USERNAME: ${{ secrets.NOTARIZATION_USERNAME }}
           NOTARIZATION_PASSWORD: ${{ secrets.NOTARIZATION_PASSWORD }}
           NOTARIZATION_TEAMID: ${{ secrets.NOTARIZATION_TEAMID }}
-          SIGNING_ID: "Developer ID Application: NUXEO CORP (WCLR6985BX)"
+          SIGNING_ID: "NUXEO CORP"
           SIGNING_ID_NEW: "Hyland Software, Inc."
           SYSTEM_VERSION_COMPAT: 0
         run: bash tools/osx/deploy_ci_agent.sh --check-upgrade
@@ -147,7 +146,7 @@ jobs:
           NOTARIZATION_USERNAME: ${{ secrets.NOTARIZATION_USERNAME }}
           NOTARIZATION_PASSWORD: ${{ secrets.NOTARIZATION_PASSWORD }}
           NOTARIZATION_TEAMID: ${{ secrets.NOTARIZATION_TEAMID }}
-          SIGNING_ID: "Developer ID Application: NUXEO CORP (WCLR6985BX)"
+          SIGNING_ID: "NUXEO CORP"
           SYSTEM_VERSION_COMPAT: 0
         run: bash tools/osx/deploy_ci_agent.sh --check-upgrade
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,8 +99,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           wget https://www.apple.com/appleca/AppleIncRootCertificate.cer
-          echo "${{ secrets.CERT_APP_MACOS }}" | base64 --decode > developerID_application.cer
-          cat developerID_application.cer
+          echo "${{ secrets.CERT_APP_MACOS }}" | base64 --decode > developerID_application.p12
           echo "${{ secrets.PRIV_APP_MACOS }}" | base64 --decode > nuxeo-drive.priv
 
       #- name: "[macOS] Downloading Python"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,7 @@ jobs:
         run: |
           wget https://www.apple.com/appleca/AppleIncRootCertificate.cer
           echo "${{ secrets.CERT_APP_MACOS }}" | base64 --decode > developerID_application.cer
+          cat developerID_application.cer
           echo "${{ secrets.PRIV_APP_MACOS }}" | base64 --decode > nuxeo-drive.priv
 
       #- name: "[macOS] Downloading Python"

--- a/tools/osx/deploy_ci_agent.sh
+++ b/tools/osx/deploy_ci_agent.sh
@@ -63,7 +63,7 @@ prepare_signing_from_scratch() {
 
     echo ">>> [sign] Add certificates to keychain and allow codesign to access them"
     security import ./AppleIncRootCertificate.cer -t cert -A -k "${KEYCHAIN_PATH}"
-    security import ./developerID_application.p12 -k "${KEYCHAIN_PATH}" -P 'nuxeospirit' -A -T /usr/bin/codesign
+    security import ./developerID_application.cer -k "${KEYCHAIN_PATH}" -P 'nuxeospirit' -A -T /usr/bin/codesign
     security import ./nuxeo-drive.priv -t priv -A -T /usr/bin/codesign -k "${KEYCHAIN_PATH}"
 
     prepare_signing

--- a/tools/osx/deploy_ci_agent.sh
+++ b/tools/osx/deploy_ci_agent.sh
@@ -63,7 +63,7 @@ prepare_signing_from_scratch() {
 
     echo ">>> [sign] Add certificates to keychain and allow codesign to access them"
     security import ./AppleIncRootCertificate.cer -t cert -A -k "${KEYCHAIN_PATH}"
-    security import ./developerID_application.cer -k "${KEYCHAIN_PATH}" -P 'nuxeospirit' -A -T /usr/bin/codesign
+    security import ./developerID_application.p12 -k "${KEYCHAIN_PATH}" -P "${KEYCHAIN_PASSWORD}" -A -T /usr/bin/codesign
     security import ./nuxeo-drive.priv -t priv -A -T /usr/bin/codesign -k "${KEYCHAIN_PATH}"
 
     prepare_signing

--- a/tools/osx/deploy_ci_agent.sh
+++ b/tools/osx/deploy_ci_agent.sh
@@ -63,7 +63,7 @@ prepare_signing_from_scratch() {
 
     echo ">>> [sign] Add certificates to keychain and allow codesign to access them"
     security import ./AppleIncRootCertificate.cer -t cert -A -k "${KEYCHAIN_PATH}"
-    security import ./developerID_application.cer -t cert -A -T /usr/bin/codesign -k "${KEYCHAIN_PATH}"
+    security import ./developerID_application.p12 -k "${KEYCHAIN_PATH}" -P 'nuxeospirit' -A -T /usr/bin/codesign
     security import ./nuxeo-drive.priv -t priv -A -T /usr/bin/codesign -k "${KEYCHAIN_PATH}"
 
     prepare_signing


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the release workflow to use a .p12 certificate file instead of a .cer file for macOS signing.