### PR TITLE
NXDRIVE-3006 : Fix code scanning SSL TLS Version

### DIFF
--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -610,7 +610,7 @@ def retrieve_ssl_certificate(hostname: str, /, *, port: int = 443) -> str:
         # Declaring a minimum version to restrict the protocol
         # For more information check NXDRIVE-2920
         context = ssl.create_default_context()
-        context.minimum_version = getattr(ssl.TLSVersion, MINIMUM_TLS_VERSION)
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
         with context.wrap_socket(conn, server_hostname=hostname) as sock:
             cert_data: bytes = sock.getpeercert(binary_form=True)  # type: ignore
             return ssl.DER_cert_to_PEM_cert(cert_data)


### PR DESCRIPTION
Forces the SSL version to TLS_v2 and above