### PR TITLE
NXDRIVE-3008: Fix translations Crowdin Job

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,6 +1,6 @@
 name: Crowdin
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 on:

--- a/docs/changes/5.6.1.md
+++ b/docs/changes/5.6.1.md
@@ -4,18 +4,18 @@ Release date: `2025-xx-xx`
 
 ## Core
 
-- [NXDRIVE-2](https://hyland.atlassian.net/browse/NXDRIVE-3):
+- [NXDRIVE-3](https://hyland.atlassian.net/browse/NXDRIVE-3):
 
 ### Direct Edit
 
-- [NXDRIVE-2](https://hyland.atlassian.net/browse/NXDRIVE-3):
+- [NXDRIVE-3](https://hyland.atlassian.net/browse/NXDRIVE-3):
 
 ### Direct Transfer
 
-- [NXDRIVE-2](https://hyland.atlassian.net/browse/NXDRIVE-3):
+- [NXDRIVE-3](https://hyland.atlassian.net/browse/NXDRIVE-3):
 
 ### Task Management
-- [NXDRIVE-2](https://hyland.atlassian.net/browse/NXDRIVE-3):
+- [NXDRIVE-3](https://hyland.atlassian.net/browse/NXDRIVE-3):
 
 ## GUI
 
@@ -23,15 +23,15 @@ Release date: `2025-xx-xx`
 
 ## Packaging / Build
 
-- [NXDRIVE-2](https://hyland.atlassian.net/browse/NXDRIVE-3):
+- [NXDRIVE-3008](https://hyland.atlassian.net/browse/NXDRIVE-3008): Fix translations Crowdin Job
 
 ## Tests
 
-- [NXDRIVE-2](https://hyland.atlassian.net/browse/NXDRIVE-3):
+- [NXDRIVE-3](https://hyland.atlassian.net/browse/NXDRIVE-3):
 
 ## Docs
 
-- [NXDRIVE-2](https://hyland.atlassian.net/browse/NXDRIVE-3):
+- [NXDRIVE-3](https://hyland.atlassian.net/browse/NXDRIVE-3):
 
 ## Minor Changes
 

--- a/nxdrive/data/i18n/i18n.json
+++ b/nxdrive/data/i18n/i18n.json
@@ -340,7 +340,7 @@
     "ROOT_USED_WITH_OTHER_BINDING_HEADER": "A folder already in use has been detected.",
     "RUNNING": "Running",
     "RUNNING_FROM_WRONG_PATH": "You are running this app from \"%1\". However, for all features to run normally, the application must be named \"%2\" and located in the \"/$HOME/Applications\" directory.",
-    "SCRIPT_ADDR": "Script Address",
+    "SCRIPT_ADDR": "Script address",
     "SECTION_ABOUT": "About",
     "SECTION_ACCOUNTS": "Accounts",
     "SECTION_ADVANCED": "Advanced",

--- a/nxdrive/data/i18n/i18n.json
+++ b/nxdrive/data/i18n/i18n.json
@@ -340,7 +340,7 @@
     "ROOT_USED_WITH_OTHER_BINDING_HEADER": "A folder already in use has been detected.",
     "RUNNING": "Running",
     "RUNNING_FROM_WRONG_PATH": "You are running this app from \"%1\". However, for all features to run normally, the application must be named \"%2\" and located in the \"/$HOME/Applications\" directory.",
-    "SCRIPT_ADDR": "Script address",
+    "SCRIPT_ADDR": "Script Address",
     "SECTION_ABOUT": "About",
     "SECTION_ACCOUNTS": "Accounts",
     "SECTION_ADVANCED": "Advanced",


### PR DESCRIPTION
## Summary by Sourcery

Fix the Crowdin translation job by granting appropriate write permissions in the CI workflow and updating the release notes with correct ticket references.

CI:
- Grant write permission for contents in the Crowdin GitHub Actions workflow

Documentation:
- Correct changelog entries to reference NXDRIVE-3 and NXDRIVE-3008