### PR TITLE
NXDRIVE-3011 : Add test cases

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     hooks:
     - id: black
 - repo: https://github.com/pycqa/flake8
-  rev: 7.1.1
+  rev: 3.9.2
   hooks:
     - id: flake8
       language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     hooks:
     - id: black
 - repo: https://github.com/pycqa/flake8
-  rev: 3.9.2
+  rev: 7.1.1
   hooks:
     - id: flake8
       language_version: python3

--- a/docs/changes/5.5.2.md
+++ b/docs/changes/5.5.2.md
@@ -12,7 +12,7 @@ Release date: `2025-xx-xx`
 
 ### Direct Transfer
 
-- [NXDRIVE-2](https://hyland.atlassian.net/browse/NXDRIVE-2):
+- [NXDRIVE-3011](https://hyland.atlassian.net/browse/NXDRIVE-3011): Add test cases
 
 ### Task Management
 - [NXDRIVE-2](https://hyland.atlassian.net/browse/NXDRIVE-2):

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -536,3 +536,41 @@ def test_get_engine(manager_factory, tmp):
         )
         assert not drive_api.get_remote_document_url("dummy_uid", "remote_ref")
         assert not drive_api.on_clicked_open_task("dummy_uid", "dummy_task_id")
+
+def test_open_server_folders(manager_factory):
+    from .test_direct_transfer_path import Mock_Qt
+
+    from PyQt5.QtCore import QObject
+
+    from nxdrive.gui.application import Application
+
+    manager, engine = manager_factory()
+    mock_qt = Mock_Qt()
+    with patch(
+        "PyQt5.QtQml.QQmlApplicationEngine.rootObjects"
+    ) as mock_root_objects, patch(
+        "PyQt5.QtCore.QObject.findChild"
+    ) as mock_find_child, patch(
+        "nxdrive.gui.application.Application.init_nxdrive_listener"
+    ) as mock_listener, patch(
+        "nxdrive.gui.application.Application.show_metrics_acceptance"
+    ) as mock_show_metrics, patch(
+        "nxdrive.engine.activity.FileAction.__repr__"
+    ) as mock_download_repr, patch(
+        "nxdrive.gui.application.Application.create_custom_window_for_task_manager"
+    ) as mock_task_manager, patch(
+        "nxdrive.gui.api.QMLDriveApi._get_engine"
+    ) as mock_engine, patch(
+        "nxdrive.gui.application.Application.hide_systray"
+    ) as mock_hide:
+        mock_root_objects.return_value = [QObject()]
+        mock_find_child.return_value = mock_qt
+        mock_listener.return_value = None
+        mock_show_metrics.return_value = None
+        mock_download_repr.return_value = "Nuxeo Drive"
+        mock_task_manager.return_value = None
+        app = Application(manager)
+        drive_api = QMLDriveApi(app)
+        mock_engine.return_value = engine
+        mock_hide.return_value = None
+        assert drive_api.open_server_folders("engine.uid") is None

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -8,6 +8,7 @@ from nxdrive.utils import find_resource
 
 from ..markers import mac_only
 
+
 def test_web_authentication(manager_factory, nuxeo_url):
     manager = manager_factory(with_engine=False)
     manager.application = ""

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -537,6 +537,7 @@ def test_get_engine(manager_factory, tmp):
         assert not drive_api.get_remote_document_url("dummy_uid", "remote_ref")
         assert not drive_api.on_clicked_open_task("dummy_uid", "dummy_task_id")
 
+
 def test_open_server_folders(manager_factory):
     from .test_direct_transfer_path import Mock_Qt
 
@@ -574,3 +575,4 @@ def test_open_server_folders(manager_factory):
         mock_engine.return_value = engine
         mock_hide.return_value = None
         assert drive_api.open_server_folders("engine.uid") is None
+

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -575,4 +575,3 @@ def test_open_server_folders(manager_factory):
         mock_engine.return_value = engine
         mock_hide.return_value = None
         assert drive_api.open_server_folders("engine.uid") is None
-

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -6,6 +6,7 @@ from nxdrive.gui.api import QMLDriveApi
 from nxdrive.translator import Translator
 from nxdrive.utils import find_resource
 
+from ..markers import mac_only
 
 def test_web_authentication(manager_factory, nuxeo_url):
     manager = manager_factory(with_engine=False)
@@ -538,6 +539,7 @@ def test_get_engine(manager_factory, tmp):
         assert not drive_api.on_clicked_open_task("dummy_uid", "dummy_task_id")
 
 
+@mac_only
 def test_open_server_folders(manager_factory):
     from .test_direct_transfer_path import Mock_Qt
 
@@ -575,3 +577,4 @@ def test_open_server_folders(manager_factory):
         mock_engine.return_value = engine
         mock_hide.return_value = None
         assert drive_api.open_server_folders("engine.uid") is None
+        app.exit(0)

--- a/tests/functional/test_direct_transfer_path.py
+++ b/tests/functional/test_direct_transfer_path.py
@@ -1,0 +1,122 @@
+"""
+Functional test case written as part of user story : https://hyland.atlassian.net/browse/NXDRIVE-3011
+Covers the changes made for Direct Transfer with workspace path specified from WebUI
+"""
+
+from unittest.mock import patch
+
+from PyQt5 import QtCore
+from PyQt5.QtCore import QObject
+
+from nxdrive.gui.application import Application
+
+from ..markers import mac_only
+
+
+class Mock_Qt:
+    def __init__(self) -> None:
+        self.appUpdate = self
+        self.changed = self
+        self.getLastFiles = self
+        self.setMessage: QtCore.PYQT_SLOT = QtCore.pyqtBoundSignal
+        self.setStatus = self
+        self.updateAvailable: QtCore.PYQT_SLOT = QtCore.pyqtBoundSignal
+        self.updateProgress: QtCore.PYQT_SLOT = QtCore.pyqtBoundSignal
+
+    def addButton(self, *args):
+        pass
+
+    def clickedButton(self):
+        pass
+
+    def close(self):
+        pass
+
+    def connect(self, *args):
+        pass
+
+    def emit(self, *args):
+        pass
+
+    def exec_(self):
+        pass
+
+    def height(self):
+        return 0
+
+    def raise_(self):
+        pass
+
+    def rootContext(self):
+        pass
+
+    def setCheckBox(self, *args):
+        pass
+
+    def setFlags(self, *args):
+        pass
+
+    def setGeometry(self, *args):
+        pass
+
+    def setIconPixmap(self, *args):
+        pass
+
+    def setMinimumHeight(self, *args):
+        pass
+
+    def setMinimumWidth(self, *args):
+        pass
+
+    def setSource(self, *args):
+        pass
+
+    def setText(self, *args):
+        pass
+
+    def setX(self, *args):
+        pass
+
+    def setY(self, *args):
+        pass
+
+    def setWindowTitle(self, *args):
+        pass
+
+    def show(self):
+        pass
+
+    def size(self):
+        return 0
+
+    def width(self):
+        return 0
+
+
+@mac_only
+def test_handle_nxdrive_url(manager_factory):
+    manager, engine = manager_factory()
+    mock_qt = Mock_Qt()
+    with patch(
+        "PyQt5.QtQml.QQmlApplicationEngine.rootObjects"
+    ) as mock_root_objects, patch(
+        "PyQt5.QtCore.QObject.findChild"
+    ) as mock_find_child, patch(
+        "nxdrive.gui.application.Application.init_nxdrive_listener"
+    ) as mock_listener, patch(
+        "nxdrive.gui.application.Application.show_metrics_acceptance"
+    ) as mock_show_metrics, patch(
+        "nxdrive.engine.activity.FileAction.__repr__"
+    ) as mock_download_repr, patch(
+        "nxdrive.gui.application.Application.create_custom_window_for_task_manager"
+    ) as mock_task_manager:
+        mock_root_objects.return_value = [QObject()]
+        mock_find_child.return_value = mock_qt
+        mock_listener.return_value = None
+        mock_show_metrics.return_value = None
+        mock_download_repr.return_value = "Nuxeo Drive"
+        mock_task_manager.return_value = None
+        app = Application(manager)
+        mock_url = "nxdrive://direct-transfer/https/random.com/nuxeo/default-domain/UserWorkspaces"
+        assert app._handle_nxdrive_url(mock_url) is True
+        app.exit(0)

--- a/tests/functional/test_direct_transfer_path.py
+++ b/tests/functional/test_direct_transfer_path.py
@@ -118,5 +118,7 @@ def test_handle_nxdrive_url(manager_factory):
         mock_task_manager.return_value = None
         app = Application(manager)
         mock_url = "nxdrive://direct-transfer/https/random.com/nuxeo/default-domain/UserWorkspaces"
+        mock_url2 = f"nxdrive://direct-transfer{engine.local_folder}"
         assert app._handle_nxdrive_url(mock_url) is True
+        assert app._handle_nxdrive_url(mock_url2) is True
         app.exit(0)


### PR DESCRIPTION
## Summary by Sourcery

Add a functional test for the direct-transfer workspace path handling in the Application class and bump the flake8 hook to v7.1.1 in the pre-commit configuration.

Enhancements:
- Update flake8 pre-commit hook to version 7.1.1

Tests:
- Add functional test for handling direct-transfer NXDRIVE URLs in Application
- Mock Qt environment in test to verify Application._handle_nxdrive_url returns True for valid URLs