### PR TITLE
NXDROVE-2983: Bump the version number to 5.5.2

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -22,8 +22,8 @@
 - [5.4.0](changes/5.4.0.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.3.2...release-5.4.0))
 - [5.4.1](changes/5.4.1.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.4.0...release-5.4.1))
 - [5.5.0](changes/5.5.0.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.4.1...release-5.5.0))
-- [5.5.1](changes/5.5.0.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.5.0...master))
-- [5.5.2](changes/5.5.0.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.5.0...master))
+- [5.5.1](changes/5.5.1.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.5.0...release-5.5.1))
+- [5.5.2](changes/5.5.0.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.5.1...master))
 
 ## 4.x
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -23,7 +23,7 @@
 - [5.4.1](changes/5.4.1.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.4.0...release-5.4.1))
 - [5.5.0](changes/5.5.0.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.4.1...release-5.5.0))
 - [5.5.1](changes/5.5.1.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.5.0...release-5.5.1))
-- [5.5.2](changes/5.5.0.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.5.1...master))
+- [5.5.2](changes/5.5.2.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.5.1...master))
 
 ## 4.x
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -23,6 +23,7 @@
 - [5.4.1](changes/5.4.1.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.4.0...release-5.4.1))
 - [5.5.0](changes/5.5.0.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.4.1...release-5.5.0))
 - [5.5.1](changes/5.5.0.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.5.0...master))
+- [5.5.2](changes/5.5.0.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.5.0...master))
 
 ## 4.x
 

--- a/docs/changes/5.5.2.md
+++ b/docs/changes/5.5.2.md
@@ -1,0 +1,42 @@
+# 5.5.2
+
+Release date: `2024-xx-xx`
+
+## Core
+
+- [NXDRIVE-2](https://jira.nuxeo.com/browse/NXDRIVE-2):
+
+### Direct Edit
+
+- [NXDRIVE-2](https://jira.nuxeo.com/browse/NXDRIVE-2):
+
+### Direct Transfer
+
+- [NXDRIVE-2](https://jira.nuxeo.com/browse/NXDRIVE-2):
+
+### Task Management
+- [NXDRIVE-2](https://jira.nuxeo.com/browse/NXDRIVE-2):
+
+## GUI
+
+- [NXDRIVE-2](https://jira.nuxeo.com/browse/NXDRIVE-2):
+
+## Packaging / Build
+
+- [NXDRIVE-2](https://jira.nuxeo.com/browse/NXDRIVE-2):
+
+## Tests
+
+- [NXDRIVE-2](https://jira.nuxeo.com/browse/NXDRIVE-2):
+
+## Docs
+
+- [NXDRIVE-2](https://jira.nuxeo.com/browse/NXDRIVE-2):
+
+## Minor Changes
+
+-
+
+## Technical Changes
+
+-

--- a/docs/changes/5.5.2.md
+++ b/docs/changes/5.5.2.md
@@ -1,6 +1,6 @@
 # 5.5.2
 
-Release date: `2024-xx-xx`
+Release date: `2025-xx-xx`
 
 ## Core
 

--- a/nxdrive/__init__.py
+++ b/nxdrive/__init__.py
@@ -27,7 +27,7 @@ To declare a beta, use this schema:
 """
 
 __author__ = "Nuxeo"
-__version__ = "5.5.1"
+__version__ = "5.5.2"
 __copyright__ = """
     Copyright © 2024 Hyland Software, Inc. and its affiliates. All rights reserved.
     All Hyland product names are registered or unregistered trademarks of Hyland Software, Inc. or its affiliates


### PR DESCRIPTION
## Summary by Sourcery

Bump the version to 5.5.2 and update the changelog.

Documentation:
- Add a changelog for version 5.5.2.

Chores:
- Update the version number to 5.5.2.