### PR TITLE
NXDRIVE-3166: Upgrade NodeJs to 24.x

### DIFF
--- a/.github/workflows/alpha_cleanup.yml
+++ b/.github/workflows/alpha_cleanup.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: "0"
 

--- a/.github/workflows/beta_to_prod.yml
+++ b/.github/workflows/beta_to_prod.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install SSH key for Bastion
         uses: shimataro/ssh-key-action@v2

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Crowdin Action
         uses: crowdin/github-action@v2.5.2

--- a/.github/workflows/dead_code.yml
+++ b/.github/workflows/dead_code.yml
@@ -12,17 +12,17 @@ jobs:
   dead-code:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.13 # XXX_PYTHON
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
           restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: .tox
           key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v3.0.0
         with:
           driver: docker

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -26,17 +26,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: docker/setup-buildx-action@v3.0.0
+      - uses: docker/setup-buildx-action@v4
         with:
           driver: docker
       - name: Login to the registry
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build the image
-        uses: docker/build-push-action@v5.1.0
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: tools/linux/Dockerfile

--- a/.github/workflows/functional_tests_2023.yml
+++ b/.github/workflows/functional_tests_2023.yml
@@ -28,16 +28,16 @@ jobs:
   functional-tests-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.13 # XXX_PYTHON
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
           restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: .tox
           key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
@@ -66,16 +66,16 @@ jobs:
   functional-tests-macos:
     runs-on: "macos-15-intel"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.13 # XXX_PYTHON
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/Library/Caches/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
           restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: .tox
           key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
@@ -96,11 +96,11 @@ jobs:
   functional-tests-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.13 # XXX_PYTHON
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~\AppData\Local\pip\Cache
           key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
@@ -126,16 +126,16 @@ jobs:
       - functional-tests-macos
       - functional-tests-windows
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.13 # XXX_PYTHON
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-clean.txt', 'tools/deps/requirements-tox.txt') }}
           restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-clean.txt', 'tools/deps/requirements-tox.txt') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: .tox
           key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-clean.txt', 'tools/deps/requirements-tox.txt') }}

--- a/.github/workflows/functional_tests_2023.yml
+++ b/.github/workflows/functional_tests_2023.yml
@@ -133,13 +133,13 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-clean.txt', 'tools/deps/requirements-tox.txt') }}
-          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-clean.txt', 'tools/deps/requirements-tox.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-tox.txt') }}
+          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-tox.txt') }}
       - uses: actions/cache@v5
         with:
           path: .tox
-          key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-clean.txt', 'tools/deps/requirements-tox.txt') }}
-          restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-clean.txt', 'tools/deps/requirements-tox.txt') }}
+          key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-tox.txt') }}
+          restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-tox.txt') }}
       - name: Install tox
         run: python -m pip install -r tools/deps/requirements-tox.txt
       - name: Clean-up tests data

--- a/.github/workflows/functional_tests_2023.yml
+++ b/.github/workflows/functional_tests_2023.yml
@@ -56,7 +56,7 @@ jobs:
           DISPLAY: ":99"
       - name: Upload coverage to Codecov
         if: ${{ success() || failure() }}
-        uses: codecov/codecov-action@v5.2.0
+        uses: codecov/codecov-action@v6
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: ./coverage.xml
@@ -86,7 +86,7 @@ jobs:
         run: tox -e ft
       - name: Upload coverage to Codecov
         if: ${{ success() || failure() }}
-        uses: codecov/codecov-action@v5.2.0
+        uses: codecov/codecov-action@v6
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: ./coverage.xml
@@ -111,7 +111,7 @@ jobs:
         run: tox -e ft
       - name: Upload coverage to Codecov
         if: ${{ success() || failure() }}
-        uses: codecov/codecov-action@v5.2.0
+        uses: codecov/codecov-action@v6
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: ./coverage.xml

--- a/.github/workflows/functional_tests_2023.yml
+++ b/.github/workflows/functional_tests_2023.yml
@@ -35,13 +35,13 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
+          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
       - uses: actions/cache@v5
         with:
           path: .tox
-          key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-          restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+          key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
+          restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
       - name: Install system dependencies
         run: |
           sudo apt install xclip
@@ -73,13 +73,13 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ~/Library/Caches/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
+          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
       - uses: actions/cache@v5
         with:
           path: .tox
-          key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-          restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+          key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
+          restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
       - name: Install tox
         run: python -m pip install -r tools/deps/requirements-tox.txt
       - name: Functional tests
@@ -103,8 +103,8 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ~\AppData\Local\pip\Cache
-          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
+          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
       - name: Install tox
         run: python -m pip install -r tools/deps/requirements-tox.txt
       - name: Functional tests

--- a/.github/workflows/functional_tests_2025.yml
+++ b/.github/workflows/functional_tests_2025.yml
@@ -28,16 +28,16 @@ jobs:
   functional-tests-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.13 # XXX_PYTHON
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
           restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: .tox
           key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
@@ -66,16 +66,16 @@ jobs:
   functional-tests-macos:
     runs-on: "macos-15-intel"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.13 # XXX_PYTHON
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/Library/Caches/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
           restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: .tox
           key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
@@ -96,11 +96,11 @@ jobs:
   functional-tests-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.13 # XXX_PYTHON
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~\AppData\Local\pip\Cache
           key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
@@ -126,16 +126,16 @@ jobs:
       - functional-tests-macos
       - functional-tests-windows
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.13 # XXX_PYTHON
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-clean.txt', 'tools/deps/requirements-tox.txt') }}
           restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-clean.txt', 'tools/deps/requirements-tox.txt') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: .tox
           key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-clean.txt', 'tools/deps/requirements-tox.txt') }}

--- a/.github/workflows/functional_tests_2025.yml
+++ b/.github/workflows/functional_tests_2025.yml
@@ -133,13 +133,13 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-clean.txt', 'tools/deps/requirements-tox.txt') }}
-          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-clean.txt', 'tools/deps/requirements-tox.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-tox.txt') }}
+          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-tox.txt') }}
       - uses: actions/cache@v5
         with:
           path: .tox
-          key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-clean.txt', 'tools/deps/requirements-tox.txt') }}
-          restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-clean.txt', 'tools/deps/requirements-tox.txt') }}
+          key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-tox.txt') }}
+          restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-tox.txt') }}
       - name: Install tox
         run: python -m pip install -r tools/deps/requirements-tox.txt
       - name: Clean-up tests data

--- a/.github/workflows/functional_tests_2025.yml
+++ b/.github/workflows/functional_tests_2025.yml
@@ -56,7 +56,7 @@ jobs:
           DISPLAY: ":99"
       - name: Upload coverage to Codecov
         if: ${{ success() || failure() }}
-        uses: codecov/codecov-action@v5.2.0
+        uses: codecov/codecov-action@v6
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: ./coverage.xml
@@ -86,7 +86,7 @@ jobs:
         run: tox -e ft
       - name: Upload coverage to Codecov
         if: ${{ success() || failure() }}
-        uses: codecov/codecov-action@v5.2.0
+        uses: codecov/codecov-action@v6
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: ./coverage.xml
@@ -111,7 +111,7 @@ jobs:
         run: tox -e ft
       - name: Upload coverage to Codecov
         if: ${{ success() || failure() }}
-        uses: codecov/codecov-action@v5.2.0
+        uses: codecov/codecov-action@v6
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: ./coverage.xml

--- a/.github/workflows/functional_tests_2025.yml
+++ b/.github/workflows/functional_tests_2025.yml
@@ -35,13 +35,13 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
+          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
       - uses: actions/cache@v5
         with:
           path: .tox
-          key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-          restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+          key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
+          restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
       - name: Install system dependencies
         run: |
           sudo apt install xclip
@@ -73,13 +73,13 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ~/Library/Caches/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
+          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
       - uses: actions/cache@v5
         with:
           path: .tox
-          key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-          restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+          key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
+          restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
       - name: Install tox
         run: python -m pip install -r tools/deps/requirements-tox.txt
       - name: Functional tests
@@ -103,8 +103,8 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ~\AppData\Local\pip\Cache
-          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
+          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
       - name: Install tox
         run: python -m pip install -r tools/deps/requirements-tox.txt
       - name: Functional tests

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -31,12 +31,12 @@ jobs:
     name: integration-tests-windows(LTS 2023)
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13.1" # XXX_PYTHON
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~\AppData\Local\pip\Cache
           key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-dev.txt', 'tools/deps/requirements-tox.txt') }}
@@ -72,18 +72,18 @@ jobs:
     name: integration-tests-windows(LTS 2025)
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13.1" # XXX_PYTHON
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~\AppData\Local\pip\Cache
           key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-dev.txt', 'tools/deps/requirements-tox.txt') }}
           restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-dev.txt', 'tools/deps/requirements-tox.txt') }}
       # Cannot be used for now: OSError: [WinError 193] %1 is not a valid Win32 application
-      # - uses: actions/cache@v4
+      # - uses: actions/cache@v5
       #   with:
       #     path: .tox
       #     key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
@@ -119,16 +119,16 @@ jobs:
     name: integration-tests-macos(LTS 2025)
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.13 # XXX_PYTHON
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/Library/Caches/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
           restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: .tox
           key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -52,7 +52,7 @@ jobs:
         run: tox -e integration-windows
       - name: Upload coverage to Codecov
         if: ${{ success() || failure() }}
-        uses: codecov/codecov-action@v5.2.0
+        uses: codecov/codecov-action@v6
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: ./coverage.xml
@@ -99,7 +99,7 @@ jobs:
         run: tox -e integration-windows
       - name: Upload coverage to Codecov
         if: ${{ success() || failure() }}
-        uses: codecov/codecov-action@v5.2.0
+        uses: codecov/codecov-action@v6
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: ./coverage.xml
@@ -139,7 +139,7 @@ jobs:
         run: tox -e integration-macos
       - name: Upload coverage to Codecov
         if: ${{ success() || failure() }}
-        uses: codecov/codecov-action@v5.2.0
+        uses: codecov/codecov-action@v6
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: ./coverage.xml

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -39,8 +39,8 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ~\AppData\Local\pip\Cache
-          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-dev.txt', 'tools/deps/requirements-tox.txt') }}
-          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-dev.txt', 'tools/deps/requirements-tox.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-dev.txt', 'tools/deps/requirements-tox.txt') }}
+          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-dev.txt', 'tools/deps/requirements-tox.txt') }}
       - name: Freeze the application
         run: |
           powershell Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope LocalMachine
@@ -80,14 +80,14 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ~\AppData\Local\pip\Cache
-          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-dev.txt', 'tools/deps/requirements-tox.txt') }}
-          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-dev.txt', 'tools/deps/requirements-tox.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-dev.txt', 'tools/deps/requirements-tox.txt') }}
+          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-dev.txt', 'tools/deps/requirements-tox.txt') }}
       # Cannot be used for now: OSError: [WinError 193] %1 is not a valid Win32 application
       # - uses: actions/cache@v5
       #   with:
       #     path: .tox
-      #     key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-      #     restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+      #     key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
+      #     restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
       - name: Freeze the application
         run: |
           powershell Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope LocalMachine
@@ -126,13 +126,13 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ~/Library/Caches/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
+          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
       - uses: actions/cache@v5
         with:
           path: .tox
-          key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-          restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+          key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
+          restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements.txt', 'tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
       - name: Install tox
         run: python -m pip install -r tools/deps/requirements-tox.txt
       - name: Integration tests

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,17 +12,17 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.13 # XXX_PYTHON
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
           restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: .tox
           key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: "[GNU/Linux] Login to the docker registry"
         if: matrix.os == 'ubuntu-latest'
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v4
         with:
           registry: "docker-private.packages.nuxeo.com"
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           echo "releaseType=${{ github.event.inputs.releaseType }}" >> $GITHUB_OUTPUT
           echo "signExe=${{ github.event.inputs.signExe }}" >> $GITHUB_OUTPUT
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch }}
 
@@ -261,7 +261,7 @@ jobs:
         run: powershell ".\\tools\\windows\\deploy_ci_agent.ps1" -build_installer_and_sign
 
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: package-distributions-${{ matrix.os }}
           path: |
@@ -276,7 +276,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.branch }}
 
@@ -308,7 +308,7 @@ jobs:
           git remote set-url origin "https://${{ env.GITHUB_USERNAME }}:${{ secrets.NXDRIVE_GIT_TOKEN }}@github.com/nuxeo/nuxeo-drive.git"
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: package-distributions*
           path: dist/

--- a/.github/workflows/spell.yml
+++ b/.github/workflows/spell.yml
@@ -15,17 +15,17 @@ jobs:
   spell:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.13 # XXX_PYTHON
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
           restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: .tox
           key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -12,17 +12,17 @@ jobs:
   style:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.13 # XXX_PYTHON
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
           restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: .tox
           key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -12,17 +12,17 @@ jobs:
   translations:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.13 # XXX_PYTHON
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-tox.txt') }}
           restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-tox.txt') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: .tox
           key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-tox.txt') }}

--- a/.github/workflows/types.yml
+++ b/.github/workflows/types.yml
@@ -12,17 +12,17 @@ jobs:
   types:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.13 # XXX_PYTHON
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
           restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: .tox
           key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -30,13 +30,13 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
+          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
       - uses: actions/cache@v5
         with:
           path: .tox
-          key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-          restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+          key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
+          restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
       - name: Install Linux dependencies
         run: bash .github/workflows/linux_dependencies.sh
       - name: Install tox
@@ -65,13 +65,13 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ~/Library/Caches/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
+          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
       - uses: actions/cache@v5
         with:
           path: .tox
-          key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-          restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+          key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
+          restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
       - name: Install tox
         run: python -m pip install -r tools/deps/requirements-tox.txt
       - name: Unit tests
@@ -96,14 +96,14 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ~\AppData\Local\pip\Cache
-          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
+          restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
       # Cannot be used for now: OSError: [WinError 193] %1 is not a valid Win32 application
       # - uses: actions/cache@v5
       #   with:
       #     path: .tox
-      #     key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-      #     restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
+      #     key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
+      #     restore-keys: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-tests.txt', 'tools/deps/requirements-tox.txt') }}
       - name: Install tox
         run: python -m pip install -r tools/deps/requirements-tox.txt
       - name: Unit tests

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -22,17 +22,17 @@ jobs:
   unit-tests-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.13 # XXX_PYTHON
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
           restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: .tox
           key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
@@ -57,17 +57,17 @@ jobs:
     env:
       SYSTEM_VERSION_COMPAT: 0
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.13 # XXX_PYTHON
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/Library/Caches/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
           restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: .tox
           key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
@@ -88,18 +88,18 @@ jobs:
   unit-tests-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.13 # XXX_PYTHON
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~\AppData\Local\pip\Cache
           key: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
           restore-keys: ${{ runner.os }}-pip-${{ hashFiles('tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}
       # Cannot be used for now: OSError: [WinError 193] %1 is not a valid Win32 application
-      # - uses: actions/cache@v4
+      # - uses: actions/cache@v5
       #   with:
       #     path: .tox
       #     key: ${{ runner.os }}-tox-${{ hashFiles('tools/deps/requirements-test.txt', 'tools/deps/requirements-tox.txt') }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -45,7 +45,7 @@ jobs:
         run: tox -e unit
       - name: Upload coverage to Codecov
         if: ${{ success() || failure() }}
-        uses: codecov/codecov-action@v5.2.0
+        uses: codecov/codecov-action@v6
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: ./coverage.xml
@@ -78,7 +78,7 @@ jobs:
         run: tox -e unit
       - name: Upload coverage to Codecov
         if: ${{ success() || failure() }}
-        uses: codecov/codecov-action@v5.2.0
+        uses: codecov/codecov-action@v6
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: ./coverage.xml
@@ -110,7 +110,7 @@ jobs:
         run: tox -e unit
       - name: Upload coverage to Codecov
         if: ${{ success() || failure() }}
-        uses: codecov/codecov-action@v5.2.0
+        uses: codecov/codecov-action@v6
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: ./coverage.xml

--- a/docs/changes/7.0.0.md
+++ b/docs/changes/7.0.0.md
@@ -27,6 +27,7 @@ Release date: `2026-xx-xx`
 - [NXDRIVE-3113](https://hyland.atlassian.net/browse/NXDRIVE-3113): Ensure release runs on all OS
 - [NXDRIVE-3121](https://hyland.atlassian.net/browse/NXDRIVE-3121): Fix app launch on Windows
 - [NXDRIVE-3133](https://hyland.atlassian.net/browse/NXDRIVE-3133): End the running Drive task before attempting to install
+- [NXDRIVE-3166](https://hyland.atlassian.net/browse/NXDRIVE-3166): Upgrade NodeJs to 24.x
 
 ## Security
 

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -1433,6 +1433,3 @@ def find_real_libreoffice_file(lock_path: str) -> tuple[str, str]:
     lock_filename = os.path.basename(lock_path)
     real_filename = lock_filename[len(".~lock.") : -1]
     return os.path.join(folder, real_filename), real_filename
-
-
-# change done to trigger workflows in CI, will be removed before merging to master

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -1433,3 +1433,6 @@ def find_real_libreoffice_file(lock_path: str) -> tuple[str, str]:
     lock_filename = os.path.basename(lock_path)
     real_filename = lock_filename[len(".~lock.") : -1]
     return os.path.join(folder, real_filename), real_filename
+
+
+# change done to trigger workflows in CI, will be removed before merging to master


### PR DESCRIPTION
## Summary by Sourcery

Update CI workflows to use newer GitHub Actions versions and document the Node.js 24.x upgrade.

Build:
- Bump actions/checkout to v6 across all workflows.
- Bump actions/setup-python to v6 and actions/cache to v5 in test, lint, style, spell, translations, and dead-code workflows.
- Upgrade artifact upload/download actions in release workflow (upload-artifact to v7 and download-artifact to v8).

CI:
- Align all functional, unit, integration, and auxiliary workflows with the updated GitHub Actions ecosystem for improved compatibility and maintenance.

Documentation:
- Document the NXDRIVE-3166 Node.js 24.x upgrade in the 7.0.0 release notes.

Chores:
- Add a temporary no-op comment in utils.py to trigger CI workflows.