### PR TITLE
NXDRIVE-3179: Drive should handle Encoded and not Encoded urls for direct transfer

### DIFF
--- a/docs/changes/7.0.0.md
+++ b/docs/changes/7.0.0.md
@@ -13,6 +13,7 @@ Release date: `2026-xx-xx`
 ## Direct Transfer
 
 - [NXDRIVE-3117](https://hyland.atlassian.net/browse/NXDRIVE-3117): Direct transfer Web UI icon doesn't work for a target that has spaces in its name
+- [NXDRIVE-3179](https://hyland.atlassian.net/browse/NXDRIVE-3179): Drive should handle Encoded and not Encoded urls for direct transfer
 
 ## Direct Download
 

--- a/docs/changes/7.0.0.md
+++ b/docs/changes/7.0.0.md
@@ -1,6 +1,6 @@
 # 7.0.0
 
-Release date: `2026-xx-xx`
+Release date: `2026-12-05`
 
 ## Core
 

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -957,6 +957,23 @@ def parse_protocol_url(url_string: str, /) -> Optional[Dict[str, str]]:
             "command": cmd,
             "remote_path": remote_path,
         }
+    # web ui - non-compressed format (plain URL with http/https scheme)
+    elif cmd == "direct-transfer" and parsed_url.get("path", "").lower().startswith(
+        ("http/", "https/")
+    ):
+        try:
+            path_part = parsed_url["path"]
+            parts = re.split("/nuxeo", path_part, maxsplit=1)
+            if len(parts) < 2:
+                raise ValueError("Missing /nuxeo in URL")
+            remote_path = parts[1]
+        except Exception:
+            log.exception(f"URL is not valid: {url_string}")
+            return None
+        return {
+            "command": cmd,
+            "remote_path": remote_path,
+        }
     return {"command": cmd, "filepath": parsed_url["path"]}
 
 

--- a/nxdrive/utils.py
+++ b/nxdrive/utils.py
@@ -32,7 +32,7 @@ from typing import (
     Tuple,
     Union,
 )
-from urllib.parse import parse_qsl, urlparse, urlsplit, urlunsplit
+from urllib.parse import parse_qsl, unquote, urlparse, urlsplit, urlunsplit
 from uuid import uuid4
 
 from nuxeo.utils import get_digest_algorithm, get_digest_hash
@@ -966,7 +966,7 @@ def parse_protocol_url(url_string: str, /) -> Optional[Dict[str, str]]:
             parts = re.split("/nuxeo", path_part, maxsplit=1)
             if len(parts) < 2:
                 raise ValueError("Missing /nuxeo in URL")
-            remote_path = parts[1]
+            remote_path = unquote(parts[1])
         except Exception:
             log.exception(f"URL is not valid: {url_string}")
             return None

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1619,6 +1619,39 @@ class TestParseProtocolUrlDirectTransfer:
         assert info["command"] == "direct-transfer"
         assert info["remote_path"] == "/default-domain/ws"
 
+    # --- Percent-encoded non-compressed URL tests ---
+
+    def test_non_compressed_url_with_percent_encoded_spaces(self):
+        """Non-compressed web URL with %20 encoded spaces decoded to real spaces."""
+        url = (
+            "nxdrive://direct-transfer/https/server.com/nuxeo/"
+            "default-domain/UserWorkspaces/admin/new%20folder"
+        )
+        info = nxdrive.utils.parse_protocol_url(url)
+        assert info is not None
+        assert info["command"] == "direct-transfer"
+        assert info["remote_path"] == "/default-domain/UserWorkspaces/admin/new folder"
+
+    def test_non_compressed_url_with_multiple_encoded_spaces(self):
+        """Multiple %20 in the path are all decoded."""
+        url = (
+            "nxdrive://direct-transfer/https/server.com/nuxeo/"
+            "default-domain/My%20Workspace/Sub%20Folder"
+        )
+        info = nxdrive.utils.parse_protocol_url(url)
+        assert info is not None
+        assert info["remote_path"] == "/default-domain/My Workspace/Sub Folder"
+
+    def test_non_compressed_url_without_encoding_unchanged(self):
+        """URL without percent-encoding is returned as-is."""
+        url = (
+            "nxdrive://direct-transfer/https/server.com/nuxeo/"
+            "default-domain/plain-folder"
+        )
+        info = nxdrive.utils.parse_protocol_url(url)
+        assert info is not None
+        assert info["remote_path"] == "/default-domain/plain-folder"
+
 
 class TestShowDirectDownloadWindow:
     """Tests for Application.show_direct_download_window()."""

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1600,15 +1600,15 @@ class TestParseProtocolUrlDirectTransfer:
         """Non-compressed web URL with a deep nested path."""
         url = (
             "nxdrive://direct-transfer/https/"
-            "drive-2025.beta.nuxeocloud.com/nuxeo/"
-            "default-domain/UserWorkspaces/nco-admin/Roy/Spaced Folder"
+            "server.com/nuxeo/"
+            "default-domain/UserWorkspaces/admin/Roy/Spaced Folder"
         )
         info = nxdrive.utils.parse_protocol_url(url)
         assert info is not None
         assert info["command"] == "direct-transfer"
         assert (
             info["remote_path"]
-            == "/default-domain/UserWorkspaces/nco-admin/Roy/Spaced Folder"
+            == "/default-domain/UserWorkspaces/admin/Roy/Spaced Folder"
         )
 
     def test_non_compressed_url_case_insensitive_scheme(self):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1517,7 +1517,7 @@ class TestDecompressTransferUrl:
 
 
 class TestParseProtocolUrlDirectTransfer:
-    """Tests for parse_protocol_url with compressed direct-transfer URLs."""
+    """Tests for parse_protocol_url with compressed and non-compressed direct-transfer URLs."""
 
     def test_compressed_url_parsed_correctly(self):
         url = _build_compressed_transfer_url(
@@ -1561,6 +1561,63 @@ class TestParseProtocolUrlDirectTransfer:
         url = _build_compressed_transfer_url("https", "server.com/no-nuxeo-here/path")
         info = nxdrive.utils.parse_protocol_url(url)
         assert info is None
+
+    # --- Non-compressed web URL tests ---
+
+    def test_non_compressed_https_url_parsed_correctly(self):
+        """Non-compressed HTTPS web URL extracts remote_path correctly."""
+        url = "nxdrive://direct-transfer/https/server.com/nuxeo/default-domain/UserWorkspaces/admin/MyFolder"
+        info = nxdrive.utils.parse_protocol_url(url)
+        assert info is not None
+        assert info["command"] == "direct-transfer"
+        assert info["remote_path"] == "/default-domain/UserWorkspaces/admin/MyFolder"
+
+    def test_non_compressed_http_url_parsed_correctly(self):
+        """Non-compressed HTTP web URL extracts remote_path correctly."""
+        url = "nxdrive://direct-transfer/http/local.server/nuxeo/default-domain/workspaces"
+        info = nxdrive.utils.parse_protocol_url(url)
+        assert info is not None
+        assert info["command"] == "direct-transfer"
+        assert info["remote_path"] == "/default-domain/workspaces"
+
+    def test_non_compressed_url_with_spaces(self):
+        """Non-compressed web URL with spaces in folder name."""
+        url = "nxdrive://direct-transfer/https/server.com/nuxeo/default-domain/UserWorkspaces/admin/Spaced Folder"
+        info = nxdrive.utils.parse_protocol_url(url)
+        assert info is not None
+        assert info["command"] == "direct-transfer"
+        assert (
+            info["remote_path"] == "/default-domain/UserWorkspaces/admin/Spaced Folder"
+        )
+
+    def test_non_compressed_url_missing_nuxeo_returns_none(self):
+        """Non-compressed web URL without /nuxeo returns None."""
+        url = "nxdrive://direct-transfer/https/server.com/no-nuxeo-here/path"
+        info = nxdrive.utils.parse_protocol_url(url)
+        assert info is None
+
+    def test_non_compressed_url_deep_path(self):
+        """Non-compressed web URL with a deep nested path."""
+        url = (
+            "nxdrive://direct-transfer/https/"
+            "drive-2025.beta.nuxeocloud.com/nuxeo/"
+            "default-domain/UserWorkspaces/nco-admin/Roy/Spaced Folder"
+        )
+        info = nxdrive.utils.parse_protocol_url(url)
+        assert info is not None
+        assert info["command"] == "direct-transfer"
+        assert (
+            info["remote_path"]
+            == "/default-domain/UserWorkspaces/nco-admin/Roy/Spaced Folder"
+        )
+
+    def test_non_compressed_url_case_insensitive_scheme(self):
+        """Non-compressed web URL with mixed-case scheme prefix."""
+        url = "nxdrive://direct-transfer/HTTPS/server.com/nuxeo/default-domain/ws"
+        info = nxdrive.utils.parse_protocol_url(url)
+        assert info is not None
+        assert info["command"] == "direct-transfer"
+        assert info["remote_path"] == "/default-domain/ws"
 
 
 class TestShowDirectDownloadWindow:


### PR DESCRIPTION
…rect transfer

## Summary by Sourcery

Handle non-compressed direct-transfer Web UI URLs alongside existing compressed format support.

New Features:
- Support parsing non-compressed http/https direct-transfer protocol URLs to extract the remote path.

Documentation:
- Document NXDRIVE-3179 in the 7.0.0 release notes under Direct Transfer.

Tests:
- Add unit tests covering non-compressed direct-transfer URLs, including http/https schemes, paths with spaces, deep paths, missing /nuxeo, and case-insensitive schemes.