### PR TITLE
NXDRIVE-3230: Deploy Nuxeo Drive Release Artifacts to Both Community Server and S3 Bucket

### DIFF
--- a/.github/workflows/beta_to_prod.yml
+++ b/.github/workflows/beta_to_prod.yml
@@ -37,3 +37,162 @@ jobs:
 
       - name: Ready for promotion
         run: bash tools/deploy.sh ${{ github.event.inputs.betaVersion }}
+
+  beta-to-prod-s3:
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      S3_BUCKET: drive.software-channels.hyland.com
+      # Public base URL used when building links inside the generated
+      # index.html pages.
+      ROOT_URL: https://drive.software-channels.hyland.com
+      S3_PREFIX: nuxeo/drive-updates/
+    permissions:
+      id-token: write # Required for OIDC authentication with AWS
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.13 # XXX_PYTHON
+
+      - name: Install python dependencies
+        run: python -m pip install pyyaml
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+        with:
+          role-to-assume: arn:aws:iam::744709874192:role/AlfrescoCI/nuxeo-drive-software-channel-upload
+          aws-region: us-east-1
+
+      - name: Fetch versions.yml
+        run: |
+          bucket="$S3_BUCKET"
+          key="${S3_PREFIX}versions.yml"
+          aws_err_file="$(mktemp)"
+
+          if aws s3api get-object --bucket "$bucket" --key "$key" versions.yml 2>"$aws_err_file"; then
+            echo ">>> versions.yml found in S3 and downloaded"
+          else
+            aws_error="$(cat "$aws_err_file")"
+
+            if echo "$aws_error" | grep -Eq 'NoSuchKey|404|Not Found'; then
+              echo ">>> versions.yml not found in S3, creating an empty one"
+              : > versions.yml
+              aws s3 cp versions.yml "s3://$bucket/$key"
+            elif echo "$aws_error" | grep -q 'AccessDenied'; then
+              echo ">>> Access denied while reading s3://$bucket/$key"
+              echo "$aws_error"
+              rm -f "$aws_err_file"
+              exit 1
+            else
+              echo ">>> Unexpected AWS error while reading s3://$bucket/$key"
+              echo "$aws_error"
+              rm -f "$aws_err_file"
+              exit 1
+            fi
+          fi
+
+          rm -f "$aws_err_file"
+
+      - name: Move beta packages to release
+        shell: bash --noprofile --norc -o pipefail {0} # Required to capture exit codes and messages
+        run: |
+          beta_version="${{ github.event.inputs.betaVersion }}"
+          files=(
+            "nuxeo-drive-$beta_version.exe"
+            "nuxeo-drive-$beta_version-admin.exe"
+            "nuxeo-drive-$beta_version.dmg"
+            "nuxeo-drive-$beta_version-x86_64.AppImage"
+            "nuxeo-drive-addons.exe"
+          )
+
+          failed=0
+          for file in "${files[@]}"; do
+            src="s3://$S3_BUCKET/${S3_PREFIX}beta/$file"
+            dst="s3://$S3_BUCKET/${S3_PREFIX}release/$file"
+
+            echo ">>> Moving $file from beta to release"
+            output=$(aws s3 mv "$src" "$dst" 2>&1)
+            exit_code=$?
+
+            if [ $exit_code -ne 0 ]; then
+              echo ">>> !! Error moving $file, attempting copy instead !!"
+              echo "$output"
+              output=$(aws s3 cp "$src" "$dst" 2>&1)
+              exit_code=$?
+              if [ $exit_code -ne 0 ]; then
+                echo ">>> !! Error copying $file to release !!"
+                echo "$output"
+                failed=1
+              else
+                echo ">>> $file copied to release successfully"
+                echo ">>> !! Make sure to clean-up $file in beta S3 manually !!"
+              fi
+            else
+              echo ">>> $file moved to release successfully"
+            fi
+          done
+
+          if [ $failed -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Promote beta version in versions.yml
+        run: |
+          beta_version="${{ github.event.inputs.betaVersion }}"
+          echo ">>> Promoting beta version $beta_version to release in versions.yml"
+          python tools/versions.py --promote "$beta_version" --type "release"
+          echo ">>> Copying updated versions.yml to S3"
+          aws s3 cp versions.yml "s3://$S3_BUCKET/$S3_PREFIX" --cache-control "no-cache, max-age=0, must-revalidate"
+          echo ">>> Removing versions.yml from local workspace"
+          rm -f versions.yml
+
+      - name: Generate and upload index.html pages
+        # Don't fail the promotion if index generation/upload fails; the
+        # pages are informational and can be uploaded manually from the
+        # artifact produced by the next step.
+        continue-on-error: true
+        run: |
+          # Promotion moves files out of beta/ into release/, so both
+          # folder listings need to be refreshed. The root index is always
+          # regenerated to keep its timestamp current.
+          python tools/generate_s3_index.py \
+            --bucket "$S3_BUCKET" \
+            --prefix "$S3_PREFIX" \
+            --root-url "$ROOT_URL" \
+            --product-name "Nuxeo Drive" \
+            --folders alpha beta release \
+            --update-folders beta release \
+            --extra-files versions.yml \
+            --output-dir index_pages
+
+          cache_ctl="no-cache, max-age=0, must-revalidate"
+
+          aws s3 cp index_pages/index.html \
+            "s3://$S3_BUCKET/${S3_PREFIX}index.html" \
+            --content-type "text/html; charset=utf-8" \
+            --cache-control "$cache_ctl"
+
+          for folder in beta release; do
+            aws s3 cp "index_pages/${folder}/index.html" \
+              "s3://$S3_BUCKET/${S3_PREFIX}${folder}/index.html" \
+              --content-type "text/html; charset=utf-8" \
+              --cache-control "$cache_ctl"
+          done
+
+      - name: Upload generated index.html pages as artifact
+        # Run even if the previous step failed so we always have a copy that
+        # can be uploaded to S3 manually if needed.
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: nuxeo-s3-index-pages
+          path: index_pages/
+          if-no-files-found: warn

--- a/.github/workflows/beta_to_prod_alfresco.yml
+++ b/.github/workflows/beta_to_prod_alfresco.yml
@@ -138,6 +138,7 @@ jobs:
             --bucket "$S3_BUCKET" \
             --prefix "$S3_PREFIX" \
             --root-url "$ROOT_URL" \
+            --product-name "Hyland Drive for Alfresco" \
             --folders alpha beta release \
             --update-folders beta release \
             --extra-files versions.yml \

--- a/.github/workflows/beta_to_prod_alfresco.yml
+++ b/.github/workflows/beta_to_prod_alfresco.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
-          role-to-assume: arn:aws:iam::744709874192:role/AlfrescoCI/nuxeo-drive-software-channel-upload
+          role-to-assume: arn:aws:iam::744709874192:role/AlfrescoCI/alfresco-drive-software-channel-upload
           aws-region: us-east-1
 
       - name: Fetch versions.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,6 @@ jobs:
           echo "signExe=${{ github.event.inputs.signExe }}" >> $GITHUB_OUTPUT
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.inputs.branch }}
 
       #
       # Global
@@ -277,8 +275,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.inputs.branch }}
 
       - name: Extract branch name
         shell: bash
@@ -358,7 +354,14 @@ jobs:
       - name: Checkout current branch
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.inputs.branch }}
+          fetch-depth: 0
+
+      - name: Bump the version number
+        if: github.event.inputs.releaseType == 'alpha' || github.event.inputs.releaseType == ''
+        run: |
+          git config user.email ${{ env.GITHUB_EMAILID }}
+          git config user.name ${{ env.GITHUB_USERNAME }}
+          bash tools/bump-alpha-version.sh || exit 1
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -374,9 +377,6 @@ jobs:
           pattern: package-distributions*
           path: dist/
           merge-multiple: true
-
-      - name: Install curl
-        run: sudo apt-get update && sudo apt-get install -y curl
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
@@ -421,6 +421,9 @@ jobs:
             aws s3 cp dist/ "s3://$S3_BUCKET/${S3_PREFIX}alpha/" --recursive
           elif [ "$release" = "release" ]; then
             aws s3 cp dist/ "s3://$S3_BUCKET/${S3_PREFIX}beta/" --recursive
+          else
+            echo ">>> Invalid release type: $release"
+            exit 1
           fi
 
       - name: Update versions.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,3 +340,156 @@ jobs:
       - name: Cancel the release
         if: failure() || cancelled()
         run: bash tools/release.sh --cancel
+
+  deploy_s3:
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      S3_BUCKET: drive.software-channels.hyland.com
+      # Public base URL used when building links inside the generated
+      # index.html pages.
+      ROOT_URL: https://drive.software-channels.hyland.com
+      S3_PREFIX: nuxeo/drive-updates/
+    needs: [release]
+    permissions:
+      id-token: write   # required for requesting the OIDC token
+      contents: read
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.13 # XXX_PYTHON
+
+      - name: Install python dependencies
+        run: python -m pip install pyyaml
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: package-distributions*
+          path: dist/
+          merge-multiple: true
+
+      - name: Install curl
+        run: sudo apt-get update && sudo apt-get install -y curl
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+        with:
+          role-to-assume: arn:aws:iam::744709874192:role/AlfrescoCI/nuxeo-drive-software-channel-upload
+          aws-region: us-east-1
+
+      - name: Fetch versions.yml
+        run: |
+          bucket="$S3_BUCKET"
+          key="${S3_PREFIX}versions.yml"
+          aws_err_file="$(mktemp)"
+
+          if aws s3api get-object --bucket "$bucket" --key "$key" versions.yml 2>"$aws_err_file"; then
+            echo ">>> versions.yml found in S3 and downloaded"
+          else
+            aws_error="$(cat "$aws_err_file")"
+
+            if echo "$aws_error" | grep -Eq 'NoSuchKey|404|Not Found'; then
+              echo ">>> versions.yml not found in S3, creating an empty one"
+              : > versions.yml
+              aws s3 cp versions.yml "s3://$bucket/$key"
+            elif echo "$aws_error" | grep -q 'AccessDenied'; then
+              echo ">>> Access denied while reading s3://$bucket/$key"
+              echo "$aws_error"
+              rm -f "$aws_err_file"
+              exit 1
+            else
+              echo ">>> Unexpected AWS error while reading s3://$bucket/$key"
+              echo "$aws_error"
+              rm -f "$aws_err_file"
+              exit 1
+            fi
+          fi
+
+          rm -f "$aws_err_file"
+
+      - name: Upload artifacts to software channel
+        run: |
+          release="${{ github.event.inputs.releaseType }}"
+          if [ "$release" = "alpha" ] || [ -z "$release" ]; then
+            aws s3 cp dist/ "s3://$S3_BUCKET/${S3_PREFIX}alpha/" --recursive
+          elif [ "$release" = "release" ]; then
+            aws s3 cp dist/ "s3://$S3_BUCKET/${S3_PREFIX}beta/" --recursive
+          fi
+
+      - name: Update versions.yml
+        run: |
+          drive_version="$(grep __version__ nxdrive/__init__.py | cut -d'"' -f2)"
+          type="${{ github.event.inputs.releaseType }}"
+          echo ">>> drive_version=$drive_version"
+          if [ "$type" = "alpha" ] || [ -z "$type" ]; then
+            type="alpha"
+          elif [ "$type" = "release" ]; then
+            type="beta"
+          else
+            echo ">>> Invalid release type: $type"
+            exit 1
+          fi
+          echo ">>> type=$type"
+          python tools/versions.py --add "$drive_version" --type "$type" || exit 1
+          python tools/versions.py --merge || exit 1
+          aws s3 cp versions.yml "s3://$S3_BUCKET/$S3_PREFIX" --cache-control "no-cache, max-age=0, must-revalidate"
+          python tools/versions.py --delete "$drive_version" || exit 1
+          rm versions.yml
+
+      - name: Generate and upload index.html pages
+        # Don't fail the whole release if index generation/upload fails; the
+        # pages are informational and can be uploaded manually from the
+        # artifact produced by the next step.
+        continue-on-error: true
+        run: |
+          # Only the folder that was just written to needs its listing
+          # refreshed. The root index is always refreshed so its "generated
+          # on" timestamp stays current.
+          release="${{ github.event.inputs.releaseType }}"
+          case "$release" in
+            ""|alpha) update_folder="alpha" ;;
+            release) update_folder="beta" ;;
+            *)
+              echo ">>> Unknown releaseType '$release', skipping index update"
+              exit 0
+              ;;
+          esac
+
+          python tools/generate_s3_index.py \
+            --bucket "$S3_BUCKET" \
+            --prefix "$S3_PREFIX" \
+            --root-url "$ROOT_URL" \
+            --product-name "Nuxeo Drive" \
+            --folders alpha beta release \
+            --update-folders "$update_folder" \
+            --extra-files versions.yml \
+            --output-dir index_pages
+
+          cache_ctl="no-cache, max-age=0, must-revalidate"
+
+          aws s3 cp index_pages/index.html \
+            "s3://$S3_BUCKET/${S3_PREFIX}index.html" \
+            --content-type "text/html; charset=utf-8" \
+            --cache-control "$cache_ctl"
+
+          aws s3 cp "index_pages/${update_folder}/index.html" \
+            "s3://$S3_BUCKET/${S3_PREFIX}${update_folder}/index.html" \
+            --content-type "text/html; charset=utf-8" \
+            --cache-control "$cache_ctl"
+
+      - name: Upload generated index.html pages as artifact
+        # Run even if the previous step failed so we always have a copy that
+        # can be uploaded to S3 manually if needed.
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: nuxeo-s3-index-pages
+          path: index_pages/
+          if-no-files-found: warn

--- a/.github/workflows/release_alfresco.yml
+++ b/.github/workflows/release_alfresco.yml
@@ -41,8 +41,6 @@ jobs:
           echo "dockerNamespace=${{ github.event.inputs.dockerNamespace }}" >> $GITHUB_OUTPUT
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.inputs.branch }}
 
       #
       # Global
@@ -269,8 +267,6 @@ jobs:
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.inputs.branch }}
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -286,9 +282,6 @@ jobs:
           pattern: package-distributions*
           path: dist/
           merge-multiple: true
-
-      - name: Install curl
-        run: sudo apt-get update && sudo apt-get install -y curl
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
@@ -333,6 +326,9 @@ jobs:
             aws s3 cp dist/ "s3://$S3_BUCKET/alfresco/drive-updates/alpha/" --recursive
           elif [ "$release" = "release" ]; then
             aws s3 cp dist/ "s3://$S3_BUCKET/alfresco/drive-updates/beta/" --recursive
+          else
+            echo ">>> Invalid release type: $release"
+            exit 1
           fi
 
       - name: Update versions.yml

--- a/.github/workflows/release_alfresco.yml
+++ b/.github/workflows/release_alfresco.yml
@@ -293,7 +293,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
-          role-to-assume: arn:aws:iam::744709874192:role/AlfrescoCI/nuxeo-drive-software-channel-upload
+          role-to-assume: arn:aws:iam::744709874192:role/AlfrescoCI/alfresco-drive-software-channel-upload
           aws-region: us-east-1
 
       - name: Fetch versions.yml

--- a/.github/workflows/release_alfresco.yml
+++ b/.github/workflows/release_alfresco.yml
@@ -380,6 +380,7 @@ jobs:
             --bucket "$S3_BUCKET" \
             --prefix "$S3_PREFIX" \
             --root-url "$ROOT_URL" \
+            --product-name "Hyland Drive for Alfresco" \
             --folders alpha beta release \
             --update-folders "$update_folder" \
             --extra-files versions.yml \

--- a/docs/changes/7.1.0.md
+++ b/docs/changes/7.1.0.md
@@ -36,6 +36,7 @@ Release date: `2026-xx-xx`
 - [NXDRIVE-3209](https://hyland.atlassian.net/browse/NXDRIVE-3209): Update the build steps and workflow for dual build
 - [NXDRIVE-3218](https://hyland.atlassian.net/browse/NXDRIVE-3218): Alfresco: Update deployment server for release and auto-update
 - [NXDRIVE-3220](https://hyland.atlassian.net/browse/NXDRIVE-3220): Alfresco : Update MacOS Notarization process and Windows Signing process
+- [NXDRIVE-3230](https://hyland.atlassian.net/browse/NXDRIVE-3230): Deploy Nuxeo Drive Release Artifacts to Both Community Server and S3 Bucket
 
 ## Security
 

--- a/tools/generate_s3_index.py
+++ b/tools/generate_s3_index.py
@@ -139,7 +139,7 @@ def _page(title, body):
     )
 
 
-def _render_root(root_url, prefix, folders, extra_files):
+def _render_root(root_url, prefix, folders, extra_files, product_name=None):
     items = []
     for folder in folders:
         # Link straight to the folder's index.html so the page works even
@@ -157,10 +157,11 @@ def _render_root(root_url, prefix, folders, extra_files):
         )
 
     body = "  <ul>\n" + "\n".join(items) + "\n  </ul>"
-    return _page("Hyland Drive for Alfresco – Software Channel", body)
+    title = product_name or "Hyland Drive for Alfresco"
+    return _page(f"{title} – Software Channel", body)
 
 
-def _render_folder(folder, root_url, prefix, files):
+def _render_folder(folder, root_url, prefix, files, product_name=None):
     rows = []
     for entry in files:
         href = f"{root_url}/{prefix}{folder}/{entry['name']}"
@@ -189,7 +190,8 @@ def _render_folder(folder, root_url, prefix, files):
     body = (
         f'  <p><a href="{html.escape(parent)}">&#8592; Back to root</a></p>\n' + table
     )
-    return _page(f"Alfresco Drive – {folder}", body)
+    title = product_name or "Alfresco Drive"
+    return _page(f"{title} – {folder}", body)
 
 
 def main():
@@ -201,6 +203,10 @@ def main():
         help="S3 key prefix (must end with '/').",
     )
     parser.add_argument("--root-url", required=True, help="Public base URL.")
+    parser.add_argument(
+        "--product-name",
+        help="Product name used in page titles.",
+    )
     parser.add_argument(
         "--folders",
         nargs="+",
@@ -237,7 +243,9 @@ def main():
 
     _write(
         os.path.join(args.output_dir, "index.html"),
-        _render_root(root_url, prefix, args.folders, args.extra_files),
+        _render_root(
+            root_url, prefix, args.folders, args.extra_files, args.product_name
+        ),
     )
 
     update_folders = args.update_folders
@@ -256,7 +264,7 @@ def main():
         files = _list_folder(args.bucket, f"{prefix}{folder}")
         _write(
             os.path.join(args.output_dir, folder, "index.html"),
-            _render_folder(folder, root_url, prefix, files),
+            _render_folder(folder, root_url, prefix, files, args.product_name),
         )
 
 


### PR DESCRIPTION
## Summary by Sourcery

Add CI support for publishing Nuxeo Drive release artifacts to an S3-based software channel and align Alfresco workflows with updated AWS roles and index page branding.

New Features:
- Introduce beta-to-prod S3 workflow to promote Nuxeo Drive beta artifacts to release in the software channel bucket.
- Add deploy_s3 job to the release workflow to upload built Nuxeo Drive distributions to S3 and maintain versions metadata and indexes.

Enhancements:
- Extend S3 index generation script to accept a configurable product name and update page titles accordingly.
- Update Alfresco beta-to-prod and release workflows to use the new product-name option when generating S3 index pages.

Build:
- Configure GitHub Actions workflows for Nuxeo Drive to handle S3-based artifact promotion and release publishing, including AWS OIDC credentials.
- Change AWS role-to-assume in Alfresco-related workflows to the alfresco-drive-software-channel-upload role.