### PR TITLE
NXDRIVE-2992: Fix Drive Release Workflow

### DIFF
--- a/docs/changes/5.5.2.md
+++ b/docs/changes/5.5.2.md
@@ -23,7 +23,7 @@ Release date: `2025-xx-xx`
 
 ## Packaging / Build
 
-- [NXDRIVE-2](https://jira.nuxeo.com/browse/NXDRIVE-2):
+- [NXDRIVE-2992](https://hyland.atlassian.net/browse/NXDRIVE-2992): Fix Drive Release Workflow
 
 ## Tests
 

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -48,7 +48,10 @@ publish() {
     fi
 
     echo ">>> [${release_type} ${drive_version}] Deploying to the server"
-    scp -o "StrictHostKeyChecking=no" tools/versions.py lethe.nuxeo.com:"${artifacts}"
+    rsync -e "ssh -o StrictHostKeyChecking=no" --chmod=755 -pvz tools/versions.py lethe.nuxeo.com:"${path}" || \
+        rsync -e "ssh -o StrictHostKeyChecking=no" -vz tools/versions.py lethe.nuxeo.com:"${path}" || exit 1  # macOS does not have --chmod
+    echo ">>> versions.py copied"
+    # scp -o "StrictHostKeyChecking=no" tools/versions.py lethe.nuxeo.com:"${artifacts}"
     ssh -o "StrictHostKeyChecking=no" -T lethe.nuxeo.com <<EOF
 cd ${artifacts} || exit 1
 


### PR DESCRIPTION
## Summary by Sourcery

Fix the Drive release workflow by replacing `scp` with `rsync` to copy the `versions.py` file to the server and update the release notes with the correct Jira ticket number.

Build:
- Replace `scp` with `rsync` to copy the `versions.py` file to the server.

Documentation:
- Update the release notes with the correct Jira ticket number NXDRIVE-2992.