### PR TITLE
NXDRIVE-3055: Remove Beta mention on Features tab

### DIFF
--- a/docs/changes/5.6.1.md
+++ b/docs/changes/5.6.1.md
@@ -21,6 +21,7 @@ Release date: `2025-xx-xx`
 ## GUI
 
 - [NXDRIVE-3049](https://hyland.atlassian.net/browse/NXDRIVE-3049): Fix wrong number of arguments in translation files
+- [NXDRIVE-3055](https://hyland.atlassian.net/browse/NXDRIVE-3055): Remove Beta mention on Features tab
 
 ## Packaging / Build
 

--- a/nxdrive/feature.py
+++ b/nxdrive/feature.py
@@ -36,6 +36,6 @@ Feature = SimpleNamespace(
     s3=False,
 )
 
-Beta: List[str] = ["s3"]
+Beta: List[str] = []
 
 DisabledFeatures: List[str] = []


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Remove S3 from the Beta features list to eliminate the Beta mention