### PR TITLE
NXDRIVE-3177: Update changelog doc

### DIFF
--- a/docs/changes/7.0.0.md
+++ b/docs/changes/7.0.0.md
@@ -4,7 +4,7 @@ Release date: `2026-xx-xx`
 
 ## Core
 
-- [NXDRIVE-3](https://hyland.atlassian.net/browse/NXDRIVE-3):
+- [NXDRIVE-3103](https://hyland.atlassian.net/browse/NXDRIVE-3103): Upgrade to PyQT6
 
 ## Direct Edit
 
@@ -23,7 +23,7 @@ Release date: `2026-xx-xx`
 
 ## Docs
 
-- [NXDRIVE-3](https://hyland.atlassian.net/browse/NXDRIVE-3):
+- [NXDRIVE-3177](https://hyland.atlassian.net/browse/NXDRIVE-3177): Update changelog doc
 
 ## GUI
 


### PR DESCRIPTION
## Summary by Sourcery

Document PyQT6 upgrade and changelog update in the 7.0.0 release notes.

Documentation:
- Record NXDRIVE-3103 PyQT6 upgrade in the 7.0.0 changelog.
- Add NXDRIVE-3177 entry for the changelog documentation update in the 7.0.0 release notes.