### PR TITLE
NXDRIVE-3019: Bump the version number to 5.6.0

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -23,7 +23,7 @@
 - [5.4.1](changes/5.4.1.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.4.0...release-5.4.1))
 - [5.5.0](changes/5.5.0.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.4.1...release-5.5.0))
 - [5.5.1](changes/5.5.1.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.5.0...release-5.5.1))
-- [5.5.2](changes/5.5.2.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.5.1...master))
+- [5.6.0](changes/5.6.0.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.5.1...master))
 
 ## 4.x
 

--- a/docs/changes/5.6.0.md
+++ b/docs/changes/5.6.0.md
@@ -1,4 +1,4 @@
-# 5.5.2
+# 5.6.0
 
 Release date: `2025-xx-xx`
 
@@ -27,6 +27,7 @@ Release date: `2025-xx-xx`
 - [NXDRIVE-2992](https://hyland.atlassian.net/browse/NXDRIVE-2992): Fix Drive Release Workflow
 - [NXDRIVE-2990](https://hyland.atlassian.net/browse/NXDRIVE-2990): Fix Dependabot issue
 - [NXDRIVE-3005](https://hyland.atlassian.net/browse/NXDRIVE-3005): Fix Release workflow for MAC
+- [NXDRIVE-3019](https://hyland.atlassian.net/browse/NXDRIVE-3019): Bump the version number to 5.6.0
 
 ## Tests
 

--- a/nxdrive/__init__.py
+++ b/nxdrive/__init__.py
@@ -27,7 +27,7 @@ To declare a beta, use this schema:
 """
 
 __author__ = "Nuxeo"
-__version__ = "5.5.2"
+__version__ = "5.6.0"
 __copyright__ = """
     Copyright © 2024 Hyland Software, Inc. and its affiliates. All rights reserved.
     All Hyland product names are registered or unregistered trademarks of Hyland Software, Inc. or its affiliates


### PR DESCRIPTION
## Summary by Sourcery

Bump the project version to 5.6.0 and update corresponding release notes and documentation

Enhancements:
- Update application version in code to 5.6.0

Documentation:
- Rename and update change log file from 5.5.2 to 5.6.0
- Add NXDRIVE-3019 entry to the 5.6.0 release notes
- Update the changes index to reference version 5.6.0