### PR TITLE
NXDRIVE-3054: Fix integration tests workflow

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -31,12 +31,12 @@ jobs:
     name: integration-tests-windows(LTS 2023)
 
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.13 # XXX_PYTHON
-          architecture: "x86"
+      # - uses: actions/checkout@v4
+      # - name: Set up Python
+      #   uses: actions/setup-python@v5
+      #   with:
+      #     python-version: 3.13 # XXX_PYTHON
+      #     architecture: "x86"
       - uses: actions/cache@v4
         with:
           path: ~\AppData\Local\pip\Cache
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.13 # XXX_PYTHON
+          python-version: "3.13.1" # XXX_PYTHON
           architecture: "x86"
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -31,12 +31,12 @@ jobs:
     name: integration-tests-windows(LTS 2023)
 
     steps:
-      # - uses: actions/checkout@v4
-      # - name: Set up Python
-      #   uses: actions/setup-python@v5
-      #   with:
-      #     python-version: 3.13 # XXX_PYTHON
-      #     architecture: "x86"
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13.1" # XXX_PYTHON
+          architecture: "x86"
       - uses: actions/cache@v4
         with:
           path: ~\AppData\Local\pip\Cache

--- a/docs/changes/5.6.1.md
+++ b/docs/changes/5.6.1.md
@@ -27,6 +27,7 @@ Release date: `2025-xx-xx`
 - [NXDRIVE-1750](https://hyland.atlassian.net/browse/NXDRIVE-1750): Code sign the AppImage
 - [NXDRIVE-3008](https://hyland.atlassian.net/browse/NXDRIVE-3008): Fix translations Crowdin Job
 - [NXDRIVE-3051](https://hyland.atlassian.net/browse/NXDRIVE-3051): Fix Windows release workflow in github
+- [NXDRIVE-3054](https://hyland.atlassian.net/browse/NXDRIVE-3054): Fix integration tests workflow
 
 ## Tests
 

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -1429,6 +1429,7 @@ def find_real_libreoffice_file(lock_path: str) -> tuple[str, str]:
     Given a LibreOffice/OpenOffice lock file (e.g. '.~lock.Report.odt#'),
     return the real filename (e.g. 'Report.odt').
     """
+    # test
     folder = os.path.dirname(lock_path)
     lock_filename = os.path.basename(lock_path)
     real_filename = lock_filename[len(".~lock.") : -1]

--- a/tools/windows/deploy_ci_agent.ps1
+++ b/tools/windows/deploy_ci_agent.ps1
@@ -388,21 +388,17 @@ function install_python {
 		Include_tools=0 `
 		" `
 		-wait
-	Write-Output ">>> Installed Python $Env:PYTHON_DRIVE_VERSION into $Env:PYTHON_DIR"
 
 	# Fix a bloody issue ... !
 	New-Item -Path $Env:STORAGE_DIR -Name Scripts -ItemType directory -Verbose
-	# Copy-Item $Env:PYTHON_DIR\vcruntime140.dll $Env:STORAGE_DIR\Scripts -Verbose
 
 	$vcDllFromPythonDir = Join-Path $Env:PYTHON_DIR "vcruntime140.dll"
 	$vcDllFromPythonLocation = Join-Path $Env:PythonLocation "vcruntime140.dll"
 
 	if (Test-Path $vcDllFromPythonDir) {
-		Write-Output ">>> Found vcruntime140.dll in PYTHON_DIR"
 		Copy-Item $vcDllFromPythonDir "$Env:STORAGE_DIR\Scripts" -Verbose
 	}
 	elseif (Test-Path $vcDllFromPythonLocation) {
-		Write-Output ">>> Found vcruntime140.dll in PythonLocation"
 		Copy-Item $vcDllFromPythonLocation "$Env:STORAGE_DIR\Scripts" -Verbose
 	}
 	else {
@@ -421,7 +417,7 @@ function install_python {
 		& $exePathPythonLocation $global:PYTHON_OPT -OO -m venv --copies "$Env:STORAGE_DIR"
 	}
 	else {
-		Write-Warning ">>> unable to execute"
+		Write-Warning ">>> unable to create venv"
 	}
 	
 	if ($lastExitCode -ne 0) {

--- a/tools/windows/deploy_ci_agent.ps1
+++ b/tools/windows/deploy_ci_agent.ps1
@@ -398,7 +398,8 @@ function install_python {
 	elseif (Test-Path $Env:PythonLocation) {
 		$vcDllFromPythonLocation = Join-Path $Env:PythonLocation "vcruntime140.dll"
 	}
-
+	Write-Output ">>> PYTHON_DIR: $Env:PYTHON_DIR"
+	Write-Output ">>> PythonLocation: $Env:PythonLocation"
 	Write-Output ">>> vcDllFromPythonDir: $vcDllFromPythonDir"
 
 	if (Test-Path $vcDllFromPythonDir) {

--- a/tools/windows/deploy_ci_agent.ps1
+++ b/tools/windows/deploy_ci_agent.ps1
@@ -372,6 +372,12 @@ function install_python {
 	$output = "$Env:WORKSPACE\$filename"
 	download $url $output
 
+	if (Test-Path $output){
+		Write-Output ">>>> present $output"
+	} else {
+		Write-Output ">>>> absent $output"
+	}
+
 	Write-Output ">>> Installing Python $Env:PYTHON_DRIVE_VERSION into $Env:PYTHON_DIR"
 	# https://docs.python.org/3.7/using/windows.html#installing-without-ui
 	Start-Process $output -argumentlist "`

--- a/tools/windows/deploy_ci_agent.ps1
+++ b/tools/windows/deploy_ci_agent.ps1
@@ -425,6 +425,9 @@ function install_python {
 
 	if (Test-Path $vcDllFromPythonDir) {
 		Write-Output ">>> Found vcruntime140.dll in PYTHON_DIR"
+		Get-ChildItem -Path $Env:PYTHON_DIR | ForEach-Object {
+			Write-Output ">>>> name: $($_.Name)"
+		}
 		Copy-Item $vcDllFromPythonDir "$Env:STORAGE_DIR\Scripts" -Verbose
 	}
 	elseif (Test-Path $vcDllFromPythonLocation) {

--- a/tools/windows/deploy_ci_agent.ps1
+++ b/tools/windows/deploy_ci_agent.ps1
@@ -426,7 +426,7 @@ function install_python {
 	if (Test-Path $vcDllFromPythonDir) {
 		Write-Output ">>> Found vcruntime140.dll in PYTHON_DIR"
 		Get-ChildItem -Path $Env:PYTHON_DIR | ForEach-Object {
-			Write-Output ">>>> name: $($_.Name)"
+			Write-Output ">>>> name: $($_ .Name)"
 		}
 		Copy-Item $vcDllFromPythonDir "$Env:STORAGE_DIR\Scripts" -Verbose
 	}

--- a/tools/windows/deploy_ci_agent.ps1
+++ b/tools/windows/deploy_ci_agent.ps1
@@ -395,9 +395,11 @@ function install_python {
 	$vcDllFromPythonDir = ""
 
 	if (Test-Path $Env:PYTHON_DIR) {
+		Write-Output ">>> PYTHON_DIR exists"
 		$vcDllFromPythonDir = Join-Path $Env:PYTHON_DIR "vcruntime140.dll"
 	}
 	elseif (Test-Path $Env:PythonLocation) {
+		Write-Output ">>> PythonLocation exists"
 		$vcDllFromPythonLocation = Join-Path $Env:PythonLocation "vcruntime140.dll"
 	}
 	Write-Output ">>> PYTHON_DIR: $Env:PYTHON_DIR"

--- a/tools/windows/deploy_ci_agent.ps1
+++ b/tools/windows/deploy_ci_agent.ps1
@@ -373,9 +373,9 @@ function install_python {
 	download $url $output
 
 	if (Test-Path $output){
-		Write-Output ">>>> present output"
+		Write-Output ">>>> present $output"
 	} else {
-		Write-Output ">>>> absent output"
+		Write-Output ">>>> absent $output"
 	}
 
 	Write-Output ">>> Installing Python $Env:PYTHON_DRIVE_VERSION into $Env:PYTHON_DIR"
@@ -394,6 +394,7 @@ function install_python {
 		Include_tools=0 `
 		" `
 		-wait
+	Write-Output ">>> Installed Python $Env:PYTHON_DRIVE_VERSION into $Env:PYTHON_DIR"
 
 
 	if (Test-Path $Env:PYTHON_DIR) {

--- a/tools/windows/deploy_ci_agent.ps1
+++ b/tools/windows/deploy_ci_agent.ps1
@@ -425,6 +425,7 @@ function install_python {
 
 	if (Test-Path $vcDllFromPythonDir) {
 		Write-Output ">>> Found vcruntime140.dll in PYTHON_DIR"
+		dir
 		Get-ChildItem -Path $Env:PYTHON_DIR | ForEach-Object {
 			Write-Output ">>>> name: $($_.Name)"
 		}

--- a/tools/windows/deploy_ci_agent.ps1
+++ b/tools/windows/deploy_ci_agent.ps1
@@ -425,12 +425,6 @@ function install_python {
 
 	if (Test-Path $vcDllFromPythonDir) {
 		Write-Output ">>> Found vcruntime140.dll in PYTHON_DIR"
-		dir
-		Get-ChildItem -Path $Env:PYTHON_DIR | ForEach-Object {
-			Write-Output ">>>> name: $($_.Name)"
-		}
-		Copy-Item $vcDllFromPythonDir "$Env:STORAGE_DIR\Scripts" -Verbose
-	}
 	elseif (Test-Path $vcDllFromPythonLocation) {
 		Write-Output ">>> Found vcruntime140.dll in PythonLocation"
 		Copy-Item $vcDllFromPythonLocation "$Env:STORAGE_DIR\Scripts" -Verbose
@@ -442,7 +436,9 @@ function install_python {
 
 	Write-Output ">>> Setting-up the Python virtual environment"
 
-	& $Env:PYTHON_DIR\python.exe $global:PYTHON_OPT -OO -m venv --copies "$Env:STORAGE_DIR"
+	$exePath = Join-Path $Env:PYTHON_DIR "python.exe"
+
+	& $exePath $global:PYTHON_OPT -OO -m venv --copies "$Env:STORAGE_DIR"
 	if ($lastExitCode -ne 0) {
 		ExitWithCode $lastExitCode
 	}

--- a/tools/windows/deploy_ci_agent.ps1
+++ b/tools/windows/deploy_ci_agent.ps1
@@ -389,9 +389,40 @@ function install_python {
 		" `
 		-wait
 
+
+	if (Test-Path $Env:PYTHON_DIR) {
+        Write-Output ">>> PYTHON_DIR exists at: $Env:PYTHON_DIR"
+        Write-Output ">>> Contents of PYTHON_DIR:"
+        Get-ChildItem -Path $Env:PYTHON_DIR | ForEach-Object {
+            if ($_.PSIsContainer) {
+                Write-Output "  [DIR]  $($_.Name)"
+            } else {
+                Write-Output "  [FILE] $($_.Name)"
+            }
+        }
+    } else {
+        Write-Output ">>> PYTHON_DIR does not exist at: $Env:PYTHON_DIR"
+    }
+
 	# Fix a bloody issue ... !
 	New-Item -Path $Env:STORAGE_DIR -Name Scripts -ItemType directory -Verbose
-	Copy-Item $Env:PYTHON_DIR\vcruntime140.dll $Env:STORAGE_DIR\Scripts -Verbose
+	# Copy-Item $Env:PYTHON_DIR\vcruntime140.dll $Env:STORAGE_DIR\Scripts -Verbose
+
+	$vcDllFromPythonDir = Join-Path $Env:PYTHON_DIR "vcruntime140.dll"
+	$vcDllFromPythonLocation = Join-Path $Env:PythonLocation "vcruntime140.dll"
+
+	if (Test-Path $vcDllFromPythonDir) {
+		Write-Output ">>> Found vcruntime140.dll in PYTHON_DIR"
+		Copy-Item $vcDllFromPythonDir "$Env:STORAGE_DIR\Scripts" -Verbose
+	}
+	elseif (Test-Path $vcDllFromPythonLocation) {
+		Write-Output ">>> Found vcruntime140.dll in PythonLocation"
+		Copy-Item $vcDllFromPythonLocation "$Env:STORAGE_DIR\Scripts" -Verbose
+	}
+	else {
+		Write-Warning ">>> vcruntime140.dll not found in either PYTHON_DIR or PythonLocation!"
+	}
+
 
 	Write-Output ">>> Setting-up the Python virtual environment"
 

--- a/tools/windows/deploy_ci_agent.ps1
+++ b/tools/windows/deploy_ci_agent.ps1
@@ -399,6 +399,8 @@ function install_python {
 		$vcDllFromPythonLocation = Join-Path $Env:PythonLocation "vcruntime140.dll"
 	}
 
+	Write-Output ">>> vcDllFromPythonDir: $vcDllFromPythonDir"
+
 	if (Test-Path $vcDllFromPythonDir) {
 		Copy-Item $vcDllFromPythonDir "$Env:STORAGE_DIR\Scripts" -Verbose
 	}
@@ -413,7 +415,7 @@ function install_python {
 
 	$exePathPYTHON_DIR = Join-Path $Env:PYTHON_DIR "python.exe"
 	$exePathPythonLocation = Join-Path $Env:PythonLocation "python.exe"
-	
+
 	if (Test-Path $exePathPYTHON_DIR) {
 		& $exePathPYTHON_DIR $global:PYTHON_OPT -OO -m venv --copies "$Env:STORAGE_DIR"
 	}
@@ -423,7 +425,7 @@ function install_python {
 	else {
 		Write-Warning ">>> unable to create venv"
 	}
-	
+
 	if ($lastExitCode -ne 0) {
 		ExitWithCode $lastExitCode
 	}

--- a/tools/windows/deploy_ci_agent.ps1
+++ b/tools/windows/deploy_ci_agent.ps1
@@ -402,19 +402,19 @@ function install_python {
 	Write-Output ">>> Installed Python $Env:PYTHON_DRIVE_VERSION into $Env:PYTHON_DIR"
 
 
-	if (Test-Path $Env:PYTHON_DIR) {
-        Write-Output ">>> PYTHON_DIR exists at: $Env:PYTHON_DIR"
-        Write-Output ">>> Contents of PYTHON_DIR:"
-        Get-ChildItem -Path $Env:PYTHON_DIR | ForEach-Object {
-            if ($_.PSIsContainer) {
-                Write-Output "  [DIR]  $($_.Name)"
-            } else {
-                Write-Output "  [FILE] $($_.Name)"
-            }
-        }
-    } else {
-        Write-Output ">>> PYTHON_DIR does not exist at: $Env:PYTHON_DIR"
-    }
+	# if (Test-Path $Env:PYTHON_DIR) {
+    #     Write-Output ">>> PYTHON_DIR exists at: $Env:PYTHON_DIR"
+    #     Write-Output ">>> Contents of PYTHON_DIR:"
+    #     Get-ChildItem -Path $Env:PYTHON_DIR | ForEach-Object {
+    #         if ($_.PSIsContainer) {
+    #             Write-Output "  [DIR]  $($_.Name)"
+    #         } else {
+    #             Write-Output "  [FILE] $($_.Name)"
+    #         }
+    #     }
+    # } else {
+    #     Write-Output ">>> PYTHON_DIR does not exist at: $Env:PYTHON_DIR"
+    # }
 
 	# Fix a bloody issue ... !
 	New-Item -Path $Env:STORAGE_DIR -Name Scripts -ItemType directory -Verbose
@@ -425,6 +425,7 @@ function install_python {
 
 	if (Test-Path $vcDllFromPythonDir) {
 		Write-Output ">>> Found vcruntime140.dll in PYTHON_DIR"
+	}
 	elseif (Test-Path $vcDllFromPythonLocation) {
 		Write-Output ">>> Found vcruntime140.dll in PythonLocation"
 		Copy-Item $vcDllFromPythonLocation "$Env:STORAGE_DIR\Scripts" -Verbose

--- a/tools/windows/deploy_ci_agent.ps1
+++ b/tools/windows/deploy_ci_agent.ps1
@@ -392,21 +392,8 @@ function install_python {
 	# Fix a bloody issue ... !
 	New-Item -Path $Env:STORAGE_DIR -Name Scripts -ItemType directory -Verbose
 
-	$vcDllFromPythonDir = ""
-	$vcDllFromPythonLocation = ""
-
-	if (Test-Path $Env:PYTHON_DIR) {
-		Write-Output ">>> PYTHON_DIR exists"
-		$vcDllFromPythonDir = Join-Path $Env:PYTHON_DIR "vcruntime140.dll"
-	}
-	elseif (Test-Path $Env:PythonLocation) {
-		Write-Output ">>> PythonLocation exists"
-		$vcDllFromPythonLocation = Join-Path $Env:PythonLocation "vcruntime140.dll"
-		Write-Output ">>> vcDllFromPythonLocation: $vcDllFromPythonLocation"
-	}
-	Write-Output ">>> PYTHON_DIR: $Env:PYTHON_DIR"
-	Write-Output ">>> PythonLocation: $Env:PythonLocation"
-	Write-Output ">>> vcDllFromPythonDir: $vcDllFromPythonDir"
+	$vcDllFromPythonDir = Join-Path $Env:PYTHON_DIR "vcruntime140.dll"
+	$vcDllFromPythonLocation = Join-Path $Env:PythonLocation "vcruntime140.dll"
 
 	if (Test-Path $vcDllFromPythonDir) {
 		Copy-Item $vcDllFromPythonDir "$Env:STORAGE_DIR\Scripts" -Verbose

--- a/tools/windows/deploy_ci_agent.ps1
+++ b/tools/windows/deploy_ci_agent.ps1
@@ -393,6 +393,7 @@ function install_python {
 	New-Item -Path $Env:STORAGE_DIR -Name Scripts -ItemType directory -Verbose
 
 	$vcDllFromPythonDir = ""
+	$vcDllFromPythonLocation = ""
 
 	if (Test-Path $Env:PYTHON_DIR) {
 		Write-Output ">>> PYTHON_DIR exists"
@@ -401,6 +402,7 @@ function install_python {
 	elseif (Test-Path $Env:PythonLocation) {
 		Write-Output ">>> PythonLocation exists"
 		$vcDllFromPythonLocation = Join-Path $Env:PythonLocation "vcruntime140.dll"
+		Write-Output ">>> vcDllFromPythonLocation: $vcDllFromPythonLocation"
 	}
 	Write-Output ">>> PYTHON_DIR: $Env:PYTHON_DIR"
 	Write-Output ">>> PythonLocation: $Env:PythonLocation"

--- a/tools/windows/deploy_ci_agent.ps1
+++ b/tools/windows/deploy_ci_agent.ps1
@@ -212,14 +212,19 @@ function check_vars {
 		$Env:PYTHON_DRIVE_VERSION = '3.13.1'  # XXX_PYTHON
 	}
 	if (-Not ($Env:WORKSPACE)) {
+		Write-Output ">>>> not workspace"
 		if ($Env:GITHUB_WORKSPACE) {
+			Write-Output ">>>> GITHUB_WORKSPACE $Env:GITHUB_WORKSPACE"
 			# Running from GitHub Actions
 			$Env:WORKSPACE = (Get-Item $Env:GITHUB_WORKSPACE).parent.FullName
+			Write-Output ">>>> new workspace $Env:WORKSPACE"
 		}
 		else {
 			Write-Output ">>> WORKSPACE not defined. Aborting."
 			ExitWithCode 1
 		}
+	} else {
+		Write-Output ">>>> workspace $Env:WORKSPACE"
 	}
 	if (-Not ($Env:WORKSPACE_DRIVE)) {
 		if (Test-Path "$($Env:WORKSPACE)\sources") {

--- a/tools/windows/deploy_ci_agent.ps1
+++ b/tools/windows/deploy_ci_agent.ps1
@@ -426,7 +426,7 @@ function install_python {
 	if (Test-Path $vcDllFromPythonDir) {
 		Write-Output ">>> Found vcruntime140.dll in PYTHON_DIR"
 		Get-ChildItem -Path $Env:PYTHON_DIR | ForEach-Object {
-			Write-Output ">>>> name: $($_ .Name)"
+			Write-Output ">>>> name: $($_.Name)"
 		}
 		Copy-Item $vcDllFromPythonDir "$Env:STORAGE_DIR\Scripts" -Verbose
 	}

--- a/tools/windows/deploy_ci_agent.ps1
+++ b/tools/windows/deploy_ci_agent.ps1
@@ -392,6 +392,8 @@ function install_python {
 	# Fix a bloody issue ... !
 	New-Item -Path $Env:STORAGE_DIR -Name Scripts -ItemType directory -Verbose
 
+	$vcDllFromPythonDir = ""
+
 	if (Test-Path $Env:PYTHON_DIR) {
 		$vcDllFromPythonDir = Join-Path $Env:PYTHON_DIR "vcruntime140.dll"
 	}

--- a/tools/windows/deploy_ci_agent.ps1
+++ b/tools/windows/deploy_ci_agent.ps1
@@ -373,9 +373,9 @@ function install_python {
 	download $url $output
 
 	if (Test-Path $output){
-		Write-Output ">>>> present $output"
+		Write-Output ">>>> present output"
 	} else {
-		Write-Output ">>>> absent $output"
+		Write-Output ">>>> absent output"
 	}
 
 	Write-Output ">>> Installing Python $Env:PYTHON_DRIVE_VERSION into $Env:PYTHON_DIR"

--- a/tools/windows/deploy_ci_agent.ps1
+++ b/tools/windows/deploy_ci_agent.ps1
@@ -392,8 +392,12 @@ function install_python {
 	# Fix a bloody issue ... !
 	New-Item -Path $Env:STORAGE_DIR -Name Scripts -ItemType directory -Verbose
 
-	$vcDllFromPythonDir = Join-Path $Env:PYTHON_DIR "vcruntime140.dll"
-	$vcDllFromPythonLocation = Join-Path $Env:PythonLocation "vcruntime140.dll"
+	if (Test-Path $Env:PYTHON_DIR) {
+		$vcDllFromPythonDir = Join-Path $Env:PYTHON_DIR "vcruntime140.dll"
+	}
+	elseif (Test-Path $Env:PythonLocation) {
+		$vcDllFromPythonLocation = Join-Path $Env:PythonLocation "vcruntime140.dll"
+	}
 
 	if (Test-Path $vcDllFromPythonDir) {
 		Copy-Item $vcDllFromPythonDir "$Env:STORAGE_DIR\Scripts" -Verbose

--- a/tools/windows/deploy_ci_agent.ps1
+++ b/tools/windows/deploy_ci_agent.ps1
@@ -212,19 +212,14 @@ function check_vars {
 		$Env:PYTHON_DRIVE_VERSION = '3.13.1'  # XXX_PYTHON
 	}
 	if (-Not ($Env:WORKSPACE)) {
-		Write-Output ">>>> not workspace"
 		if ($Env:GITHUB_WORKSPACE) {
-			Write-Output ">>>> GITHUB_WORKSPACE $Env:GITHUB_WORKSPACE"
 			# Running from GitHub Actions
 			$Env:WORKSPACE = (Get-Item $Env:GITHUB_WORKSPACE).parent.FullName
-			Write-Output ">>>> new workspace $Env:WORKSPACE"
 		}
 		else {
 			Write-Output ">>> WORKSPACE not defined. Aborting."
 			ExitWithCode 1
 		}
-	} else {
-		Write-Output ">>>> workspace $Env:WORKSPACE"
 	}
 	if (-Not ($Env:WORKSPACE_DRIVE)) {
 		if (Test-Path "$($Env:WORKSPACE)\sources") {

--- a/tools/windows/deploy_ci_agent.ps1
+++ b/tools/windows/deploy_ci_agent.ps1
@@ -377,12 +377,6 @@ function install_python {
 	$output = "$Env:WORKSPACE\$filename"
 	download $url $output
 
-	if (Test-Path $output){
-		Write-Output ">>>> present $output"
-	} else {
-		Write-Output ">>>> absent $output"
-	}
-
 	Write-Output ">>> Installing Python $Env:PYTHON_DRIVE_VERSION into $Env:PYTHON_DIR"
 	# https://docs.python.org/3.7/using/windows.html#installing-without-ui
 	Start-Process $output -argumentlist "`
@@ -401,21 +395,6 @@ function install_python {
 		-wait
 	Write-Output ">>> Installed Python $Env:PYTHON_DRIVE_VERSION into $Env:PYTHON_DIR"
 
-
-	# if (Test-Path $Env:PYTHON_DIR) {
-    #     Write-Output ">>> PYTHON_DIR exists at: $Env:PYTHON_DIR"
-    #     Write-Output ">>> Contents of PYTHON_DIR:"
-    #     Get-ChildItem -Path $Env:PYTHON_DIR | ForEach-Object {
-    #         if ($_.PSIsContainer) {
-    #             Write-Output "  [DIR]  $($_.Name)"
-    #         } else {
-    #             Write-Output "  [FILE] $($_.Name)"
-    #         }
-    #     }
-    # } else {
-    #     Write-Output ">>> PYTHON_DIR does not exist at: $Env:PYTHON_DIR"
-    # }
-
 	# Fix a bloody issue ... !
 	New-Item -Path $Env:STORAGE_DIR -Name Scripts -ItemType directory -Verbose
 	# Copy-Item $Env:PYTHON_DIR\vcruntime140.dll $Env:STORAGE_DIR\Scripts -Verbose
@@ -425,6 +404,7 @@ function install_python {
 
 	if (Test-Path $vcDllFromPythonDir) {
 		Write-Output ">>> Found vcruntime140.dll in PYTHON_DIR"
+		Copy-Item $vcDllFromPythonDir "$Env:STORAGE_DIR\Scripts" -Verbose
 	}
 	elseif (Test-Path $vcDllFromPythonLocation) {
 		Write-Output ">>> Found vcruntime140.dll in PythonLocation"
@@ -434,19 +414,16 @@ function install_python {
 		Write-Warning ">>> vcruntime140.dll not found in either PYTHON_DIR or PythonLocation!"
 	}
 
-
 	Write-Output ">>> Setting-up the Python virtual environment"
 
-
-
-	$exePath1 = Join-Path $Env:PYTHON_DIR "python.exe"
-	$exePath2 = Join-Path $Env:PythonLocation "python.exe"
+	$exePathPYTHON_DIR = Join-Path $Env:PYTHON_DIR "python.exe"
+	$exePathPythonLocation = Join-Path $Env:PythonLocation "python.exe"
 	
-	if (Test-Path $exePath1) {
-		& $exePath1 $global:PYTHON_OPT -OO -m venv --copies "$Env:STORAGE_DIR"
+	if (Test-Path $exePathPYTHON_DIR) {
+		& $exePathPYTHON_DIR $global:PYTHON_OPT -OO -m venv --copies "$Env:STORAGE_DIR"
 	}
-	elseif (Test-Path $exePath2) {
-		& $exePath2 $global:PYTHON_OPT -OO -m venv --copies "$Env:STORAGE_DIR"
+	elseif (Test-Path $exePathPythonLocation) {
+		& $exePathPythonLocation $global:PYTHON_OPT -OO -m venv --copies "$Env:STORAGE_DIR"
 	}
 	else {
 		Write-Warning ">>> unable to execute"

--- a/tools/windows/deploy_ci_agent.ps1
+++ b/tools/windows/deploy_ci_agent.ps1
@@ -437,9 +437,21 @@ function install_python {
 
 	Write-Output ">>> Setting-up the Python virtual environment"
 
-	$exePath = Join-Path $Env:PYTHON_DIR "python.exe"
 
-	& $exePath $global:PYTHON_OPT -OO -m venv --copies "$Env:STORAGE_DIR"
+
+	$exePath1 = Join-Path $Env:PYTHON_DIR "python.exe"
+	$exePath2 = Join-Path $Env:PythonLocation "python.exe"
+	
+	if (Test-Path $exePath1) {
+		& $exePath1 $global:PYTHON_OPT -OO -m venv --copies "$Env:STORAGE_DIR"
+	}
+	elseif (Test-Path $exePath2) {
+		& $exePath2 $global:PYTHON_OPT -OO -m venv --copies "$Env:STORAGE_DIR"
+	}
+	else {
+		Write-Warning ">>> unable to execute"
+	}
+	
 	if ($lastExitCode -ne 0) {
 		ExitWithCode $lastExitCode
 	}


### PR DESCRIPTION
## Summary by Sourcery

Fix the integration tests workflow by disabling redundant checkout and setup-python steps for Windows jobs and bump the Python version to 3.13.1; also include a temporary debug comment in utils.

Bug Fixes:
- Comment out checkout and Python setup steps in the Windows integration test job to restore workflow execution

Enhancements:
- Update integration tests workflow to use Python version 3.13.1

Chores:
- Add a temporary "# test" comment in find_real_libreoffice_file for debugging purposes