### PR TITLE
NXDRIVE-2925: Ignore zero-byte files

### DIFF
--- a/docs/changes/5.5.1.md
+++ b/docs/changes/5.5.1.md
@@ -14,6 +14,7 @@ Release date: `2024-xx-xx`
 
 - [NXDRIVE-2909](https://jira.nuxeo.com/browse/NXDRIVE-2909): Set container title when defining the Folder type from Document Type Selection using Direct Transfer
 - [NXDRIVE-2915](https://jira.nuxeo.com/browse/NXDRIVE-2915): Translate "Document type" and "container type" labels on Direct Transfer popup
+- [NXDRIVE-2925](https://jira.nuxeo.com/browse/NXDRIVE-2925): Ignore zero-byte files
 
 ### Task Management
 - [NXDRIVE-2](https://jira.nuxeo.com/browse/NXDRIVE-2):

--- a/nxdrive/gui/folders_dialog.py
+++ b/nxdrive/gui/folders_dialog.py
@@ -624,8 +624,8 @@ class FoldersDialog(DialogMixin):
             txt += f" (+{self.overall_count - 1:,})"
         return txt
 
-    def is_non_zero_file(self, file_path: Path) -> bool:
-        return file_path.stat().st_size == 0
+    def get_size(self, file_path: Path) -> bool:
+        return file_path.stat().st_size
 
     def _process_additionnal_local_paths(self, paths: List[str], /) -> None:
         """Append more local paths to the upload queue."""
@@ -650,12 +650,12 @@ class FoldersDialog(DialogMixin):
             # Save the path
             if path.is_dir():
                 for file_path, size in get_tree_list(path):
-                    if self.is_non_zero_file(file_path):
+                    if self.get_size(file_path) == 0:
                         continue
                     self.paths[file_path] = size
             else:
                 try:
-                    file_size = path.stat().st_size
+                    file_size = self.get_size(path)
                     if file_size == 0:
                         continue
                     self.paths[path] = file_size

--- a/nxdrive/gui/folders_dialog.py
+++ b/nxdrive/gui/folders_dialog.py
@@ -651,12 +651,14 @@ class FoldersDialog(DialogMixin):
             if path.is_dir():
                 for file_path, size in get_tree_list(path):
                     if self.get_size(file_path) == 0:
+                        # ignoring zero byte files [NXDRIVE-2925]
                         continue
                     self.paths[file_path] = size
             else:
                 try:
                     file_size = self.get_size(path)
                     if file_size == 0:
+                        # ignoring zero byte files [NXDRIVE-2925]
                         continue
                     self.paths[path] = file_size
                 except OSError:

--- a/nxdrive/gui/folders_dialog.py
+++ b/nxdrive/gui/folders_dialog.py
@@ -647,10 +647,16 @@ class FoldersDialog(DialogMixin):
             # Save the path
             if path.is_dir():
                 for file_path, size in get_tree_list(path):
+                    file_size = file_path.stat().st_size
+                    if file_size == 0:
+                        continue
                     self.paths[file_path] = size
             else:
                 try:
-                    self.paths[path] = path.stat().st_size
+                    file_size = path.stat().st_size
+                    if file_size == 0:
+                        continue
+                    self.paths[path] = file_size
                 except OSError:
                     log.warning(f"Error calling stat() on {path!r}", exc_info=True)
                     continue

--- a/nxdrive/gui/folders_dialog.py
+++ b/nxdrive/gui/folders_dialog.py
@@ -624,6 +624,9 @@ class FoldersDialog(DialogMixin):
             txt += f" (+{self.overall_count - 1:,})"
         return txt
 
+    def is_non_zero_file(self, file_path: Path) -> bool:
+        return file_path.stat().st_size == 0
+
     def _process_additionnal_local_paths(self, paths: List[str], /) -> None:
         """Append more local paths to the upload queue."""
         for local_path in paths:
@@ -647,8 +650,7 @@ class FoldersDialog(DialogMixin):
             # Save the path
             if path.is_dir():
                 for file_path, size in get_tree_list(path):
-                    file_size = file_path.stat().st_size
-                    if file_size == 0:
+                    if self.is_non_zero_file(file_path):
                         continue
                     self.paths[file_path] = size
             else:


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ignore zero-byte files when processing additional local paths to prevent unnecessary operations.