### PR TITLE
NXDRIVE-3117:  Direct transfer Web UI icon doesn't work for a target that has spaces in its name

### DIFF
--- a/docs/changes/7.0.0.md
+++ b/docs/changes/7.0.0.md
@@ -12,7 +12,7 @@ Release date: `2026-xx-xx`
 
 ## Direct Transfer
 
-- [NXDRIVE-3](https://hyland.atlassian.net/browse/NXDRIVE-3):
+- [NXDRIVE-3117](https://hyland.atlassian.net/browse/NXDRIVE-3117): Direct transfer Web UI icon doesn't work for a target that has spaces in its name
 
 ## Docs
 

--- a/nxdrive/client/local/__init__.py
+++ b/nxdrive/client/local/__init__.py
@@ -1,4 +1,4 @@
-""" API to access local resources for synchronization. """
+"""API to access local resources for synchronization."""
 
 from .base import FileInfo, get
 

--- a/nxdrive/client/local/base.py
+++ b/nxdrive/client/local/base.py
@@ -1,4 +1,4 @@
-""" API to access local resources for synchronization. """
+"""API to access local resources for synchronization."""
 
 import errno
 import os

--- a/nxdrive/client/local/darwin.py
+++ b/nxdrive/client/local/darwin.py
@@ -1,4 +1,4 @@
-""" API to access local resources for synchronization. """
+"""API to access local resources for synchronization."""
 
 import errno
 import os

--- a/nxdrive/client/local/linux.py
+++ b/nxdrive/client/local/linux.py
@@ -1,4 +1,4 @@
-""" API to access local resources for synchronization. """
+"""API to access local resources for synchronization."""
 
 import errno
 import os

--- a/nxdrive/client/local/windows.py
+++ b/nxdrive/client/local/windows.py
@@ -1,4 +1,4 @@
-""" API to access local resources for synchronization. """
+"""API to access local resources for synchronization."""
 
 import ctypes
 import errno

--- a/nxdrive/commandline.py
+++ b/nxdrive/commandline.py
@@ -1,4 +1,4 @@
-""" Utilities to operate Nuxeo Drive from the command line. """
+"""Utilities to operate Nuxeo Drive from the command line."""
 
 import faulthandler
 import os

--- a/nxdrive/console.py
+++ b/nxdrive/console.py
@@ -1,4 +1,4 @@
-""" Console mode application. """
+"""Console mode application."""
 
 from logging import getLogger
 from typing import TYPE_CHECKING, Any

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -1,4 +1,4 @@
-""" Main Qt application handling OS events and system tray UI. """
+"""Main Qt application handling OS events and system tray UI."""
 
 import os
 import webbrowser

--- a/nxdrive/gui/folders_loader.py
+++ b/nxdrive/gui/folders_loader.py
@@ -63,7 +63,7 @@ class ContentLoaderMixin(QRunnable):
             if item:
                 item.removeRows(0, item.rowCount())
                 item.appendRow(
-                    QStandardItem(Translator.get("LOADING_ERROR") + " \U0001F937")
+                    QStandardItem(Translator.get("LOADING_ERROR") + " \U0001f937")
                 )
             return
 

--- a/nxdrive/logging_config.py
+++ b/nxdrive/logging_config.py
@@ -1,4 +1,4 @@
-""" Utilities to log nxdrive operations and failures. """
+"""Utilities to log nxdrive operations and failures."""
 
 import logging
 import os

--- a/nxdrive/osi/darwin/pyNotificationCenter.py
+++ b/nxdrive/osi/darwin/pyNotificationCenter.py
@@ -1,4 +1,4 @@
-""" Python integration macOS notification center. """
+"""Python integration macOS notification center."""
 
 from typing import TYPE_CHECKING, Dict
 

--- a/nxdrive/updater/__init__.py
+++ b/nxdrive/updater/__init__.py
@@ -1,4 +1,4 @@
-""" Auto-update framework. """
+"""Auto-update framework."""
 
 from logging import getLogger
 from typing import TYPE_CHECKING

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -31,7 +31,7 @@ from typing import (
     Tuple,
     Union,
 )
-from urllib.parse import parse_qsl, urlparse, urlsplit, urlunsplit
+from urllib.parse import parse_qsl, unquote, urlparse, urlsplit, urlunsplit
 from uuid import uuid4
 
 from nuxeo.utils import get_digest_algorithm, get_digest_hash
@@ -922,6 +922,9 @@ def parse_protocol_url(url_string: str, /) -> Optional[Dict[str, str]]:
         "/http/" in url_string or "/https/" in url_string
     ):
         remote_path = re.split("/nuxeo", url_string.strip(), maxsplit=1)[1]
+        # Decode URL-encoded characters (e.g., %20 -> space)
+        # Note: literal %20 in folder names would be encoded as %2520, so this is safe
+        remote_path = unquote(remote_path)
         return {
             "command": cmd,
             "remote_path": remote_path,

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -922,9 +922,10 @@ def parse_protocol_url(url_string: str, /) -> Optional[Dict[str, str]]:
         "/http/" in url_string or "/https/" in url_string
     ):
         remote_path = re.split("/nuxeo", url_string.strip(), maxsplit=1)[1]
-        # Decode URL-encoded characters (e.g., %20 -> space)
+        # On Windows, URL-encoded characters need to be decoded (e.g., %20 -> space)
         # Note: literal %20 in folder names would be encoded as %2520, so this is safe
-        remote_path = unquote(remote_path)
+        if WINDOWS:
+            remote_path = unquote(remote_path)
         return {
             "command": cmd,
             "remote_path": remote_path,

--- a/tests/functional/test_remote_client.py
+++ b/tests/functional/test_remote_client.py
@@ -268,10 +268,8 @@ def test_store_refresh_token(manager_factory):
     manager, engine = manager_factory()
     remote = engine.remote
     remote.token = {
-        "access_token": "D0QCbs1aJJsPDXzT\
-                    1IrC4oKzjbFevn4s",
-        "refresh_token": "Fch4TbOM8okl8sLajlN\
-                        37L8YHKMSfc9cFe7RMVWRG4ctNvBmSvn2SFXg5CtUJKS2",
+        "access_token": "D0QCbs1aJJsPDXzT1IrC4oKzjbFevn4s",
+        "refresh_token": "Fch4TbOM8okl8sLajlN37L8YHKMSfc9cFe7RMVWRG4ctNvBmSvn2SFXg5CtUJKS2",
         "token_type": "bearer",
         "expires_in": 3239,
         "expires_at": 1711427876,
@@ -285,10 +283,8 @@ def test_store_refresh_token(manager_factory):
     assert old_remote_token == remote.token
 
     remote.auth.auth.token = {
-        "access_token": "D0QCbs1aJJsPDXzT\
-                    1IrC4oKzjbFevn4s",
-        "refresh_token": "Fch4TbOM8okl8sLajlP\
-                        37L8YHKMSfc9cFe7RMVWRG4ctNvBmSvn2SFXg5CtUJKS2",
+        "access_token": "D0QCbs1aJJsPDXzT1IrC4oKzjbFevn4s",
+        "refresh_token": "Fch4TbOM8okl8sLajlP37L8YHKMSfc9cFe7RMVWRG4ctNvBmSvn2SFXg5CtUJKS2",
         "token_type": "bearer",
         "expires_in": 3239,
         "expires_at": 1711427876,
@@ -299,10 +295,8 @@ def test_store_refresh_token(manager_factory):
     assert remote.token == remote.auth.auth.token
 
     remote.auth.auth.token = {
-        "access_token": "D0QCbs1aJJsPDXzT\
-                    1IrC4oKzjbFevn4s",
-        "refresh_token": "Fch4TbOM8okl8sLajlP\
-                        37L8YHKMSfc9cFe7RMVWRG4ctNvBmSvn2SFXg5CtUJKS2",
+        "access_token": "D0QCbs1aJJsPDXzT1IrC4oKzjbFevn4s",
+        "refresh_token": "Fch4TbOM8okl8sLajlP37L8YHKMSfc9cFe7RMVWRG4ctNvBmSvn2SFXg5CtUJKS2",
         "token_type": "bearer",
         "expires_in": 3239,
         "expires_at": 1711427876,

--- a/tests/functional/test_remote_watcher.py
+++ b/tests/functional/test_remote_watcher.py
@@ -1029,8 +1029,8 @@ def test_sync_root_name(manager_factory):
 
     docpair = namedtuple(
         "DocPair",
-        "local_path, local_parent_path, remote_ref, local_state, \
-            remote_state, pair_state, last_error, remote_parent_path",
+        "local_path, local_parent_path, remote_ref, local_state, "
+        "remote_state, pair_state, last_error, remote_parent_path",
         defaults=(
             ".",
             ".",
@@ -1048,38 +1048,52 @@ def test_sync_root_name(manager_factory):
     test_watcher = RemoteWatcher(engine, dao)
 
     def get_changes():
-        return eval(
-            '{ "type": "test", "fileSystemChanges": [ { "repositoryId": "default", \
-                "eventId": "securityUpdated", "eventDate": 1681875648592, "docUuid": \
-                    "a7e4ce2a-e4a7-432a-b5e1-62b354606929", "fileSystemItem": {"id": \
-                        "defaultSyncRootFolderItemFactory#default#a7e4ce2a-e4a7-432a-\
-                        b5e1-62b354606929-test", "parentId": "org.nuxeo.drive.service.\
-                            impl.DefaultTopLevelFolderItemFactory#", "name": "ROY", \
-                            "folder": True, "creator": "Administrator", \
-                                "lastContributor": "Administrator", \
-                                    "creationDate": 1681875486061, \
-                                        "lastModificationDate": 1681875528408, \
-                                            "canRename": True, "canDelete": True, \
-                                                "lockInfo": None, "path": "/org.nuxeo.\
-                                                    drive.service.impl.DefaultTopLevelFolder\
-                                                        ItemFactory#/defaultSyncRootFolderItemFactory\
-                                                        #default#a7e4ce2a-e4a7-432a-b5e1-62b354606929-test",\
-                                                         "userName": "Administrator", "canCreateChild": True,\
-                                                              "canScrollDescendants": True }, "fileSystemItemId": \
-                                                                "defaultSyncRootFolderItemFactory#default#a7e4ce2a-\
-                                                                e4a7-432a-b5e1-62b354606929-test", \
-                                                                    "fileSystemItemName": "ROY" } ]\
-                                                                    , "syncDate": 1681875652000, "upp\
-                                                                        erBound": 7834,\
-                                                                          "hasTooManyChanges": True, \
-                                                                            "activeSynchronizationRootDe\
-                                                                            finitions": "default:ffed6ec7-\
-                                                                                b6d3-41a7-ba10-801b7678a5\
-                                                                                84-test,default:a7e4ce2a-e4a7-432a-b5e1-62b35460692\
-                                                                                    9-test,default:db4e8005-c7aa-4f26-937b-23476e85\
-                                                                                        2223-test,default:47176834-992d-4d81-9ce1-a\
-                                                                                            51b7841d648-test" }'
-        )
+        return {
+            "type": "test",
+            "fileSystemChanges": [
+                {
+                    "repositoryId": "default",
+                    "eventId": "securityUpdated",
+                    "eventDate": 1681875648592,
+                    "docUuid": "a7e4ce2a-e4a7-432a-b5e1-62b354606929",
+                    "fileSystemItem": {
+                        "id": "defaultSyncRootFolderItemFactory#default#a7e4ce2a-e4a7-432a-b5e1-62b354606929-test",
+                        "parentId": "org.nuxeo.drive.service.impl.DefaultTopLevelFolderItemFactory#",
+                        "name": "ROY",
+                        "folder": True,
+                        "creator": "Administrator",
+                        "lastContributor": "Administrator",
+                        "creationDate": 1681875486061,
+                        "lastModificationDate": 1681875528408,
+                        "canRename": True,
+                        "canDelete": True,
+                        "lockInfo": None,
+                        "path": (
+                            "/org.nuxeo.drive.service.impl.DefaultTopLevelFolderItemFactory#"
+                            "/defaultSyncRootFolderItemFactory#default"
+                            "#a7e4ce2a-e4a7-432a-b5e1-62b354606929-test"
+                        ),
+                        "userName": "Administrator",
+                        "canCreateChild": True,
+                        "canScrollDescendants": True,
+                    },
+                    "fileSystemItemId": (
+                        "defaultSyncRootFolderItemFactory#default"
+                        "#a7e4ce2a-e4a7-432a-b5e1-62b354606929-test"
+                    ),
+                    "fileSystemItemName": "ROY",
+                }
+            ],
+            "syncDate": 1681875652000,
+            "upperBound": 7834,
+            "hasTooManyChanges": True,
+            "activeSynchronizationRootDefinitions": (
+                "default:ffed6ec7-b6d3-41a7-ba10-801b7678a584-test,"
+                "default:a7e4ce2a-e4a7-432a-b5e1-62b354606929-test,"
+                "default:db4e8005-c7aa-4f26-937b-23476e852223-test,"
+                "default:47176834-992d-4d81-9ce1-a51b7841d648-test"
+            ),
+        }
 
     def init_scan_remote(doc_pair, remote_info):
         return remote_path
@@ -1116,29 +1130,27 @@ def test_sync_root_name(manager_factory):
     assert info is not None
 
     remote_info = RemoteFileInfo.from_dict(
-        eval(
-            '{"id": "defaultSyncRootFolderItemFactory#default\
-                                                #a7e4ce2a-e4a7-432a-b5e1-62b354606929-test",\
-                                                "parentId": "org.nuxeo.drive.service.impl.\
-                                                DefaultTopLevelFolderItemFactory#",\
-                                                "name": "ROY",\
-                                                "folder": True,\
-                                                "creator": "Administrator",\
-                                                "lastContributor": "Administrator",\
-                                                "creationDate": 1681875486061,\
-                                                "lastModificationDate": 1681875528408,\
-                                                "canRename": True,\
-                                                "canDelete": True,\
-                                                "lockInfo": None,\
-                                                "path": "/org.nuxeo.drive.service.\
-                                                impl.DefaultTopLevelFolderItemFactory\
-                                                #/defaultSyncRootFolderItemFactory#default\
-                                                #a7e4ce2a-e4a7-432a-b5e1-62b354606929-test",\
-                                                "userName": "Administrator",\
-                                                 "canCreateChild": True,\
-                                                "canScrollDescendants": True\
-                                                }'
-        )
+        {
+            "id": "defaultSyncRootFolderItemFactory#default#a7e4ce2a-e4a7-432a-b5e1-62b354606929-test",
+            "parentId": "org.nuxeo.drive.service.impl.DefaultTopLevelFolderItemFactory#",
+            "name": "ROY",
+            "folder": True,
+            "creator": "Administrator",
+            "lastContributor": "Administrator",
+            "creationDate": 1681875486061,
+            "lastModificationDate": 1681875528408,
+            "canRename": True,
+            "canDelete": True,
+            "lockInfo": None,
+            "path": (
+                "/org.nuxeo.drive.service.impl.DefaultTopLevelFolderItemFactory#"
+                "/defaultSyncRootFolderItemFactory#default"
+                "#a7e4ce2a-e4a7-432a-b5e1-62b354606929-test"
+            ),
+            "userName": "Administrator",
+            "canCreateChild": True,
+            "canScrollDescendants": True,
+        }
     )
 
     def get_fs_children_(*args):

--- a/tests/integration/windows/utils.py
+++ b/tests/integration/windows/utils.py
@@ -54,9 +54,9 @@ def fatal_error_dlg(
     # Check if the fatal error dialog is prompted.
     # XXX: Keep synced with FATAL_ERROR_TITLE.
     print(
-        f"fatal_error_dlg called with app={app}, \
-        with_details={with_details}, \
-        wait_timeout_multiplier={wait_timeout_multiplier}"
+        f"fatal_error_dlg called with app={app}, "
+        f"with_details={with_details}, "
+        f"wait_timeout_multiplier={wait_timeout_multiplier}"
     )
 
     import pywinauto

--- a/tests/old_functional/common.py
+++ b/tests/old_functional/common.py
@@ -1,4 +1,4 @@
-""" Common test utilities. """
+"""Common test utilities."""
 
 import os
 import sys

--- a/tests/old_functional/test_local_changes_when_offline.py
+++ b/tests/old_functional/test_local_changes_when_offline.py
@@ -1,4 +1,4 @@
-""""
+"""
 Test if changes made to local file system when Drive is offline sync's back
 later when Drive becomes online.
 """

--- a/tests/unit/gui/__init__.py
+++ b/tests/unit/gui/__init__.py
@@ -1,1 +1,1 @@
-""" Unit tests for gui module. """
+"""Unit tests for gui module."""

--- a/tests/unit/gui/test_folders_treeview.py
+++ b/tests/unit/gui/test_folders_treeview.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import MagicMock, Mock, patch
 
-
 _UNSET = object()  # sentinel for "use default MagicMock"
 
 

--- a/tests/unit/test_commandline.py
+++ b/tests/unit/test_commandline.py
@@ -15,8 +15,7 @@ def create_ini(
 ) -> Path:
     path = Options.nxdrive_home / "config.ini"
     with open(path, "w", encoding=encoding) as f:
-        f.writelines(
-            f"""
+        f.writelines(f"""
 [{default_section}]
 env = {env}
 
@@ -39,8 +38,7 @@ tmp-file-limit = 0.0105
 log-level-console = DEBUG
  debug = False
 delay = 3
-"""
-        )
+""")
 
     if env != "Inception":
         return path
@@ -49,15 +47,13 @@ delay = 3
     path = Options.nxdrive_home / "drive_home" / "config.ini"
     path.parent.mkdir(exist_ok=True)
     with open(path, "w", encoding=encoding) as f:
-        f.writelines(
-            """
+        f.writelines("""
 [DEFAULT]
 env = français
 
 [français]
 force-locale = fr
-"""
-        )
+""")
 
     return path
 

--- a/tests/unit/test_pytest_random.py
+++ b/tests/unit/test_pytest_random.py
@@ -204,48 +204,40 @@ def test_success(): assert True
 
 
 def test_bypass_on_passing_test(testdir):
-    testdir.makepyfile(
-        """
+    testdir.makepyfile("""
 import pytest
 @pytest.mark.randombug('NXDRIVE-0', mode='BYPASS')
 def test_success(): assert True
-"""
-    )
+""")
     result = testdir.runpytest()
     assert_outcomes(result, passed=0, skipped=1)
 
 
 def test_bypass_on_failing_test(testdir):
-    testdir.makepyfile(
-        """
+    testdir.makepyfile("""
 import pytest
 @pytest.mark.randombug('NXDRIVE-0', mode='BYPASS')
 def test_fail(): assert False
-"""
-    )
+""")
     result = testdir.runpytest()
     assert_outcomes(result, passed=0, skipped=1)
 
 
 def test_bypass_and_false_condition_on_passing_test(testdir):
-    testdir.makepyfile(
-        """
+    testdir.makepyfile("""
 import pytest
 @pytest.mark.randombug('NXDRIVE-0', condition=False, mode='BYPASS')
 def test_success(): assert True
-"""
-    )
+""")
     result = testdir.runpytest()
     assert_outcomes(result)
 
 
 def test_bypass_and_false_condition_on_failing_test(testdir):
-    testdir.makepyfile(
-        """
+    testdir.makepyfile("""
 import pytest
 @pytest.mark.randombug('NXDRIVE-0', condition=False, mode='BYPASS')
 def test_fail(): assert False
-"""
-    )
+""")
     result = testdir.runpytest()
     assert_outcomes(result, passed=0, failed=1)

--- a/tests/unit/test_pytest_random.py
+++ b/tests/unit/test_pytest_random.py
@@ -39,166 +39,138 @@ def assert_outcomes(
 
 
 def test_no_repeat_on_skipif_mark(testdir):
-    testdir.makepyfile(
-        """
+    testdir.makepyfile("""
 import pytest
 @pytest.mark.skipif(reason='Skipping this test')
 @pytest.mark.randombug('NXDRIVE-0', mode='STRICT')
 def test_skip():
     pass
-"""
-    )
+""")
     result = testdir.runpytest()
     assert_outcomes(result, passed=0, skipped=1)
 
 
 def test_no_repeat_on_skip_call(testdir):
-    testdir.makepyfile(
-        """
+    testdir.makepyfile("""
 import pytest
 @pytest.mark.randombug('NXDRIVE-0', mode='STRICT')
 def test_skip():
     pytest.skip('Skipping this test')
-"""
-    )
+""")
     result = testdir.runpytest()
     assert_outcomes(result, passed=0, skipped=1)
 
 
 def test_no_repeat_on_xfail_mark(testdir):
-    testdir.makepyfile(
-        """
+    testdir.makepyfile("""
 import pytest
 @pytest.mark.xfail()
 @pytest.mark.randombug('NXDRIVE-0')
 def test_xfail():
     assert False
-"""
-    )
+""")
     result = testdir.runpytest()
     assert_outcomes(result, passed=0, xfailed=1)
 
 
 def test_no_repeat_on_xfail_call(testdir):
-    testdir.makepyfile(
-        """
+    testdir.makepyfile("""
 import pytest
 @pytest.mark.randombug('NXDRIVE-0')
 def test_xfail():
     pytest.xfail('Skipping this test')
-"""
-    )
+""")
     result = testdir.runpytest()
     assert_outcomes(result, passed=0, xfailed=1)
 
 
 def test_relax_on_failing_test(testdir):
-    testdir.makepyfile(
-        """
+    testdir.makepyfile("""
 import pytest
 @pytest.mark.randombug('NXDRIVE-0')
 def test_fail(): assert False
-"""
-    )
+""")
     result = testdir.runpytest()
     assert_outcomes(result, passed=0, failed=1, repeated=9)
 
 
 def test_relax_on_passing_test(testdir):
-    testdir.makepyfile(
-        """
+    testdir.makepyfile("""
 import pytest
 @pytest.mark.randombug('NXDRIVE-0')
 def test_success(): assert True
-"""
-    )
+""")
     result = testdir.runpytest()
     assert_outcomes(result)
 
 
 def test_relax_and_false_condition_on_failing_test(testdir):
-    testdir.makepyfile(
-        """
+    testdir.makepyfile("""
 import pytest
 @pytest.mark.randombug('NXDRIVE-0', condition=False)
 def test_fail(): assert False
-"""
-    )
+""")
     result = testdir.runpytest()
     assert_outcomes(result, passed=0, failed=1)
 
 
 def test_relax_passing_after_failure(testdir):
-    testdir.makepyfile(
-        """
+    testdir.makepyfile("""
 import pytest
 @pytest.mark.randombug('NXDRIVE-0')
 def test_fail():
-"""
-        + temporary_failure(3)
-    )
+""" + temporary_failure(3))
     result = testdir.runpytest()
     assert_outcomes(result, repeated=3)
 
 
 def test_strict_on_failing_test(testdir):
-    testdir.makepyfile(
-        """
+    testdir.makepyfile("""
 import pytest
 @pytest.mark.randombug('NXDRIVE-0', mode='STRICT')
 def test_fail(): assert False
-"""
-    )
+""")
     result = testdir.runpytest()
     assert_outcomes(result, passed=0, failed=1)
 
 
 def test_strict_on_passing_test(testdir):
     """In STRICT mode, if the test never fails, the result _must_ be a failure."""
-    testdir.makepyfile(
-        """
+    testdir.makepyfile("""
 import pytest
 @pytest.mark.randombug('NXDRIVE-0', mode='STRICT')
 def test_success(): assert True
-"""
-    )
+""")
     result = testdir.runpytest()
     assert_outcomes(result, passed=0, failed=1, repeated=9)
 
 
 def test_strict_and_false_condition_on_passing_test(testdir):
-    testdir.makepyfile(
-        """
+    testdir.makepyfile("""
 import pytest
 @pytest.mark.randombug('NXDRIVE-0', condition=False, mode='STRICT')
 def test_success(): assert True
-"""
-    )
+""")
     result = testdir.runpytest()
     assert_outcomes(result)
 
 
 def test_strict_failing_after_success(testdir):
-    testdir.makepyfile(
-        """
+    testdir.makepyfile("""
 import pytest
 @pytest.mark.randombug('NXDRIVE-0', mode='STRICT')
 def test_fail():
-"""
-        + temporary_failure(3, reverse=True)
-    )
+""" + temporary_failure(3, reverse=True))
     result = testdir.runpytest()
     assert_outcomes(result, passed=0, failed=1, repeated=3)
 
 
 def test_strict_and_lower_repeat_number_on_passing_test(testdir):
-    testdir.makepyfile(
-        """
+    testdir.makepyfile("""
 import pytest
 @pytest.mark.randombug('NXDRIVE-0', repeat=5, mode='STRICT')
 def test_success(): assert True
-"""
-    )
+""")
     result = testdir.runpytest()
     assert_outcomes(result, passed=0, failed=1, repeated=4)
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1028,6 +1028,40 @@ def test_parse_protocol_url_bad_http_scheme():
 
 
 @windows_only
+def test_parse_protocol_url_direct_transfer_web_ui_url_decoding():
+    """On Windows, URL-encoded characters should be decoded for direct-transfer Web UI URLs."""
+    # Test %20 is decoded to space
+    url = "nxdrive://direct-transfer/https/server.nuxeo.com/nuxeo/default-domain/UserWorkspaces/user/not%20shared"
+    info = nxdrive.utils.parse_protocol_url(url)
+    assert info == {
+        "command": "direct-transfer",
+        "remote_path": "/default-domain/UserWorkspaces/user/not shared",
+    }
+
+
+@windows_only
+def test_parse_protocol_url_direct_transfer_web_ui_literal_percent20():
+    """On Windows, %2520 should decode to literal %20 (folder name contains %20)."""
+    url = "nxdrive://direct-transfer/https/server.nuxeo.com/nuxeo/default-domain/folder%2520special"
+    info = nxdrive.utils.parse_protocol_url(url)
+    assert info == {
+        "command": "direct-transfer",
+        "remote_path": "/default-domain/folder%20special",
+    }
+
+
+@not_windows(reason="URL decoding only applies on Windows.")
+def test_parse_protocol_url_direct_transfer_web_ui_no_decoding():
+    """On non-Windows, URL-encoded characters should NOT be decoded."""
+    url = "nxdrive://direct-transfer/https/server.nuxeo.com/nuxeo/default-domain/UserWorkspaces/user/not%20shared"
+    info = nxdrive.utils.parse_protocol_url(url)
+    assert info == {
+        "command": "direct-transfer",
+        "remote_path": "/default-domain/UserWorkspaces/user/not%20shared",
+    }
+
+
+@windows_only
 @pytest.mark.parametrize(
     "path, result",
     [

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -71,8 +71,7 @@ def debug(*args, **kwargs):
 def examples():
     """Print several examples."""
 
-    print(
-        """
+    print("""
 Example {}: changelog.py
 
     Print changelog of commits from HEAD to the latest release tag.
@@ -114,10 +113,7 @@ Example {}: changelog.py -- --since=2017-03-16 --until=2017-03-28 --author="Mick
 
     Print changelog of commits between the dates on the master branch for a given author.
     Useful for sprint reports.
-""".format(
-            *range(1, 42)
-        ).strip()
-    )  # noqa
+""".format(*range(1, 42)).strip())  # noqa
 
 
 def get_latest_tag():

--- a/tools/scripts/slow_thread_detection.py
+++ b/tools/scripts/slow_thread_detection.py
@@ -1,4 +1,4 @@
-""" Detect slow threads. """
+"""Detect slow threads."""
 
 import re
 from datetime import datetime


### PR DESCRIPTION
…hat has spaces in its name

## Summary by Sourcery

Decode direct transfer URLs to correctly handle remote paths containing URL-encoded characters and document the associated change.

Bug Fixes:
- Fix direct transfer Web UI behavior when the target path contains spaces or other URL-encoded characters.

Documentation:
- Update 7.0.0 changelog to reference NXDRIVE-3117 and describe the direct transfer Web UI fix.