### PR TITLE
NXDRIVE-3013: Release Beta 5.6.0

### DIFF
--- a/docs/changes/5.6.0.md
+++ b/docs/changes/5.6.0.md
@@ -9,8 +9,8 @@ Release date: `2025-07-25`
 
 ## Packaging / Build
 
-- [NXDRIVE-2992](https://hyland.atlassian.net/browse/NXDRIVE-2992): Fix Drive Release Workflow
 - [NXDRIVE-2990](https://hyland.atlassian.net/browse/NXDRIVE-2990): Fix Dependabot issue
+- [NXDRIVE-2992](https://hyland.atlassian.net/browse/NXDRIVE-2992): Fix Drive Release Workflow
 - [NXDRIVE-3005](https://hyland.atlassian.net/browse/NXDRIVE-3005): Fix Release workflow for MAC
 - [NXDRIVE-3019](https://hyland.atlassian.net/browse/NXDRIVE-3019): Bump the version number to 5.6.0
 - [NXDRIVE-3020](https://hyland.atlassian.net/browse/NXDRIVE-3020): Update license headers for Nuxeo Drive
@@ -19,8 +19,8 @@ Release date: `2025-07-25`
 
 - [NXDRIVE-2985](https://hyland.atlassian.net/browse/NXDRIVE-2985): Align Nuxeo Drive addon to LTS 2025
 - [NXDRIVE-3011](https://hyland.atlassian.net/browse/NXDRIVE-3011): Add test cases
-- [NXDRIVE-3021](https://hyland.atlassian.net/browse/NXDRIVE-3021): Remove workflows running on LTS-2021
 - [NXDRIVE-3018](https://hyland.atlassian.net/browse/NXDRIVE-3018): Add test cases on already in used socket issue
+- [NXDRIVE-3021](https://hyland.atlassian.net/browse/NXDRIVE-3021): Remove workflows running on LTS-2021
 
 ## Minor Changes
 
@@ -50,9 +50,9 @@ Release date: `2025-07-25`
 ## Security
 
 - [NXDRIVE-2993](https://hyland.atlassian.net/browse/NXDRIVE-2993): Sentry's Python SDK unintentionally exposes environment variables to subprocesses
-- [NXDRIVE-3006](https://hyland.atlassian.net/browse/NXDRIVE-3006): Fix code scanning SSL TLS Version
 - [NXDRIVE-3000](https://hyland.atlassian.net/browse/NXDRIVE-3000): Fix code scanning issues
+- [NXDRIVE-3006](https://hyland.atlassian.net/browse/NXDRIVE-3006): Fix code scanning SSL TLS Version
 - [NXDRIVE-3014](https://hyland.atlassian.net/browse/NXDRIVE-3014): Fix "Requests" vulnerability
-- [NXDRIVE-3016](https://hyland.atlassian.net/browse/NXDRIVE-3016): Fix "setuptools" vulnerability
 - [NXDRIVE-3015](https://hyland.atlassian.net/browse/NXDRIVE-3015): Fix "urllib3" related security issue
+- [NXDRIVE-3016](https://hyland.atlassian.net/browse/NXDRIVE-3016): Fix "setuptools" vulnerability
 - [NXDRIVE-3017](https://hyland.atlassian.net/browse/NXDRIVE-3017): Fix Excessive Secrets Exposure Security issues

--- a/docs/changes/5.6.0.md
+++ b/docs/changes/5.6.0.md
@@ -1,26 +1,11 @@
 # 5.6.0
 
-Release date: `2025-xx-xx`
-
-## Core
-
-- [NXDRIVE-2](https://hyland.atlassian.net/browse/NXDRIVE-2):
-
-### Direct Edit
-
-- [NXDRIVE-2](https://hyland.atlassian.net/browse/NXDRIVE-2):
+Release date: `2025-07-25`
 
 ### Direct Transfer
 
 - [NXDRIVE-3010](https://hyland.atlassian.net/browse/NXDRIVE-3010): Fix New transfer window behavior
 - [NXDRIVE-3011](https://hyland.atlassian.net/browse/NXDRIVE-3011): Add test cases
-
-### Task Management
-- [NXDRIVE-2](https://hyland.atlassian.net/browse/NXDRIVE-2):
-
-## GUI
-
-- [NXDRIVE-2](https://hyland.atlassian.net/browse/NXDRIVE-2):
 
 ## Packaging / Build
 
@@ -36,10 +21,6 @@ Release date: `2025-xx-xx`
 - [NXDRIVE-3011](https://hyland.atlassian.net/browse/NXDRIVE-3011): Add test cases
 - [NXDRIVE-3021](https://hyland.atlassian.net/browse/NXDRIVE-3021): Remove workflows running on LTS-2021
 - [NXDRIVE-3018](https://hyland.atlassian.net/browse/NXDRIVE-3018): Add test cases on already in used socket issue
-
-## Docs
-
-- [NXDRIVE-2](https://hyland.atlassian.net/browse/NXDRIVE-2):
 
 ## Minor Changes
 
@@ -59,7 +40,6 @@ Release date: `2025-xx-xx`
 - Upgraded `urllib3` from 1.26.19 to 2.5.0
 - Upgraded `virtualenv` from 20.29.3 to 20.31.2
 - Upgraded `zipp` from 3.21.0 to 3.23.0
-
 
 ## Technical Changes
 


### PR DESCRIPTION
NXDRIVE-3013: Release Beta 5.6.0

## Summary by Sourcery

Prepare and clean up the changelog for the 5.6.0 Beta release

Documentation:
- Set release date to 2025-07-25 in the 5.6.0 changelog
- Remove empty placeholder sections (Core, GUI, Docs) from the changelog

Chores:
- Finalize changelog structure for Beta 5.6.0 release