### PR TITLE
NXDRIVE-3013: Bump the version number to 5.6.1

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -23,7 +23,8 @@
 - [5.4.1](changes/5.4.1.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.4.0...release-5.4.1))
 - [5.5.0](changes/5.5.0.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.4.1...release-5.5.0))
 - [5.5.1](changes/5.5.1.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.5.0...release-5.5.1))
-- [5.6.0](changes/5.6.0.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.5.1...master))
+- [5.6.0](changes/5.6.0.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.5.1...release-5.6.0))
+- [5.6.1](changes/5.6.1.md) ([diff](https://github.com/nuxeo/nuxeo-drive/compare/release-5.6.0...master))
 
 ## 4.x
 

--- a/docs/changes/5.6.1.md
+++ b/docs/changes/5.6.1.md
@@ -1,0 +1,42 @@
+# 5.6.1
+
+Release date: `2025-xx-xx`
+
+## Core
+
+- [NXDRIVE-2](https://hyland.atlassian.net/browse/NXDRIVE-3):
+
+### Direct Edit
+
+- [NXDRIVE-2](https://hyland.atlassian.net/browse/NXDRIVE-3):
+
+### Direct Transfer
+
+- [NXDRIVE-2](https://hyland.atlassian.net/browse/NXDRIVE-3):
+
+### Task Management
+- [NXDRIVE-2](https://hyland.atlassian.net/browse/NXDRIVE-3):
+
+## GUI
+
+- [NXDRIVE-2](https://hyland.atlassian.net/browse/NXDRIVE-3):
+
+## Packaging / Build
+
+- [NXDRIVE-2](https://hyland.atlassian.net/browse/NXDRIVE-3):
+
+## Tests
+
+- [NXDRIVE-2](https://hyland.atlassian.net/browse/NXDRIVE-3):
+
+## Docs
+
+- [NXDRIVE-2](https://hyland.atlassian.net/browse/NXDRIVE-3):
+
+## Minor Changes
+
+-
+
+## Technical Changes
+
+-

--- a/nxdrive/__init__.py
+++ b/nxdrive/__init__.py
@@ -27,7 +27,7 @@ To declare a beta, use this schema:
 """
 
 __author__ = "Nuxeo"
-__version__ = "5.6.0"
+__version__ = "5.6.1"
 __copyright__ = """
     Copyright © 2025 Hyland Software, Inc. and its affiliates. All rights reserved.
     All Hyland product names are registered or unregistered trademarks of Hyland Software, Inc. or its affiliates


### PR DESCRIPTION
## Summary by Sourcery

Bump the project version to 5.6.1 and update the changelog documentation

Enhancements:
- Increment package version to 5.6.1

Documentation:
- Update docs/changes.md to correct the 5.6.0 diff link and add an entry for 5.6.1
- Add a new placeholder changelog file for version 5.6.1