### PR TITLE
NXDRIVE-3176: Fix Direct Download window opening issue

### DIFF
--- a/docs/changes/7.0.0.md
+++ b/docs/changes/7.0.0.md
@@ -19,7 +19,7 @@ Release date: `2026-xx-xx`
 - [NXDRIVE-3132](https://hyland.atlassian.net/browse/NXDRIVE-3132): Implement UI of Direct Download
 - [NXDRIVE-3143](https://hyland.atlassian.net/browse/NXDRIVE-3143): Implement direct download feature (backend changes)
 - [NXDRIVE-3146](https://hyland.atlassian.net/browse/NXDRIVE-3146): Align changes with PyQt6
-- [NXDRIVE-xxxx](https://hyland.atlassian.net/browse/NXDRIVE-xxxx): Fix Direct Download window opening issue
+- [NXDRIVE-3176](https://hyland.atlassian.net/browse/NXDRIVE-3176): Fix Direct Download window opening issue
 
 ## Docs
 

--- a/docs/changes/7.0.0.md
+++ b/docs/changes/7.0.0.md
@@ -19,6 +19,7 @@ Release date: `2026-xx-xx`
 - [NXDRIVE-3132](https://hyland.atlassian.net/browse/NXDRIVE-3132): Implement UI of Direct Download
 - [NXDRIVE-3143](https://hyland.atlassian.net/browse/NXDRIVE-3143): Implement direct download feature (backend changes)
 - [NXDRIVE-3146](https://hyland.atlassian.net/browse/NXDRIVE-3146): Align changes with PyQt6
+- [NXDRIVE-xxxx](https://hyland.atlassian.net/browse/NXDRIVE-xxxx): Fix Direct Download window opening issue
 
 ## Docs
 

--- a/nxdrive/data/qml/Main.qml
+++ b/nxdrive/data/qml/Main.qml
@@ -77,8 +77,10 @@ QtObject {
         visible: false
 
         signal setEngine(string uid)
+        signal switchToTab(int tabIndex)
 
         onSetEngine: directTransferWin.setEngine(uid)
+        onSwitchToTab: directTransferWin.switchToTab(tabIndex)
 
         DirectTransferWindow { id: directTransferWin }
     }

--- a/nxdrive/direct_download.py
+++ b/nxdrive/direct_download.py
@@ -343,13 +343,20 @@ class DirectDownload(Worker):
             # Handle duplicate zip filenames
             zip_path = self._get_unique_path(zip_path)
 
+            # Collect files to archive
+            archive_files = [f for f in batch_folder.rglob("*") if f.is_file()]
+
+            if not archive_files:
+                log.warning("No files to archive - all downloads may have failed")
+                self._cleanup_batch_folder(batch_folder)
+                return None
+
             # Create the zip archive
             with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
-                for file_path in batch_folder.rglob("*"):
-                    if file_path.is_file():
-                        # Calculate the archive name (relative path from batch folder)
-                        arcname = file_path.relative_to(batch_folder)
-                        zipf.write(file_path, arcname)
+                for file_path in archive_files:
+                    # Calculate the archive name (relative path from batch folder)
+                    arcname = file_path.relative_to(batch_folder)
+                    zipf.write(file_path, arcname)
 
             log.info(
                 f"Selected documents downloaded successfully to {downloads_folder}"

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -1103,7 +1103,11 @@ class Application(QApplication):
     def show_direct_download_window(self) -> None:
         """Display the Direct Transfer window with the Direct Download tab selected."""
         engines = list(self.manager.engines.values())
-        engine = engines[0] if engines else None
+        engine: Optional[Engine] = None
+        if len(engines) > 1:
+            engine = self._select_account(engines)
+        elif engines:
+            engine = engines[0]
         if not engine:
             return
         window = self._window_root(self.direct_transfer_window)

--- a/nxdrive/gui/application.py
+++ b/nxdrive/gui/application.py
@@ -1100,8 +1100,11 @@ class Application(QApplication):
         window.setEngine.emit(engine_uid)
         self._center_on_screen(self.direct_transfer_window)
 
-    def show_direct_download_window(self) -> None:
-        """Display the Direct Transfer window with the Direct Download tab selected."""
+    def show_direct_download_window(self) -> Optional[Engine]:
+        """Display the Direct Transfer window with the Direct Download tab selected.
+
+        :return: The selected engine, or None if cancelled or no engines.
+        """
         engines = list(self.manager.engines.values())
         engine: Optional[Engine] = None
         if len(engines) > 1:
@@ -1109,11 +1112,12 @@ class Application(QApplication):
         elif engines:
             engine = engines[0]
         if not engine:
-            return
+            return None
         window = self._window_root(self.direct_transfer_window)
         window.setEngine.emit(engine.uid)
         window.switchToTab.emit(0)
         self._center_on_screen(self.direct_transfer_window)
+        return engine
 
     @pyqtSlot()
     def close_direct_transfer_window(self) -> None:
@@ -1847,11 +1851,20 @@ class Application(QApplication):
                 log.warning("No documents found in direct download URL")
                 return False
 
+            # Open the Direct Download window and let the user select an account
+            engine = self.show_direct_download_window()
+            if not engine:
+                return False
+
+            # Inject the selected engine's username into documents
+            # so _get_engine() can find the correct engine
+            bind = engine.get_binder()
+            for doc in documents:
+                if not doc.get("user"):
+                    doc["user"] = bind.username
+
             func = manager.directDownload.emit
             args = (documents,)
-
-            # Open the Direct Download window to show progress
-            self.show_direct_download_window()
 
         elif cmd == "authorize":
             func = self.api.continue_oauth2_flow

--- a/tests/unit/test_direct_download.py
+++ b/tests/unit/test_direct_download.py
@@ -396,6 +396,23 @@ class TestDirectDownloadCreateZipArchive:
             result = dd._create_zip_archive(batch)
             assert result is None
 
+    def test_archive_empty_batch_returns_none(self):
+        """Test that an empty batch folder (all downloads failed) returns None
+        without creating an empty zip and without logging false success."""
+        dd = DirectDownload(self.manager, self.folder)
+        batch = self.folder / "download_20250101_120000"
+        batch.mkdir()
+        # Batch has only an empty subfolder - no files (all downloads failed)
+        (batch / "empty_subdir").mkdir()
+
+        with patch.object(dd, "_get_download_destination", return_value=self.downloads):
+            result = dd._create_zip_archive(batch)
+            assert result is None
+            # No zip should be created in the downloads folder
+            assert not any(self.downloads.glob("*.zip"))
+            # Batch folder should be cleaned up
+            assert not batch.exists()
+
 
 class TestDirectDownloadCleanupBatchFolder:
     """Test _cleanup_batch_folder method."""

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1588,20 +1588,23 @@ class TestShowDirectDownloadWindow:
         mock_window = Mock()
         app._window_root.return_value = mock_window
 
-        app.show_direct_download_window()
+        result = app.show_direct_download_window()
 
         mock_window.setEngine.emit.assert_called_once_with("test-engine-uid")
         mock_window.switchToTab.emit.assert_called_once_with(0)
         app._center_on_screen.assert_called_once_with(app.direct_transfer_window)
+        assert result is not None
+        assert result.uid == "test-engine-uid"
 
     def test_no_engines_does_nothing(self):
         """Test that nothing happens when no engines are configured."""
         app = self._make_app(engines={})
 
-        app.show_direct_download_window()
+        result = app.show_direct_download_window()
 
         app._window_root.assert_not_called()
         app._center_on_screen.assert_not_called()
+        assert result is None
 
     def test_multiple_engines_shows_account_selection(self):
         """Test that account selection dialog is shown when multiple engines exist."""
@@ -1615,12 +1618,13 @@ class TestShowDirectDownloadWindow:
         mock_window = Mock()
         app._window_root.return_value = mock_window
 
-        app.show_direct_download_window()
+        result = app.show_direct_download_window()
 
         app._select_account.assert_called_once()
         mock_window.setEngine.emit.assert_called_once_with("engine-uid-2")
         mock_window.switchToTab.emit.assert_called_once_with(0)
         app._center_on_screen.assert_called_once_with(app.direct_transfer_window)
+        assert result is engine2
 
     def test_multiple_engines_cancelled_does_nothing(self):
         """Test that cancelling account selection does not open the window."""
@@ -1632,8 +1636,9 @@ class TestShowDirectDownloadWindow:
         app = self._make_app(engines=engines)
         app._select_account.return_value = None
 
-        app.show_direct_download_window()
+        result = app.show_direct_download_window()
 
         app._select_account.assert_called_once()
         app._window_root.assert_not_called()
         app._center_on_screen.assert_not_called()
+        assert result is None

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1602,3 +1602,38 @@ class TestShowDirectDownloadWindow:
 
         app._window_root.assert_not_called()
         app._center_on_screen.assert_not_called()
+
+    def test_multiple_engines_shows_account_selection(self):
+        """Test that account selection dialog is shown when multiple engines exist."""
+        engine1 = Mock()
+        engine1.uid = "engine-uid-1"
+        engine2 = Mock()
+        engine2.uid = "engine-uid-2"
+        engines = {"uid1": engine1, "uid2": engine2}
+        app = self._make_app(engines=engines)
+        app._select_account.return_value = engine2
+        mock_window = Mock()
+        app._window_root.return_value = mock_window
+
+        app.show_direct_download_window()
+
+        app._select_account.assert_called_once()
+        mock_window.setEngine.emit.assert_called_once_with("engine-uid-2")
+        mock_window.switchToTab.emit.assert_called_once_with(0)
+        app._center_on_screen.assert_called_once_with(app.direct_transfer_window)
+
+    def test_multiple_engines_cancelled_does_nothing(self):
+        """Test that cancelling account selection does not open the window."""
+        engine1 = Mock()
+        engine1.uid = "engine-uid-1"
+        engine2 = Mock()
+        engine2.uid = "engine-uid-2"
+        engines = {"uid1": engine1, "uid2": engine2}
+        app = self._make_app(engines=engines)
+        app._select_account.return_value = None
+
+        app.show_direct_download_window()
+
+        app._select_account.assert_called_once()
+        app._window_root.assert_not_called()
+        app._center_on_screen.assert_not_called()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1642,3 +1642,119 @@ class TestShowDirectDownloadWindow:
         app._window_root.assert_not_called()
         app._center_on_screen.assert_not_called()
         assert result is None
+
+
+class TestHandleNxdriveUrlDirectDownload:
+    """Tests for Application._handle_nxdrive_url() direct download branch.
+
+    Covers the account-selection and user-injection logic added to
+    handle multi-account direct download requests.
+    """
+
+    def _make_app(self):
+        app = Mock()
+        app._handle_nxdrive_url = __import__(
+            "nxdrive.gui.application", fromlist=["Application"]
+        ).Application._handle_nxdrive_url.__get__(app)
+        manager = Mock()
+        manager.restart_needed = False
+        app.manager = manager
+        return app
+
+    def _parse_return(self, documents):
+        return {"command": "download_direct", "documents": documents}
+
+    def test_download_direct_injects_selected_user(self):
+        """User from selected engine is injected into documents missing 'user'."""
+        app = self._make_app()
+        engine = Mock()
+        bind = Mock()
+        bind.username = "alice"
+        engine.get_binder.return_value = bind
+        app.show_direct_download_window.return_value = engine
+
+        documents = [
+            {"server_url": "https://s.com/nuxeo/", "doc_id": "d1", "user": None},
+            {"server_url": "https://s.com/nuxeo/", "doc_id": "d2"},
+        ]
+
+        with patch(
+            "nxdrive.gui.application.parse_protocol_url",
+            return_value=self._parse_return(documents),
+        ), patch("nxdrive.gui.application.normalized_path", return_value=""):
+            result = app._handle_nxdrive_url("nxdrive://direct-download/x")
+
+        assert result is True
+        app.manager.directDownload.emit.assert_called_once()
+        emitted = app.manager.directDownload.emit.call_args[0][0]
+        assert all(doc["user"] == "alice" for doc in emitted)
+
+    def test_download_direct_preserves_existing_user(self):
+        """Existing 'user' values in documents are not overwritten."""
+        app = self._make_app()
+        engine = Mock()
+        bind = Mock()
+        bind.username = "alice"
+        engine.get_binder.return_value = bind
+        app.show_direct_download_window.return_value = engine
+
+        documents = [
+            {"server_url": "https://s.com/nuxeo/", "doc_id": "d1", "user": "bob"},
+            {"server_url": "https://s.com/nuxeo/", "doc_id": "d2"},
+        ]
+
+        with patch(
+            "nxdrive.gui.application.parse_protocol_url",
+            return_value=self._parse_return(documents),
+        ), patch("nxdrive.gui.application.normalized_path", return_value=""):
+            result = app._handle_nxdrive_url("nxdrive://direct-download/x")
+
+        assert result is True
+        emitted = app.manager.directDownload.emit.call_args[0][0]
+        assert emitted[0]["user"] == "bob"
+        assert emitted[1]["user"] == "alice"
+
+    def test_download_direct_cancelled_does_not_emit(self):
+        """If user cancels account selection, download is not started."""
+        app = self._make_app()
+        app.show_direct_download_window.return_value = None
+
+        documents = [{"server_url": "https://s.com/nuxeo/", "doc_id": "d1"}]
+        with patch(
+            "nxdrive.gui.application.parse_protocol_url",
+            return_value=self._parse_return(documents),
+        ), patch("nxdrive.gui.application.normalized_path", return_value=""):
+            result = app._handle_nxdrive_url("nxdrive://direct-download/x")
+
+        assert result is False
+        app.manager.directDownload.emit.assert_not_called()
+
+    def test_download_direct_empty_documents(self):
+        """Empty documents list returns False without opening window."""
+        app = self._make_app()
+        with patch(
+            "nxdrive.gui.application.parse_protocol_url",
+            return_value=self._parse_return([]),
+        ), patch("nxdrive.gui.application.normalized_path", return_value=""):
+            result = app._handle_nxdrive_url("nxdrive://direct-download/x")
+
+        assert result is False
+        app.show_direct_download_window.assert_not_called()
+        app.manager.directDownload.emit.assert_not_called()
+
+    def test_download_direct_restart_needed(self):
+        """If a restart is needed, show msgbox and return False."""
+        app = self._make_app()
+        app.manager.restart_needed = True
+
+        documents = [{"server_url": "https://s.com/nuxeo/", "doc_id": "d1"}]
+        with patch(
+            "nxdrive.gui.application.parse_protocol_url",
+            return_value=self._parse_return(documents),
+        ), patch("nxdrive.gui.application.normalized_path", return_value=""):
+            result = app._handle_nxdrive_url("nxdrive://direct-download/x")
+
+        assert result is False
+        app.show_msgbox_restart_needed.assert_called_once()
+        app.show_direct_download_window.assert_not_called()
+        app.manager.directDownload.emit.assert_not_called()


### PR DESCRIPTION
## Summary by Sourcery

Handle engine selection and improve robustness when opening and using the Direct Download window.

Bug Fixes:
- Ensure the Direct Download window only opens when an engine is selected and correctly handles multiple or zero configured engines.
- Prevent creating empty ZIP archives when all direct downloads fail, cleaning up temporary folders instead.

Enhancements:
- Return the selected engine from the Direct Download window flow and use it to inject the correct user into direct download documents.
- Wire QML signals to allow programmatic tab switching in the Direct Transfer window.
- Propagate the selected engine into direct download URL handling so the correct account is used for the download.

Documentation:
- Document the Direct Download window opening fix in the 7.0.0 changelog.

Tests:
- Extend unit tests for the Direct Download window to cover return values, multi-engine selection, and cancellation scenarios.