### PR TITLE
NXDRIVE-2984 : Build (hdiutil) is failing while using HFS+ filesystem in macos 13

### DIFF
--- a/tools/osx/deploy_ci_agent.sh
+++ b/tools/osx/deploy_ci_agent.sh
@@ -161,8 +161,9 @@ create_package() {
             -srcfolder "${src_folder_tmp}" \
             -volname "${app_name}"         \
             -fs HFS+                       \
+            -fsargs "-c c=8,a=8,e=8"       \
             -format UDRW                   \
-            -size "${dmg_size}m"           \
+            -size 500           \
             "${dmg_tmp}"
 
     # -size "${dmg_size}m"           \


### PR DESCRIPTION
NXDRIVE-2984 : Build (hdiutil) is failing while using HFS+ filesystem in macos 13

## Summary by Sourcery

Bug Fixes:
- Fix DMG creation failure on HFS+ filesystem in macOS 13 by specifying HFS+ FS type, custom block arguments, and using the configured DMG size