### PR TITLE
Potential fix for code scanning alert no. 11: Excessive Secrets Exposure

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -30,8 +30,8 @@ jobs:
 
     env:
       NXDRIVE_TEST_NUXEO_URL: ${{ matrix.lts_environment[0] }}
-      NXDRIVE_TEST_USERNAME: ${{ secrets[matrix.lts_environment[2]] }}
-      NXDRIVE_TEST_PASSWORD: ${{ secrets[matrix.lts_environment[3]] }}
+      NXDRIVE_TEST_USERNAME: ${{ matrix.lts_environment[2] == 'NXDRIVE_TEST_USERNAME' && secrets.NXDRIVE_TEST_USERNAME || matrix.lts_environment[2] == 'NXDRIVE_2023_TEST_USERNAME' && secrets.NXDRIVE_2023_TEST_USERNAME || matrix.lts_environment[2] == 'NXDRIVE_2025_TEST_USERNAME' && secrets.NXDRIVE_2025_TEST_USERNAME }}
+      NXDRIVE_TEST_PASSWORD: ${{ matrix.lts_environment[3] == 'NXDRIVE_TEST_PASSWORD' && secrets.NXDRIVE_TEST_PASSWORD || matrix.lts_environment[3] == 'NXDRIVE_2023_TEST_PASSWORD' && secrets.NXDRIVE_2023_TEST_PASSWORD || matrix.lts_environment[3] == 'NXDRIVE_2025_TEST_PASSWORD' && secrets.NXDRIVE_2025_TEST_PASSWORD }}
 
     name: integration-tests-windows(LTS ${{ matrix.lts_environment[1] }})
 


### PR DESCRIPTION
Potential fix for [https://github.com/nuxeo/nuxeo-drive/security/code-scanning/11](https://github.com/nuxeo/nuxeo-drive/security/code-scanning/11)

To fix the issue, we need to avoid dynamically accessing secrets using `secrets[matrix.lts_environment[3]]`. Instead, we should explicitly define the secrets required for each matrix environment. This can be achieved by restructuring the matrix and using conditional logic to assign the correct secret to the environment variables. This ensures that only the necessary secrets are passed to the workflow runner.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Avoid dynamic secret lookup in the GitHub Actions integration tests workflow by explicitly mapping matrix environments to their corresponding secrets to prevent excessive secrets exposure.

Bug Fixes:
- Fix code scanning alert by preventing dynamic access to secrets in the integration_tests workflow.

CI:
- Replace dynamic secrets access in integration_tests.yml with conditional logic that assigns environment-specific secrets based on the matrix configuration.