### PR TITLE
NXDRIVE-3201: [Implementation] Publish Nuxeo Drive release tag on successful GA release

### DIFF
--- a/.github/workflows/beta_to_prod.yml
+++ b/.github/workflows/beta_to_prod.yml
@@ -1,6 +1,6 @@
 name: Beta to production
 permissions:
-  contents: read
+  contents: write # Required to publish release tag
   pull-requests: read
 
 on:
@@ -196,3 +196,14 @@ jobs:
           name: nuxeo-s3-index-pages
           path: index_pages/
           if-no-files-found: warn
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="${{ github.event.inputs.betaVersion }}"
+          gh release create "release-$version" \
+            --verify-tag \
+            --title "Release $version" \
+            --generate-notes \
+            --latest

--- a/docs/changes/7.1.0.md
+++ b/docs/changes/7.1.0.md
@@ -2,6 +2,11 @@
 
 Release date: `2026-xx-xx`
 
+## CI/CD
+
+- [NXDRIVE-3201](https://hyland.atlassian.net/browse/NXDRIVE-3201): [Implementation] Publish Nuxeo Drive release tag on successful GA release
+- [NXDRIVE-3208](https://hyland.atlassian.net/browse/NXDRIVE-3208): [SPIKE] Automate release tag publish on GitHub
+
 ## Core
 
 - [NXDRIVE-3163](https://hyland.atlassian.net/browse/NXDRIVE-3163): Align on user and group generated UUID at Drive


### PR DESCRIPTION
## Summary by Sourcery

Automate publishing a GitHub release tag as part of the beta-to-production workflow and document the change in the 7.1.0 release notes.

CI:
- Update the beta-to-production GitHub Actions workflow to publish a verified GitHub release tagged with the GA version and marked as latest.

Documentation:
- Add CI/CD release automation notes for NXDRIVE-3201 and NXDRIVE-3208 to the 7.1.0 change log.