### PR TITLE
NXDRIVE-3264: [BUG] Alfresco Drive keeps on syncing after resolving conflicts

### DIFF
--- a/docs/changes/8.0.0.md
+++ b/docs/changes/8.0.0.md
@@ -75,6 +75,7 @@ Release date: `2026-xx-xx`
 - [NXDRIVE-3229](https://hyland.atlassian.net/browse/NXDRIVE-3229): [BUG] Alfresco Drive - Unsynchronized files get re-downloaded
 - [NXDRIVE-3256](https://hyland.atlassian.net/browse/NXDRIVE-3256): Pause and Resume Actions Not Working from Activity Feed During Sync in Nuxeo Drive 7.1.0.30 (PySide6)
 - [NXDRIVE-3260](https://hyland.atlassian.net/browse/NXDRIVE-3260): Intermittent Issue: Conflict Files Not Displayed When Clicking Conflict Notification in Activity Feed
+- [NXDRIVE-3264](https://hyland.atlassian.net/browse/NXDRIVE-3264): [BUG] Alfresco Drive keeps on syncing after resolving conflicts
 
 ## Task Management
 

--- a/nxdrive/alfresco/client/remote.py
+++ b/nxdrive/alfresco/client/remote.py
@@ -46,6 +46,10 @@ ALFRESCO_UPLOAD_BLOCK_SIZE = 65536
 UPLOAD_PROGRESS_INTERVAL = 1.0
 UPLOAD_PROGRESS_PERCENT_STEP = 1.0
 
+#: Most bytes we are willing to stream to emulate a ranged read when the
+#: server ignores the ``Range`` header.
+RANGE_FALLBACK_MAX_BYTES = 20 * 1024 * 1024
+
 
 class AlfrescoRemote:
     """Remote client for Alfresco Content Services.
@@ -254,13 +258,17 @@ class AlfrescoRemote:
                 return child
         return None
 
-    def get_content_range(self, node_id: str, start: int, length: int, /) -> bytes:
+    def get_content_range(
+        self, node_id: str, start: int, length: int, /
+    ) -> Optional[bytes]:
         """Return ``length`` bytes of a node's content starting at ``start``.
 
         The Alfresco SDK exposes no ``Range`` parameter, so the request is
-        issued directly on the client session.  Servers that ignore the
-        header answer ``200`` with the whole body; in that case the stream
-        is sliced and abandoned as soon as the window has been read.
+        issued directly on the client session.  A server honouring the
+        header answers ``206``; one ignoring it answers ``200`` with the
+        whole body, and reaching ``start`` then costs everything before it.
+        Return ``None`` when emulating the window that way would exceed
+        ``RANGE_FALLBACK_MAX_BYTES``, so the caller can degrade instead.
         """
         if length <= 0:
             return b""
@@ -278,13 +286,27 @@ class AlfrescoRemote:
             if resp.status_code == 206:
                 return resp.content[:length]
 
-            buf = bytearray()
             wanted = start + length
+            if wanted > RANGE_FALLBACK_MAX_BYTES:
+                log.warning(
+                    f"Server ignored the Range header for {node_id!r}: refusing "
+                    f"to stream {wanted} bytes to reach offset {start}"
+                )
+                return None
+
+            # Discard everything before the window so peak memory stays at
+            # ``length`` instead of ``start + length``.
+            buf = bytearray()
+            consumed = 0
             for chunk in resp.iter_content(ALFRESCO_UPLOAD_BLOCK_SIZE):
-                buf.extend(chunk)
-                if len(buf) >= wanted:
+                chunk_start = consumed
+                consumed += len(chunk)
+                if consumed <= start:
+                    continue
+                buf.extend(chunk[max(0, start - chunk_start) :])
+                if len(buf) >= length:
                     break
-            return bytes(buf[start:wanted])
+            return bytes(buf[:length])
         finally:
             resp.close()
 

--- a/nxdrive/alfresco/client/remote.py
+++ b/nxdrive/alfresco/client/remote.py
@@ -247,6 +247,47 @@ class AlfrescoRemote:
         """Return a streaming response for a node's content."""
         return self.client.nodes.get_content_stream(node_id)
 
+    def find_file_child(self, parent_id: str, name: str, /) -> Optional[Node]:
+        """Return the first *file* child of ``parent_id`` named ``name``."""
+        for child in self.client.nodes.iter_children(parent_id):
+            if child.name == name and child.is_file:
+                return child
+        return None
+
+    def get_content_range(self, node_id: str, start: int, length: int, /) -> bytes:
+        """Return ``length`` bytes of a node's content starting at ``start``.
+
+        The Alfresco SDK exposes no ``Range`` parameter, so the request is
+        issued directly on the client session.  Servers that ignore the
+        header answer ``200`` with the whole body; in that case the stream
+        is sliced and abandoned as soon as the window has been read.
+        """
+        if length <= 0:
+            return b""
+
+        url = f"{self.client.api_url}/nodes/{node_id}/content"
+        end = start + length - 1
+        resp = self.client.session.get(
+            url,
+            headers={"Range": f"bytes={start}-{end}"},
+            stream=True,
+            timeout=self.client.timeout,
+        )
+        try:
+            resp.raise_for_status()
+            if resp.status_code == 206:
+                return resp.content[:length]
+
+            buf = bytearray()
+            wanted = start + length
+            for chunk in resp.iter_content(ALFRESCO_UPLOAD_BLOCK_SIZE):
+                buf.extend(chunk)
+                if len(buf) >= wanted:
+                    break
+            return bytes(buf[start:wanted])
+        finally:
+            resp.close()
+
     def download_content(
         self,
         node_id: str,

--- a/nxdrive/alfresco/engine/engine.py
+++ b/nxdrive/alfresco/engine/engine.py
@@ -414,6 +414,8 @@ class AlfrescoEngine(Engine):
           we reset to ``locally_modified`` (the conflict was spurious —
           typically a stale watcher poll or a same-content re-upload).
           Otherwise we emit ``newConflict`` so the systray surfaces it.
+          The check is skipped for a document created on both sides,
+          which has no sync history to be fresh relative to.
         - **Folders:** auto-resolve when the local xattr ``remote_id``
           matches ``pair.remote_ref`` (same node, no real conflict).
 
@@ -425,8 +427,15 @@ class AlfrescoEngine(Engine):
             log.debug("Alfresco conflict resolver: empty pair, skipping")
             return
 
+        # Created on both sides: ``last_remote_updated`` was written from
+        # this very node when the pair was linked, so the freshness check
+        # below would always report "unchanged" and cancel a real conflict.
+        created_both_sides = (
+            pair.local_state == "created" and pair.remote_state == "created"
+        )
+
         # File path: timestamp-based freshness check.
-        if not pair.folderish and pair.remote_ref:
+        if not pair.folderish and pair.remote_ref and not created_both_sides:
             remote_info = None
             try:
                 remote_info = self.remote.get_fs_info(pair.remote_ref)
@@ -470,6 +479,11 @@ class AlfrescoEngine(Engine):
             log.warning(
                 f"Alfresco conflict resolver: surfacing conflict for "
                 f"{pair.local_name!r}"
+            )
+            # Stop any processor still working this path, else an in-flight
+            # upload completes and silently overwrites the remote.
+            self.queue_manager.interrupt_processors_on(
+                pair.local_path, exact_match=True
             )
             self.newConflict.emit(row_id)
             self.manager.osi.send_sync_status(pair, self.local.abspath(pair.local_path))

--- a/nxdrive/alfresco/engine/processor.py
+++ b/nxdrive/alfresco/engine/processor.py
@@ -6,6 +6,7 @@ items (remotely_created, locally_created, etc.) using the
 ``AlfrescoRemote`` adapter methods.
 """
 
+import hashlib
 import shutil
 import sqlite3
 from contextlib import suppress
@@ -46,6 +47,14 @@ if TYPE_CHECKING:
 __all__ = ("AlfrescoProcessor",)
 
 log = getLogger(__name__)
+
+#: Bytes hashed from the head *and* from the tail when comparing a local
+#: file against a same-named remote node.  Files up to twice this size are
+#: compared in full.
+PARTIAL_COMPARE_SIZE = 10 * 1024 * 1024
+
+#: Attempts allowed when reading remote content for that comparison.
+PARTIAL_COMPARE_ATTEMPTS = 3
 
 
 def _fmt_remote_ts(ts: Any) -> str:
@@ -165,6 +174,104 @@ class AlfrescoProcessor(_ProcessorBase):
             f"(remote={doc_pair.remote_ref!r})"
         )
         self.dao._force_sync(doc_pair, "modified", "modified", "conflicted")
+
+    @staticmethod
+    def _local_head_tail_digest(path: Path, size: int, /) -> str:
+        limit = PARTIAL_COMPARE_SIZE
+        h = hashlib.md5(usedforsecurity=False)
+        with path.open("rb") as f:
+            if size <= 2 * limit:
+                for chunk in iter(lambda: f.read(limit), b""):
+                    h.update(chunk)
+            else:
+                h.update(f.read(limit))
+                f.seek(size - limit)
+                h.update(f.read(limit))
+        return h.hexdigest()
+
+    def _remote_head_tail_digest(self, node_id: str, size: int, /) -> str:
+        limit = PARTIAL_COMPARE_SIZE
+        h = hashlib.md5(usedforsecurity=False)
+        if size <= 2 * limit:
+            h.update(self.remote.get_content_range(node_id, 0, size))
+        else:
+            h.update(self.remote.get_content_range(node_id, 0, limit))
+            h.update(self.remote.get_content_range(node_id, size - limit, limit))
+        return h.hexdigest()
+
+    def _conflicting_remote_twin(
+        self, doc_pair: DocPair, parent_ref: str, /
+    ) -> Optional[Any]:
+        """Return a same-named remote node holding different content, if any.
+
+        Called before uploading a never-linked local creation: Alfresco's
+        ``stream_file`` silently updates a same-named node instead of
+        creating one, which would clobber a document somebody else created
+        server-side.  Compare name, then size, then a head+tail hash.
+
+        Errors resolve to ``None`` (upload anyway) so a transient failure
+        cannot block synchronisation.
+        """
+        name = doc_pair.local_path.name
+        try:
+            twin = self.remote.find_file_child(parent_ref, name)
+        except Exception:
+            log.warning(
+                f"Could not check {name!r} against {parent_ref!r}, "
+                "proceeding with upload",
+                exc_info=True,
+            )
+            return None
+        if twin is None:
+            return None
+
+        # The xattr is written right after a successful upload, before the
+        # DB is updated: a match means this node is our own interrupted
+        # upload, not somebody else's document.
+        with suppress(Exception):
+            if self.local.get_remote_id(doc_pair.local_path) == twin.id:
+                return None
+
+        local_path = self.local.abspath(doc_pair.local_path)
+        try:
+            local_size = local_path.stat().st_size
+        except OSError:
+            log.warning(
+                f"Could not stat {local_path!r}, proceeding with upload",
+                exc_info=True,
+            )
+            return None
+        remote_size = twin.content.size_in_bytes if twin.content else -1
+        if remote_size != local_size:
+            log.info(
+                f"Remote {name!r} ({twin.id}) already exists with a different "
+                f"size (remote={remote_size}, local={local_size})"
+            )
+            return twin
+
+        for attempt in range(1, PARTIAL_COMPARE_ATTEMPTS + 1):
+            try:
+                remote_digest = self._remote_head_tail_digest(twin.id, remote_size)
+                break
+            except Exception:
+                if attempt == PARTIAL_COMPARE_ATTEMPTS:
+                    log.warning(
+                        f"Could not read remote content of {name!r} ({twin.id}) "
+                        f"after {attempt} attempts, proceeding with upload",
+                        exc_info=True,
+                    )
+                    return None
+                sleep(1)
+
+        local_digest = self._local_head_tail_digest(local_path, local_size)
+        if local_digest == remote_digest:
+            return None
+
+        log.info(
+            f"Remote {name!r} ({twin.id}) already exists with different content "
+            f"(remote={remote_digest}, local={local_digest})"
+        )
+        return twin
 
     def _refresh_remote(
         self, doc_pair: DocPair, remote_info: RemoteFileInfo = None, /
@@ -699,6 +806,30 @@ class AlfrescoProcessor(_ProcessorBase):
                 self._postpone_pair(doc_pair, "Unaccessible hash")
                 return
 
+        # A never-linked pair whose name is already taken server-side is a
+        # creation on both sides: conflict rather than clobber the remote.
+        # ``resolved`` means the user already arbitrated, so never re-ask.
+        if (
+            not doc_pair.folderish
+            and not doc_pair.remote_ref
+            and doc_pair.local_state != "resolved"
+        ):
+            twin = self._conflicting_remote_twin(doc_pair, parent_ref)
+            if twin:
+                # Bind the pair to the node it conflicts with, else "Use
+                # remote" has nothing to download from.
+                twin_info = self.remote._node_to_remote_file_info(twin)
+                self.dao.link_remote_ref(doc_pair.id, twin_info)
+                doc_pair.remote_ref = twin_info.uid
+                doc_pair.remote_name = twin_info.name
+                doc_pair.remote_parent_ref = twin_info.parent_uid
+                doc_pair.remote_can_rename = twin_info.can_rename
+                doc_pair.remote_can_delete = twin_info.can_delete
+                doc_pair.remote_can_update = twin_info.can_update
+                doc_pair.remote_can_create_child = twin_info.can_create_child
+                self._mark_conflicted(doc_pair)
+                return
+
         filter_path = ""
         filter_removed = False
         try:
@@ -737,6 +868,25 @@ class AlfrescoProcessor(_ProcessorBase):
 
         with suppress(NotFound):
             self.local.set_remote_id(doc_pair.local_path, remote_ref)
+
+        # The node may already have been claimed by another pair (e.g. a
+        # remote scan linked it while this upload was queued).  Writing
+        # ``remote_ref`` here would violate UNIQUE(remote_ref, local_path)
+        # and the pair would retry forever, re-uploading on each round.
+        owner = self.dao.get_normal_state_from_remote(remote_ref)
+        if (
+            owner
+            and owner.id != doc_pair.id
+            and owner.local_path == doc_pair.local_path
+        ):
+            log.info(
+                f"Dropping duplicate pair {doc_pair!r}: {remote_ref} is already "
+                f"owned by {owner!r}"
+            )
+            self.dao.remove_state(doc_pair)
+            self.remove_void_transfers(doc_pair)
+            return
+
         # After upload, store the digest computed by stream_file/make_folder
         # so that the next remote scan doesn't see a spurious mismatch.
         if fs_item_info.digest:

--- a/nxdrive/alfresco/engine/processor.py
+++ b/nxdrive/alfresco/engine/processor.py
@@ -13,7 +13,7 @@ from contextlib import suppress
 from logging import getLogger
 from pathlib import Path
 from time import monotonic_ns, sleep
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple
 
 from nxdrive.drive.client.local import FileInfo
 from nxdrive.drive.constants import (
@@ -176,11 +176,15 @@ class AlfrescoProcessor(_ProcessorBase):
         self.dao._force_sync(doc_pair, "modified", "modified", "conflicted")
 
     @staticmethod
-    def _local_head_tail_digest(path: Path, size: int, /) -> str:
+    def _local_head_tail_digest(
+        path: Path, size: int, /, *, head_only: bool = False
+    ) -> str:
         limit = PARTIAL_COMPARE_SIZE
         h = hashlib.md5(usedforsecurity=False)
         with path.open("rb") as f:
-            if size <= 2 * limit:
+            if head_only:
+                h.update(f.read(limit))
+            elif size <= 2 * limit:
                 for chunk in iter(lambda: f.read(limit), b""):
                     h.update(chunk)
             else:
@@ -189,15 +193,25 @@ class AlfrescoProcessor(_ProcessorBase):
                 h.update(f.read(limit))
         return h.hexdigest()
 
-    def _remote_head_tail_digest(self, node_id: str, size: int, /) -> str:
+    def _remote_head_tail_digest(self, node_id: str, size: int, /) -> Tuple[str, bool]:
+        """Return the digest and whether only the head window was hashed.
+
+        A server ignoring ``Range`` cannot serve the tail cheaply, so the
+        comparison degrades to head-only; the caller must then hash the
+        local side the same way or every large file would look different.
+        """
         limit = PARTIAL_COMPARE_SIZE
         h = hashlib.md5(usedforsecurity=False)
         if size <= 2 * limit:
-            h.update(self.remote.get_content_range(node_id, 0, size))
-        else:
-            h.update(self.remote.get_content_range(node_id, 0, limit))
-            h.update(self.remote.get_content_range(node_id, size - limit, limit))
-        return h.hexdigest()
+            h.update(self.remote.get_content_range(node_id, 0, size) or b"")
+            return h.hexdigest(), False
+
+        h.update(self.remote.get_content_range(node_id, 0, limit) or b"")
+        tail = self.remote.get_content_range(node_id, size - limit, limit)
+        if tail is None:
+            return h.hexdigest(), True
+        h.update(tail)
+        return h.hexdigest(), False
 
     def _conflicting_remote_twin(
         self, doc_pair: DocPair, parent_ref: str, /
@@ -249,9 +263,13 @@ class AlfrescoProcessor(_ProcessorBase):
             )
             return twin
 
+        remote_digest = ""
+        head_only = False
         for attempt in range(1, PARTIAL_COMPARE_ATTEMPTS + 1):
             try:
-                remote_digest = self._remote_head_tail_digest(twin.id, remote_size)
+                remote_digest, head_only = self._remote_head_tail_digest(
+                    twin.id, remote_size
+                )
                 break
             except Exception:
                 if attempt == PARTIAL_COMPARE_ATTEMPTS:
@@ -263,7 +281,15 @@ class AlfrescoProcessor(_ProcessorBase):
                     return None
                 sleep(1)
 
-        local_digest = self._local_head_tail_digest(local_path, local_size)
+        if head_only:
+            log.info(
+                f"Comparing only the first {PARTIAL_COMPARE_SIZE} bytes of "
+                f"{name!r} ({twin.id}): the server does not honour Range"
+            )
+
+        local_digest = self._local_head_tail_digest(
+            local_path, local_size, head_only=head_only
+        )
         if local_digest == remote_digest:
             return None
 

--- a/nxdrive/alfresco/engine/processor.py
+++ b/nxdrive/alfresco/engine/processor.py
@@ -927,6 +927,14 @@ class AlfrescoProcessor(_ProcessorBase):
         self.dao.synchronize_state(doc_pair)
 
     def _synchronize_locally_modified(self, doc_pair: DocPair, /) -> None:
+        if doc_pair.folderish:
+            # A folder has no content: hashing one yields UNACCESSIBLE_HASH,
+            # which would postpone the pair every 60s forever.  Only its
+            # metadata can differ, and children sync as their own pairs.
+            self._refresh_remote(doc_pair)
+            self.dao.synchronize_state(doc_pair)
+            return
+
         if doc_pair.local_digest == UNACCESSIBLE_HASH:
             info = self.local.get_info(doc_pair.local_path)
             doc_pair.local_digest = info.get_digest()
@@ -975,7 +983,9 @@ class AlfrescoProcessor(_ProcessorBase):
         first because the local file may have been re-edited between
         the conflict being surfaced and the user resolving it.
         """
-        if self.local.exists(doc_pair.local_path):
+        # Directories are unhashable, and a folder conflict is about the
+        # folder existing on both sides, which linking already settled.
+        if not doc_pair.folderish and self.local.exists(doc_pair.local_path):
             info = self.local.get_info(doc_pair.local_path)
             doc_pair.local_digest = info.get_digest()
             self.dao.update_local_state(doc_pair, info, versioned=False, queue=False)

--- a/nxdrive/alfresco/engine/watcher/remote_watcher.py
+++ b/nxdrive/alfresco/engine/watcher/remote_watcher.py
@@ -6,6 +6,7 @@ Alfresco has no direct equivalent of the ``GetChangeSummary`` /
 change-log endpoint, so this watcher does full remote tree diffing.
 """
 
+from contextlib import suppress
 from datetime import datetime, timezone
 from logging import getLogger
 from pathlib import Path
@@ -273,6 +274,11 @@ class AlfrescoRemoteWatcher(RemoteWatcherBase):
                         # None in (local_digest, None)), so we must
                         # override it with force_remote.
                         self.dao.force_remote(child_pair)
+                elif child_pair.pair_state == "conflicted":
+                    log.debug(
+                        f"Skipping update for {child_info.name!r}: "
+                        "pair is already conflicted (awaiting user)"
+                    )
                 else:
                     self.dao.update_remote_state(
                         child_pair,
@@ -282,18 +288,13 @@ class AlfrescoRemoteWatcher(RemoteWatcherBase):
                 if child_info.folderish:
                     to_scan.append((child_pair, child_info))
             else:
-                # New item — insert into DAO
+                # New item — adopt an existing local pair or insert into DAO
                 local_path = doc_pair.local_path / child_info.name
-                row_id = self.dao.insert_remote_state(
-                    child_info,
-                    remote_parent_path,
-                    local_path,
-                    doc_pair.local_path,
+                child_pair = self._match_or_create_child(
+                    child_info, local_path, doc_pair.local_path, remote_parent_path
                 )
-                if child_info.folderish and row_id:
-                    child_pair = self.dao.get_state_from_id(row_id, from_write=True)
-                    if child_pair:
-                        to_scan.append((child_pair, child_info))
+                if child_info.folderish and child_pair:
+                    to_scan.append((child_pair, child_info))
 
         # Mark remaining DB children as deleted on server
         for deleted_pair in children.values():
@@ -308,6 +309,84 @@ class AlfrescoRemoteWatcher(RemoteWatcherBase):
         # Recurse into sub-folders
         for pair, info in to_scan:
             self._scan_remote_recursive(pair, info)
+
+    def _match_or_create_child(
+        self,
+        child_info: RemoteFileInfo,
+        local_path: Path,
+        local_parent_path: Path,
+        remote_parent_path: str,
+        /,
+    ) -> Optional[DocPair]:
+        """Link ``child_info`` to an existing local pair, or insert a new one.
+
+        Mirrors ``RemoteWatcher._find_remote_child_match_or_create()``.
+        Without this step a document created locally (still unlinked,
+        ``remote_ref=''``) and picked up by a remote scan before its
+        upload completed would get a *second* row for the same
+        ``local_path``.  Both rows then race, and the loser hits
+        ``UNIQUE constraint failed: States.remote_ref, States.local_path``
+        on every retry, looping forever.
+        """
+        existing = self.dao.get_state_from_local(local_path)
+
+        # Checked before the remote-ref guard below: the processor binds a
+        # conflicted pair to the node it conflicts with, so that ref is
+        # legitimately already in the database.
+        if existing and existing.pair_state == "conflicted":
+            # Refreshing ``last_remote_updated`` here would make the engine's
+            # freshness check see an unchanged remote and auto-resolve a
+            # conflict the user has not arbitrated yet.
+            log.debug(
+                f"Not linking {child_info.name!r}: pair is already "
+                "conflicted (awaiting user)"
+            )
+            return None
+
+        if self.dao.get_normal_state_from_remote(child_info.uid):
+            log.warning(
+                "Illegal state: a remote creation cannot happen if there "
+                f"already is the same remote ref in the database: {child_info!r}"
+            )
+            return None
+
+        if existing:
+            if existing.remote_ref and existing.remote_ref != child_info.uid:
+                log.info(
+                    "Got an existing pair with a different remote ref: "
+                    f"{existing!r} | {child_info!r}"
+                )
+                return None
+
+            log.info(
+                f"Linking remote {child_info.name!r} ({child_info.uid}) to the "
+                f"existing local pair {existing!r}"
+            )
+            # A local creation that was never uploaded means the remote node
+            # was created independently: same name on both sides is a
+            # conflict, not a link.  ``versioned`` bumps the row version so
+            # an in-flight processor holding stale state cannot overwrite
+            # the conflict via ``synchronize_state``'s optimistic lock.
+            conflicting = not existing.remote_ref and existing.local_state == "created"
+            if conflicting:
+                existing.remote_state = "created"
+            self.dao.update_remote_state(
+                existing,
+                child_info,
+                remote_parent_path=remote_parent_path,
+                versioned=conflicting,
+            )
+            # Claiming the node in the xattr would make the processor treat
+            # it as its own interrupted upload and overwrite the remote.
+            if not conflicting:
+                with suppress(Exception):
+                    self.engine.local.set_remote_id(local_path, child_info.uid)
+            return self.dao.get_state_from_id(existing.id, from_write=True)
+
+        row_id = self.dao.insert_remote_state(
+            child_info, remote_parent_path, local_path, local_parent_path
+        )
+        return self.dao.get_state_from_id(row_id, from_write=True) if row_id else None
 
     # -- Incremental change polling ------------------------------------------
 

--- a/nxdrive/drive/dao/engine.py
+++ b/nxdrive/drive/dao/engine.py
@@ -1006,6 +1006,39 @@ class EngineDAO(BaseDAO):
                 "UPDATE States SET remote_name = ? WHERE id = ?", (remote_name, row_id)
             )
 
+    def link_remote_ref(self, row_id: int, info: RemoteFileInfo, /) -> None:
+        """Bind a pair to a remote node without touching its sync state.
+
+        ``last_remote_updated`` is deliberately left alone: a conflicted pair
+        must not gain a fresh observation timestamp, else the engine's
+        freshness check would see an unchanged remote and auto-resolve it.
+        The permission flags are needed by ``DocPair.is_readonly()``, which
+        does bitwise arithmetic and raises on NULLs.
+        """
+        with self.lock:
+            c = self._get_write_connection().cursor()
+            c.execute(
+                "UPDATE States"
+                "   SET remote_ref = ?,"
+                "       remote_parent_ref = ?,"
+                "       remote_name = ?,"
+                "       remote_can_rename = ?,"
+                "       remote_can_delete = ?,"
+                "       remote_can_update = ?,"
+                "       remote_can_create_child = ?"
+                " WHERE id = ?",
+                (
+                    info.uid,
+                    info.parent_uid,
+                    info.name,
+                    info.can_rename,
+                    info.can_delete,
+                    info.can_update,
+                    info.can_create_child,
+                    row_id,
+                ),
+            )
+
     def get_dedupe_pair(
         self, name: str, parent: str, row_id: int, /
     ) -> Optional[DocPair]:
@@ -1844,25 +1877,36 @@ class EngineDAO(BaseDAO):
                 log.debug(f"Increasing version to {row.version + 1} for pair {row!r}")
 
             query += " WHERE id = ?"
-            c.execute(
-                query,
-                (
-                    info.uid,
-                    info.parent_uid,
-                    remote_parent_path,
-                    info.name,
-                    info.last_modification_time,
-                    info.can_rename,
-                    info.can_delete,
-                    info.can_update,
-                    info.can_create_child,
-                    info.last_contributor,
-                    row.local_state,
-                    row.remote_state,
-                    row.pair_state,
-                    row.id,
-                ),
-            )
+            try:
+                c.execute(
+                    query,
+                    (
+                        info.uid,
+                        info.parent_uid,
+                        remote_parent_path,
+                        info.name,
+                        info.last_modification_time,
+                        info.can_rename,
+                        info.can_delete,
+                        info.can_update,
+                        info.can_create_child,
+                        info.last_contributor,
+                        row.local_state,
+                        row.remote_state,
+                        row.pair_state,
+                        row.id,
+                    ),
+                )
+            except IntegrityError:
+                clash = c.execute(
+                    "SELECT * FROM States WHERE remote_ref = ? AND local_path = ?",
+                    (info.uid, row.local_path),
+                ).fetchone()
+                log.error(
+                    f"Cannot link {info.uid!r} to {row!r}: the pair {clash!r} "
+                    "already owns that (remote_ref, local_path) couple"
+                )
+                raise
             if queue:
                 # Check if parent is not in creation
                 parent = c.execute(

--- a/nxdrive/drive/dao/engine.py
+++ b/nxdrive/drive/dao/engine.py
@@ -1897,14 +1897,32 @@ class EngineDAO(BaseDAO):
                         row.id,
                     ),
                 )
-            except IntegrityError:
-                clash = c.execute(
-                    "SELECT * FROM States WHERE remote_ref = ? AND local_path = ?",
-                    (info.uid, row.local_path),
-                ).fetchone()
+            except IntegrityError as exc:
+                # States has two unique couples on remote_ref; report whichever
+                # is actually occupied instead of assuming one of them.
+                candidates = (
+                    (
+                        "(remote_ref, local_path)",
+                        "SELECT * FROM States"
+                        " WHERE remote_ref = ? AND local_path = ?",
+                        (info.uid, row.local_path),
+                    ),
+                    (
+                        "(remote_ref, remote_parent_ref)",
+                        "SELECT * FROM States"
+                        " WHERE remote_ref = ? AND remote_parent_ref = ?",
+                        (info.uid, info.parent_uid),
+                    ),
+                )
+                clashes = [
+                    f"{couple} already held by {clash!r}"
+                    for couple, query, args in candidates
+                    for clash in (c.execute(query, args).fetchone(),)
+                    if clash and clash.id != row.id
+                ]
                 log.error(
-                    f"Cannot link {info.uid!r} to {row!r}: the pair {clash!r} "
-                    "already owns that (remote_ref, local_path) couple"
+                    f"Cannot link {info.uid!r} to {row!r}: {exc} "
+                    f"({'; '.join(clashes) or 'no conflicting row found'})"
                 )
                 raise
             if queue:

--- a/tests/alfresco/unit/test_alfresco_misc_coverage_gaps.py
+++ b/tests/alfresco/unit/test_alfresco_misc_coverage_gaps.py
@@ -21,6 +21,7 @@ def _engine():
     engine.remote = MagicMock()
     engine.local = MagicMock()
     engine.manager = MagicMock()
+    engine.queue_manager = MagicMock()
     engine.uid = "alfresco-coverage-engine"
     engine.server_url = "https://alfresco.example.com/alfresco"
     engine.remote_user = "admin"

--- a/tests/alfresco/unit/test_client_remote.py
+++ b/tests/alfresco/unit/test_client_remote.py
@@ -1215,6 +1215,63 @@ class TestFetch:
 # --- NEW TESTS BELOW ---
 
 
+class TestFindFileChild:
+    """Name lookup used to spot a remote twin before an initial upload."""
+
+    @staticmethod
+    def _child(name, *, is_file=True):
+        child = MagicMock()
+        # ``name`` is consumed by the Mock constructor, so assign it after.
+        child.name = name
+        child.is_file = is_file
+        return child
+
+    def test_returns_the_matching_file(self, _client_patch) -> None:
+        remote = _build_remote(_client_patch)
+        wanted = self._child("report.pdf")
+        remote.client.nodes.iter_children.return_value = iter(
+            [self._child("other.pdf"), wanted]
+        )
+
+        assert remote.find_file_child("parent-1", "report.pdf") is wanted
+        remote.client.nodes.iter_children.assert_called_once_with("parent-1")
+
+    def test_ignores_a_folder_of_the_same_name(self, _client_patch) -> None:
+        """A folder never shadows the file we are looking for."""
+        remote = _build_remote(_client_patch)
+        the_file = self._child("archive")
+        remote.client.nodes.iter_children.return_value = iter(
+            [self._child("archive", is_file=False), the_file]
+        )
+
+        assert remote.find_file_child("parent-1", "archive") is the_file
+
+    def test_returns_none_when_the_name_is_free(self, _client_patch) -> None:
+        remote = _build_remote(_client_patch)
+        remote.client.nodes.iter_children.return_value = iter(
+            [self._child("a.txt"), self._child("b.txt", is_file=False)]
+        )
+
+        assert remote.find_file_child("parent-1", "c.txt") is None
+
+    def test_returns_none_on_an_empty_folder(self, _client_patch) -> None:
+        remote = _build_remote(_client_patch)
+        remote.client.nodes.iter_children.return_value = iter([])
+
+        assert remote.find_file_child("parent-1", "a.txt") is None
+
+    def test_stops_at_the_first_match(self, _client_patch) -> None:
+        """Large folders must not be walked past the hit."""
+        remote = _build_remote(_client_patch)
+        tail = self._child("tail.txt")
+        children = iter([self._child("hit.txt"), tail])
+        remote.client.nodes.iter_children.return_value = children
+
+        remote.find_file_child("parent-1", "hit.txt")
+
+        assert next(children) is tail
+
+
 class TestGetContentRange:
     """Ranged reads, and the fallback when the server ignores ``Range``."""
 

--- a/tests/alfresco/unit/test_client_remote.py
+++ b/tests/alfresco/unit/test_client_remote.py
@@ -1215,6 +1215,54 @@ class TestFetch:
 # --- NEW TESTS BELOW ---
 
 
+class TestGetContentRange:
+    """Ranged reads, and the fallback when the server ignores ``Range``."""
+
+    @staticmethod
+    def _response(status, body, chunk=8):
+        resp = MagicMock()
+        resp.status_code = status
+        resp.content = body
+        resp.iter_content.return_value = [
+            body[i : i + chunk] for i in range(0, len(body), chunk)
+        ]
+        return resp
+
+    def test_zero_length_short_circuits(self, _client_patch) -> None:
+        remote = _build_remote(_client_patch)
+        assert remote.get_content_range("node-1", 0, 0) == b""
+        remote.client.session.get.assert_not_called()
+
+    def test_206_returns_the_served_window(self, _client_patch) -> None:
+        remote = _build_remote(_client_patch)
+        remote.client.session.get.return_value = self._response(206, b"PARTIAL!")
+
+        assert remote.get_content_range("node-1", 4, 8) == b"PARTIAL!"
+        headers = remote.client.session.get.call_args.kwargs["headers"]
+        assert headers["Range"] == "bytes=4-11"
+
+    def test_200_fallback_slices_the_window(self, _client_patch) -> None:
+        """The server ignored Range, so the window is cut from the stream."""
+        remote = _build_remote(_client_patch)
+        remote.client.session.get.return_value = self._response(
+            200, b"0123456789abcdef"
+        )
+
+        assert remote.get_content_range("node-1", 10, 4) == b"abcd"
+
+    def test_200_fallback_refuses_beyond_the_budget(self, _client_patch) -> None:
+        """Reaching a far offset would mean streaming everything before it."""
+        from nxdrive.alfresco.client.remote import RANGE_FALLBACK_MAX_BYTES
+
+        remote = _build_remote(_client_patch)
+        resp = self._response(200, b"")
+        remote.client.session.get.return_value = resp
+
+        assert remote.get_content_range("node-1", RANGE_FALLBACK_MAX_BYTES, 16) is None
+        resp.iter_content.assert_not_called()
+        resp.close.assert_called_once()
+
+
 class TestStreamContentExtended:
     """Additional stream_content tests: progress callback and DownloadPaused."""
 

--- a/tests/alfresco/unit/test_engine.py
+++ b/tests/alfresco/unit/test_engine.py
@@ -499,6 +499,51 @@ class TestConflictResolver:
         engine.conflict_resolver(42)
         engine.newConflict.emit.assert_called_once_with(42)
 
+    def test_created_both_sides_ignores_freshness_check(self):
+        """A document created on both sides has no sync history.
+
+        ``last_remote_updated`` was written from this very node when the
+        pair was linked, so an equal timestamp proves nothing and must
+        not cancel the conflict.
+        """
+        engine = _make_engine()
+        pair = MagicMock()
+        pair.folderish = False
+        pair.remote_ref = "node-123"
+        pair.local_state = "created"
+        pair.remote_state = "created"
+        pair.last_remote_updated = "2024-01-01 00:00:00"
+        pair.local_name = "file.txt"
+        pair.local_path = "/test"
+        engine.dao.get_state_from_id.return_value = pair
+
+        remote_info = MagicMock()
+        remote_info.last_modification_time = MagicMock()
+        remote_info.last_modification_time.strftime.return_value = "2024-01-01 00:00:00"
+        engine.remote.get_fs_info.return_value = remote_info
+
+        engine.conflict_resolver(42)
+
+        engine.dao._force_sync.assert_not_called()
+        engine.newConflict.emit.assert_called_once_with(42)
+
+    def test_surfacing_a_conflict_interrupts_processors(self):
+        """An in-flight upload must be stopped before the conflict is shown."""
+        engine = _make_engine()
+        pair = MagicMock()
+        pair.folderish = True
+        pair.remote_ref = "folder-abc"
+        pair.local_path = "/test-folder"
+        pair.local_name = "TestFolder"
+        engine.dao.get_state_from_id.return_value = pair
+        engine.local.get_remote_id.return_value = "different-id"
+
+        engine.conflict_resolver(42)
+
+        engine.queue_manager.interrupt_processors_on.assert_called_once_with(
+            pair.local_path, exact_match=True
+        )
+
 
 # ------------------------------------------------------------------ get_metadata_url
 

--- a/tests/alfresco/unit/test_processor.py
+++ b/tests/alfresco/unit/test_processor.py
@@ -966,6 +966,51 @@ class TestRemoteTwinDiffers:
         offsets = [c[0][1] for c in proc.remote.get_content_range.call_args_list]
         assert offsets == [0, size - PARTIAL_COMPARE_SIZE]
 
+    def test_unavailable_tail_degrades_to_head_only(self, proc, tmp_path) -> None:
+        """A server ignoring Range cannot serve the tail cheaply.
+
+        Both sides must then hash the head alone, else every large file
+        would compare as different.
+        """
+        from nxdrive.alfresco.engine.processor import PARTIAL_COMPARE_SIZE
+
+        size = 2 * PARTIAL_COMPARE_SIZE + 1024
+        path = tmp_path / "big.bin"
+        path.write_bytes(
+            b"\x00" * PARTIAL_COMPARE_SIZE + b"\xff" * (size - PARTIAL_COMPARE_SIZE)
+        )
+        proc.local.abspath.return_value = path
+        pair = Mock()
+        pair.local_path = Path("Shared/big.bin")
+
+        proc.remote.find_file_child.return_value = self._twin(size)
+        # Head served, tail refused.
+        proc.remote.get_content_range.side_effect = [
+            b"\x00" * PARTIAL_COMPARE_SIZE,
+            None,
+        ]
+
+        assert proc._conflicting_remote_twin(pair, "parent-ref") is None
+
+    def test_head_only_still_detects_a_different_head(self, proc, tmp_path) -> None:
+        from nxdrive.alfresco.engine.processor import PARTIAL_COMPARE_SIZE
+
+        size = 2 * PARTIAL_COMPARE_SIZE + 1024
+        path = tmp_path / "big.bin"
+        path.write_bytes(b"\x00" * size)
+        proc.local.abspath.return_value = path
+        pair = Mock()
+        pair.local_path = Path("Shared/big.bin")
+
+        twin = self._twin(size)
+        proc.remote.find_file_child.return_value = twin
+        proc.remote.get_content_range.side_effect = [
+            b"\xff" * PARTIAL_COMPARE_SIZE,
+            None,
+        ]
+
+        assert proc._conflicting_remote_twin(pair, "parent-ref") is twin
+
 
 class TestSynchronizeLocallyModified:
     def test_digests_differ_uploads(self, proc) -> None:

--- a/tests/alfresco/unit/test_processor.py
+++ b/tests/alfresco/unit/test_processor.py
@@ -734,6 +734,238 @@ class TestSynchronizeLocallyCreated:
         proc.dao.remove_filter.assert_not_called()
         proc.dao.add_filter.assert_not_called()
 
+    def test_unlinked_pair_with_differing_twin_conflicts(self, proc) -> None:
+        """A first upload must not clobber an independently created node."""
+        pair, parent = self._file_pair_and_parent()
+        pair.remote_ref = ""
+        proc.dao.get_state_from_local.return_value = parent
+        proc.remote.get_fs_info.return_value.path = "/Company Home/Shared"
+
+        twin = Mock()
+        twin.id = "twin-id"
+        twin.name = "newfile.txt"
+        twin.parent_id = "parent-ref"
+
+        with patch.object(proc, "_conflicting_remote_twin", return_value=twin):
+            proc._synchronize_locally_created(pair)
+
+        proc.remote.stream_file.assert_not_called()
+        proc.dao._force_sync.assert_called_once_with(
+            pair, "modified", "modified", "conflicted"
+        )
+
+    def test_conflicted_pair_is_bound_to_the_twin(self, proc) -> None:
+        """Without a remote ref, "Use remote" has nothing to download."""
+        pair, parent = self._file_pair_and_parent()
+        pair.remote_ref = ""
+        proc.dao.get_state_from_local.return_value = parent
+        proc.remote.get_fs_info.return_value.path = "/Company Home/Shared"
+
+        twin = Mock()
+        twin_info = Mock()
+        twin_info.uid = "twin-id"
+        twin_info.name = "newfile.txt"
+        twin_info.parent_uid = "parent-ref"
+        twin_info.can_update = True
+        proc.remote._node_to_remote_file_info.return_value = twin_info
+
+        with patch.object(proc, "_conflicting_remote_twin", return_value=twin):
+            proc._synchronize_locally_created(pair)
+
+        proc.dao.link_remote_ref.assert_called_once_with(pair.id, twin_info)
+        # is_readonly() does bitwise arithmetic and raises on NULL flags.
+        assert pair.remote_can_update is True
+
+    def test_unlinked_pair_with_matching_twin_uploads(self, proc) -> None:
+        pair, parent = self._file_pair_and_parent()
+        pair.remote_ref = ""
+        proc.dao.get_state_from_local.return_value = parent
+        proc.dao.get_filters.return_value = []
+        proc.remote.get_fs_info.return_value.path = "/Company Home/Shared"
+        proc.local.abspath.return_value = Path("/local/Shared/newfile.txt")
+        proc.remote.stream_file.return_value.uid = "new-file-id"
+        proc.remote.stream_file.return_value.digest = "local-hash"
+
+        with patch.object(proc, "_conflicting_remote_twin", return_value=None):
+            proc._synchronize_locally_created(pair)
+
+        proc.remote.stream_file.assert_called_once()
+
+    def test_resolved_pair_is_never_re_conflicted(self, proc) -> None:
+        """ "Use local" must upload, not bounce back into conflict.
+
+        ``force_local`` leaves ``remote_ref`` empty, so a resolved pair
+        re-enters this handler and would otherwise loop forever.
+        """
+        pair, parent = self._file_pair_and_parent()
+        pair.remote_ref = ""
+        pair.local_state = "resolved"
+        proc.dao.get_state_from_local.return_value = parent
+        proc.dao.get_filters.return_value = []
+        proc.remote.get_fs_info.return_value.path = "/Company Home/Shared"
+        proc.local.abspath.return_value = Path("/local/Shared/newfile.txt")
+        proc.remote.stream_file.return_value.uid = "new-file-id"
+        proc.remote.stream_file.return_value.digest = "local-hash"
+
+        with patch.object(proc, "_conflicting_remote_twin") as check:
+            proc._synchronize_locally_created(pair)
+
+        check.assert_not_called()
+        proc.remote.stream_file.assert_called_once()
+
+    def test_duplicate_pair_is_dropped_instead_of_relinked(self, proc) -> None:
+        """A ghost row for an already-owned node must be removed, not updated.
+
+        Writing ``remote_ref`` on it would break
+        UNIQUE(remote_ref, local_path) and loop forever.
+        """
+        pair, parent = self._file_pair_and_parent()
+        proc.dao.get_state_from_local.return_value = parent
+        proc.dao.get_filters.return_value = []
+        proc.remote.get_fs_info.return_value.path = "/Company Home/Shared"
+        proc.local.abspath.return_value = Path("/local/Shared/newfile.txt")
+        proc.remote.stream_file.return_value.uid = "existing-file-id"
+        proc.remote.stream_file.return_value.digest = "local-hash"
+
+        owner = Mock()
+        owner.id = 7
+        owner.local_path = pair.local_path
+        proc.dao.get_normal_state_from_remote.return_value = owner
+
+        proc._synchronize_locally_created(pair)
+
+        proc.dao.remove_state.assert_called_once_with(pair)
+        proc.dao.update_remote_state.assert_not_called()
+        proc.dao.synchronize_state.assert_not_called()
+
+    def test_same_path_owned_by_self_still_updates(self, proc) -> None:
+        pair, parent = self._file_pair_and_parent()
+        proc.dao.get_state_from_local.return_value = parent
+        proc.dao.get_filters.return_value = []
+        proc.remote.get_fs_info.return_value.path = "/Company Home/Shared"
+        proc.local.abspath.return_value = Path("/local/Shared/newfile.txt")
+        proc.remote.stream_file.return_value.uid = "new-file-id"
+        proc.remote.stream_file.return_value.digest = "local-hash"
+
+        owner = Mock()
+        owner.id = pair.id
+        owner.local_path = pair.local_path
+        proc.dao.get_normal_state_from_remote.return_value = owner
+
+        proc._synchronize_locally_created(pair)
+
+        proc.dao.remove_state.assert_not_called()
+        proc.dao.update_remote_state.assert_called_once()
+        proc.dao.synchronize_state.assert_called_once_with(pair)
+
+
+class TestRemoteTwinDiffers:
+    """Name -> size -> head+tail hash comparison before a first upload."""
+
+    @staticmethod
+    def _twin(size, node_id="twin-id"):
+        twin = Mock()
+        twin.id = node_id
+        twin.name = "newfile.txt"
+        twin.parent_id = "parent-ref"
+        twin.content.size_in_bytes = size
+        return twin
+
+    def _local(self, proc, tmp_path, data: bytes) -> Mock:
+        path = tmp_path / "newfile.txt"
+        path.write_bytes(data)
+        proc.local.abspath.return_value = path
+        pair = Mock()
+        pair.local_path = Path("Shared/newfile.txt")
+        return pair
+
+    def test_no_twin_means_no_conflict(self, proc, tmp_path) -> None:
+        pair = self._local(proc, tmp_path, b"hello")
+        proc.remote.find_file_child.return_value = None
+        assert proc._conflicting_remote_twin(pair, "parent-ref") is None
+
+    def test_lookup_failure_falls_through_to_upload(self, proc, tmp_path) -> None:
+        pair = self._local(proc, tmp_path, b"hello")
+        proc.remote.find_file_child.side_effect = RuntimeError("network")
+        assert proc._conflicting_remote_twin(pair, "parent-ref") is None
+
+    def test_matching_xattr_means_the_node_is_ours(self, proc, tmp_path) -> None:
+        """An interrupted upload leaves the xattr set but ``remote_ref`` empty."""
+        pair = self._local(proc, tmp_path, b"hello")
+        proc.remote.find_file_child.return_value = self._twin(999)
+        proc.local.get_remote_id.return_value = "twin-id"
+
+        assert proc._conflicting_remote_twin(pair, "parent-ref") is None
+        proc.remote.get_content_range.assert_not_called()
+
+    def test_vanished_local_file_falls_through_to_upload(self, proc, tmp_path) -> None:
+        pair = self._local(proc, tmp_path, b"hello")
+        proc.local.abspath.return_value = tmp_path / "gone.txt"
+        proc.remote.find_file_child.return_value = self._twin(5)
+
+        assert proc._conflicting_remote_twin(pair, "parent-ref") is None
+
+    def test_size_mismatch_is_a_conflict(self, proc, tmp_path) -> None:
+        pair = self._local(proc, tmp_path, b"hello")
+        twin = self._twin(999)
+        proc.remote.find_file_child.return_value = twin
+        assert proc._conflicting_remote_twin(pair, "parent-ref") is twin
+        proc.remote.get_content_range.assert_not_called()
+
+    def test_same_size_same_content_is_not_a_conflict(self, proc, tmp_path) -> None:
+        data = b"hello world"
+        pair = self._local(proc, tmp_path, data)
+        proc.remote.find_file_child.return_value = self._twin(len(data))
+        proc.remote.get_content_range.return_value = data
+        assert proc._conflicting_remote_twin(pair, "parent-ref") is None
+
+    def test_same_size_different_content_is_a_conflict(self, proc, tmp_path) -> None:
+        data = b"hello world"
+        pair = self._local(proc, tmp_path, data)
+        twin = self._twin(len(data))
+        proc.remote.find_file_child.return_value = twin
+        proc.remote.get_content_range.return_value = b"HELLO WORLD"
+        assert proc._conflicting_remote_twin(pair, "parent-ref") is twin
+
+    def test_read_retries_then_falls_through_to_upload(self, proc, tmp_path) -> None:
+        data = b"hello world"
+        pair = self._local(proc, tmp_path, data)
+        proc.remote.find_file_child.return_value = self._twin(len(data))
+        proc.remote.get_content_range.side_effect = RuntimeError("boom")
+
+        with patch("nxdrive.alfresco.engine.processor.sleep"):
+            assert proc._conflicting_remote_twin(pair, "parent-ref") is None
+
+        assert proc.remote.get_content_range.call_count == 3
+
+    def test_read_succeeds_on_retry(self, proc, tmp_path) -> None:
+        data = b"hello world"
+        pair = self._local(proc, tmp_path, data)
+        proc.remote.find_file_child.return_value = self._twin(len(data))
+        proc.remote.get_content_range.side_effect = [RuntimeError("boom"), data]
+
+        with patch("nxdrive.alfresco.engine.processor.sleep"):
+            assert proc._conflicting_remote_twin(pair, "parent-ref") is None
+
+    def test_large_file_hashes_head_and_tail(self, proc, tmp_path) -> None:
+        from nxdrive.alfresco.engine.processor import PARTIAL_COMPARE_SIZE
+
+        size = 2 * PARTIAL_COMPARE_SIZE + 1024
+        path = tmp_path / "big.bin"
+        path.write_bytes(b"\x00" * size)
+        proc.local.abspath.return_value = path
+        pair = Mock()
+        pair.local_path = Path("Shared/big.bin")
+
+        proc.remote.find_file_child.return_value = self._twin(size)
+        proc.remote.get_content_range.return_value = b"\x00" * PARTIAL_COMPARE_SIZE
+
+        assert proc._conflicting_remote_twin(pair, "parent-ref") is None
+
+        # Head window then tail window, never the whole file.
+        offsets = [c[0][1] for c in proc.remote.get_content_range.call_args_list]
+        assert offsets == [0, size - PARTIAL_COMPARE_SIZE]
+
 
 class TestSynchronizeLocallyModified:
     def test_digests_differ_uploads(self, proc) -> None:

--- a/tests/alfresco/unit/test_processor.py
+++ b/tests/alfresco/unit/test_processor.py
@@ -12,7 +12,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from nxdrive.alfresco.engine.processor import AlfrescoProcessor
-from nxdrive.drive.constants import TransferStatus
+from nxdrive.drive.constants import UNACCESSIBLE_HASH, TransferStatus
 from nxdrive.drive.exceptions import PairInterrupt
 
 
@@ -1017,6 +1017,7 @@ class TestSynchronizeLocallyModified:
         pair = Mock()
         pair.local_path = Path("/local/file.txt")
         pair.local_name = "file.txt"
+        pair.folderish = False
         pair.local_digest = "local_hash"
         pair.remote_digest = "remote_hash"
         pair.remote_ref = "node-1"
@@ -1038,6 +1039,7 @@ class TestSynchronizeLocallyModified:
         pair = Mock()
         pair.local_path = Path("/local/file.txt")
         pair.local_name = "file.txt"
+        pair.folderish = False
         pair.local_digest = "local_hash"
         pair.remote_digest = "remote_hash"
         pair.remote_ref = "node-1"
@@ -1052,6 +1054,7 @@ class TestSynchronizeLocallyModified:
     def test_same_digest_just_syncs(self, proc) -> None:
         pair = Mock()
         pair.local_path = Path("/local/file.txt")
+        pair.folderish = False
         pair.local_digest = "same"
         pair.remote_digest = "same"
         pair.remote_ref = "node-1"
@@ -1065,12 +1068,31 @@ class TestSynchronizeLocallyModified:
         proc.remote.stream_update.assert_not_called()
         proc.dao.synchronize_state.assert_called_once_with(pair)
 
+    def test_a_folder_settles_without_hashing_it(self, proc) -> None:
+        """Directories are unhashable: never take the content path."""
+        pair = Mock()
+        pair.local_path = Path("/local/folder2")
+        pair.folderish = True
+        pair.local_digest = UNACCESSIBLE_HASH
+        pair.remote_ref = "node-1"
+        pair.id = 1
+
+        proc.remote.get_fs_info.return_value = Mock()
+
+        proc._synchronize_locally_modified(pair)
+
+        proc.local.get_info.assert_not_called()
+        proc.remote.stream_update.assert_not_called()
+        proc.engine.queue_manager.push_error.assert_not_called()
+        proc.dao.synchronize_state.assert_called_once_with(pair)
+
 
 class TestSynchronizeLocallyResolved:
     def test_with_remote_ref_delegates_to_modify(self, proc) -> None:
         pair = Mock()
         pair.local_path = Path("/local/file.txt")
         pair.remote_ref = "node-1"
+        pair.folderish = False
         pair.local_digest = "hash"
         pair.remote_digest = "hash"
         pair.id = 1
@@ -1085,6 +1107,23 @@ class TestSynchronizeLocallyResolved:
 
         proc._synchronize_locally_resolved(pair)
         proc.dao.synchronize_state.assert_called()
+
+    def test_a_resolved_folder_is_not_hashed(self, proc) -> None:
+        """Hashing the directory would stamp it with UNACCESSIBLE_HASH."""
+        pair = Mock()
+        pair.local_path = Path("/local/folder2")
+        pair.remote_ref = "node-1"
+        pair.folderish = True
+        pair.id = 1
+
+        proc.local.exists.return_value = True
+        proc.remote.get_fs_info.return_value = Mock()
+
+        proc._synchronize_locally_resolved(pair)
+
+        proc.local.get_info.assert_not_called()
+        proc.engine.queue_manager.push_error.assert_not_called()
+        proc.dao.synchronize_state.assert_called_once_with(pair)
 
     def test_without_remote_ref_delegates_to_create(self, proc) -> None:
         pair = Mock()

--- a/tests/alfresco/unit/test_processor_coverage_gaps.py
+++ b/tests/alfresco/unit/test_processor_coverage_gaps.py
@@ -300,6 +300,7 @@ def test_local_modify_refreshes_an_inaccessible_digest(processor, digest):
     pair.id = 12
     pair.local_path = Path("sync/document.txt")
     pair.local_name = "document.txt"
+    pair.folderish = False
     pair.local_digest = UNACCESSIBLE_HASH
     pair.remote_digest = "readable-digest"
     pair.remote_ref = "document-id"

--- a/tests/alfresco/unit/test_remote_watcher.py
+++ b/tests/alfresco/unit/test_remote_watcher.py
@@ -24,6 +24,8 @@ def _make_watcher():
     engine = MagicMock()
     dao = MagicMock()
     dao.get_config.return_value = None
+    dao.get_state_from_local.return_value = None
+    dao.get_normal_state_from_remote.return_value = None
 
     with patch.object(AlfrescoRemoteWatcher, "__init__", lambda self, *a, **kw: None):
         w = AlfrescoRemoteWatcher(engine, dao)
@@ -45,6 +47,7 @@ def _make_doc_pair(**kwargs):
     pair.remote_parent_path = kwargs.get("remote_parent_path", "")
     pair.local_path = kwargs.get("local_path", ROOT)
     pair.local_name = kwargs.get("local_name", "folder")
+    pair.local_state = kwargs.get("local_state", "synchronized")
     pair.pair_state = kwargs.get("pair_state", "synchronized")
     pair.last_remote_updated = kwargs.get("last_remote_updated", "2024-01-01 00:00:00")
     pair.local_digest = kwargs.get("local_digest", None)
@@ -186,6 +189,228 @@ class TestScanRemoteRecursive:
         )
 
         watcher.dao.insert_remote_state.assert_called_once()
+
+    def test_unlinked_local_pair_is_adopted_not_duplicated(self):
+        """A locally created, not-yet-uploaded pair must be linked, not cloned.
+
+        Inserting a second row for the same ``local_path`` makes both rows
+        race on UNIQUE(remote_ref, local_path) and loop forever.
+        """
+        watcher = _make_watcher()
+        remote = MagicMock()
+        watcher.engine.remote = remote
+
+        remote.client.nodes.iter_children.return_value = [MagicMock()]
+        child_info = _make_remote_info(uid="child-1", name="Doc.txt", folderish=False)
+        remote._node_to_remote_file_info.return_value = child_info
+
+        watcher.dao.get_remote_children.return_value = []
+        watcher.dao.is_filter.return_value = False
+        unlinked = _make_doc_pair(
+            remote_ref="",
+            local_state="created",
+            pair_state="locally_created",
+            local_path=ROOT / "Doc.txt",
+        )
+        watcher.dao.get_state_from_local.return_value = unlinked
+
+        parent_pair = _make_doc_pair(
+            remote_ref="parent-node", remote_parent_path="", local_path=ROOT
+        )
+        watcher._scan_remote_recursive(
+            parent_pair, _make_remote_info(uid="parent-node")
+        )
+
+        watcher.dao.insert_remote_state.assert_not_called()
+        watcher.dao.update_remote_state.assert_called_once()
+        assert watcher.dao.update_remote_state.call_args[0][0] is unlinked
+
+    def test_unlinked_local_creation_is_marked_conflicted(self):
+        """Same name created on both sides must surface as a conflict.
+
+        The version must be bumped so an in-flight processor cannot undo
+        it through ``synchronize_state``'s optimistic lock.
+        """
+        watcher = _make_watcher()
+        remote = MagicMock()
+        watcher.engine.remote = remote
+
+        remote.client.nodes.iter_children.return_value = [MagicMock()]
+        child_info = _make_remote_info(uid="child-1", name="Doc.txt", folderish=False)
+        remote._node_to_remote_file_info.return_value = child_info
+
+        watcher.dao.get_remote_children.return_value = []
+        watcher.dao.is_filter.return_value = False
+        unlinked = _make_doc_pair(
+            remote_ref="",
+            local_state="created",
+            pair_state="locally_created",
+            local_path=ROOT / "Doc.txt",
+        )
+        watcher.dao.get_state_from_local.return_value = unlinked
+
+        parent_pair = _make_doc_pair(
+            remote_ref="parent-node", remote_parent_path="", local_path=ROOT
+        )
+        watcher._scan_remote_recursive(
+            parent_pair, _make_remote_info(uid="parent-node")
+        )
+
+        assert unlinked.remote_state == "created"
+        assert watcher.dao.update_remote_state.call_args[1]["versioned"] is True
+        # Claiming the node would make the processor treat it as its own
+        # interrupted upload and overwrite the remote.
+        watcher.engine.local.set_remote_id.assert_not_called()
+
+    def test_already_synced_pair_is_linked_without_conflict(self):
+        """An unlinked pair that is not a local creation just gets linked."""
+        watcher = _make_watcher()
+        remote = MagicMock()
+        watcher.engine.remote = remote
+
+        remote.client.nodes.iter_children.return_value = [MagicMock()]
+        child_info = _make_remote_info(uid="child-1", name="Doc.txt", folderish=False)
+        remote._node_to_remote_file_info.return_value = child_info
+
+        watcher.dao.get_remote_children.return_value = []
+        watcher.dao.is_filter.return_value = False
+        existing = _make_doc_pair(
+            remote_ref="",
+            local_state="synchronized",
+            local_path=ROOT / "Doc.txt",
+        )
+        watcher.dao.get_state_from_local.return_value = existing
+
+        parent_pair = _make_doc_pair(
+            remote_ref="parent-node", remote_parent_path="", local_path=ROOT
+        )
+        watcher._scan_remote_recursive(
+            parent_pair, _make_remote_info(uid="parent-node")
+        )
+
+        assert existing.remote_state != "created"
+        assert watcher.dao.update_remote_state.call_args[1]["versioned"] is False
+        watcher.engine.local.set_remote_id.assert_called_once_with(
+            ROOT / "Doc.txt", "child-1"
+        )
+
+    def test_already_conflicted_pair_is_left_untouched(self):
+        """A pair awaiting user arbitration must not be re-linked.
+
+        Refreshing ``last_remote_updated`` would make the engine's
+        freshness check see an unchanged remote and auto-resolve it.
+        """
+        watcher = _make_watcher()
+        remote = MagicMock()
+        watcher.engine.remote = remote
+
+        remote.client.nodes.iter_children.return_value = [MagicMock()]
+        child_info = _make_remote_info(uid="child-1", name="Doc.txt", folderish=False)
+        remote._node_to_remote_file_info.return_value = child_info
+
+        watcher.dao.get_remote_children.return_value = []
+        watcher.dao.is_filter.return_value = False
+        # ``_mark_conflicted`` leaves the pair modified/modified, not created.
+        conflicted = _make_doc_pair(
+            remote_ref="",
+            local_state="modified",
+            pair_state="conflicted",
+            local_path=ROOT / "Doc.txt",
+        )
+        watcher.dao.get_state_from_local.return_value = conflicted
+
+        parent_pair = _make_doc_pair(
+            remote_ref="parent-node", remote_parent_path="", local_path=ROOT
+        )
+        watcher._scan_remote_recursive(
+            parent_pair, _make_remote_info(uid="parent-node")
+        )
+
+        watcher.dao.update_remote_state.assert_not_called()
+        watcher.dao.insert_remote_state.assert_not_called()
+        watcher.engine.local.set_remote_id.assert_not_called()
+
+    def test_known_conflicted_child_is_not_refreshed(self):
+        """Same guard for a child already linked in the DB."""
+        watcher = _make_watcher()
+        remote = MagicMock()
+        watcher.engine.remote = remote
+
+        remote.client.nodes.iter_children.return_value = [MagicMock()]
+        child_info = _make_remote_info(
+            uid="child-1",
+            name="Doc.txt",
+            folderish=False,
+            last_modification_time=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        )
+        remote._node_to_remote_file_info.return_value = child_info
+
+        conflicted = _make_doc_pair(
+            remote_ref="child-1",
+            pair_state="conflicted",
+            last_remote_updated="2024-01-01 00:00:00",
+        )
+        watcher.dao.get_remote_children.return_value = [conflicted]
+        watcher.dao.is_filter.return_value = False
+
+        parent_pair = _make_doc_pair(remote_ref="parent-node", remote_parent_path="")
+        watcher._scan_remote_recursive(
+            parent_pair, _make_remote_info(uid="parent-node")
+        )
+
+        watcher.dao.update_remote_state.assert_not_called()
+
+    def test_remote_ref_already_known_is_skipped(self):
+        """Illegal state: the same remote ref cannot be created twice."""
+        watcher = _make_watcher()
+        remote = MagicMock()
+        watcher.engine.remote = remote
+
+        remote.client.nodes.iter_children.return_value = [MagicMock()]
+        child_info = _make_remote_info(uid="child-1", name="Doc.txt", folderish=False)
+        remote._node_to_remote_file_info.return_value = child_info
+
+        watcher.dao.get_remote_children.return_value = []
+        watcher.dao.is_filter.return_value = False
+        watcher.dao.get_normal_state_from_remote.return_value = _make_doc_pair(
+            remote_ref="child-1"
+        )
+
+        parent_pair = _make_doc_pair(
+            remote_ref="parent-node", remote_parent_path="", local_path=ROOT
+        )
+        watcher._scan_remote_recursive(
+            parent_pair, _make_remote_info(uid="parent-node")
+        )
+
+        watcher.dao.insert_remote_state.assert_not_called()
+        watcher.dao.update_remote_state.assert_not_called()
+
+    def test_local_pair_with_other_remote_ref_is_left_alone(self):
+        """A same-path pair already bound to another node must not be relinked."""
+        watcher = _make_watcher()
+        remote = MagicMock()
+        watcher.engine.remote = remote
+
+        remote.client.nodes.iter_children.return_value = [MagicMock()]
+        child_info = _make_remote_info(uid="child-1", name="Doc.txt", folderish=False)
+        remote._node_to_remote_file_info.return_value = child_info
+
+        watcher.dao.get_remote_children.return_value = []
+        watcher.dao.is_filter.return_value = False
+        watcher.dao.get_state_from_local.return_value = _make_doc_pair(
+            remote_ref="some-other-node", local_path=ROOT / "Doc.txt"
+        )
+
+        parent_pair = _make_doc_pair(
+            remote_ref="parent-node", remote_parent_path="", local_path=ROOT
+        )
+        watcher._scan_remote_recursive(
+            parent_pair, _make_remote_info(uid="parent-node")
+        )
+
+        watcher.dao.insert_remote_state.assert_not_called()
+        watcher.dao.update_remote_state.assert_not_called()
 
     def test_existing_item_unchanged_updates_state(self):
         watcher = _make_watcher()

--- a/tests/common/unit/test_engine_dao_extra.py
+++ b/tests/common/unit/test_engine_dao_extra.py
@@ -510,6 +510,28 @@ def test_mark_delete_and_remove_state_trees_persist_expected_scope(dao):
     assert dao.get_state_from_id(remote_recursive_child.id) is None
 
 
+def test_link_remote_ref_binds_without_refreshing_the_timestamp(dao, tmp_path):
+    """A conflicted pair needs an identity and permissions, but no new mtime.
+
+    ``last_remote_updated`` must stay NULL so the engine's freshness check
+    cannot report "remote unchanged" and auto-resolve the conflict, and the
+    permission flags must be set because ``is_readonly()`` raises on NULLs.
+    """
+    (tmp_path / "conflict.txt").write_bytes(b"local")
+    local_info = FileInfo(tmp_path, Path("conflict.txt"), False, FIXED_TIME)
+    row_id = dao.insert_local_state(local_info, None)
+
+    info = _remote_info("conflict.txt", "remote-twin", "parent-ref")
+    dao.link_remote_ref(row_id, info)
+
+    row = dao.get_state_from_id(row_id)
+    assert row.remote_ref == "remote-twin"
+    assert row.remote_parent_ref == "parent-ref"
+    assert row.remote_name == "conflict.txt"
+    assert row.last_remote_updated is None
+    assert row.is_readonly() is False
+
+
 def test_remote_state_insert_update_and_lookup_queries(dao):
     queue = Mock()
     dao.queue_manager = queue

--- a/tests/common/unit/test_engine_dao_extra.py
+++ b/tests/common/unit/test_engine_dao_extra.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from sqlite3 import OperationalError
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -530,6 +530,34 @@ def test_link_remote_ref_binds_without_refreshing_the_timestamp(dao, tmp_path):
     assert row.remote_name == "conflict.txt"
     assert row.last_remote_updated is None
     assert row.is_readonly() is False
+
+
+def test_update_remote_state_names_the_violated_unique_couple(dao, tmp_path):
+    """States has two unique couples on remote_ref.
+
+    The error must identify the one actually hit, else triage is misled.
+    """
+    from sqlite3 import IntegrityError
+
+    owner_info = _remote_info("taken.txt", "shared-ref", "parent-a")
+    dao.insert_remote_state(owner_info, "", Path("taken.txt"), ROOT)
+
+    (tmp_path / "other.txt").write_bytes(b"local")
+    other_id = dao.insert_local_state(
+        FileInfo(tmp_path, Path("other.txt"), False, FIXED_TIME), None
+    )
+    other = dao.get_state_from_id(other_id)
+
+    # Same remote_ref and parent as the row above, so (remote_ref,
+    # remote_parent_ref) collides while (remote_ref, local_path) does not.
+    with patch.object(engine_module, "log") as logger:
+        with pytest.raises(IntegrityError):
+            dao.update_remote_state(other, owner_info)
+
+    message = logger.error.call_args[0][0]
+    assert "States.remote_ref, States.remote_parent_ref" in message
+    assert "(remote_ref, remote_parent_ref) already held by" in message
+    assert "no conflicting row found" not in message
 
 
 def test_remote_state_insert_update_and_lookup_queries(dao):


### PR DESCRIPTION
### Summary of Changes

Fixes two related defects in Alfresco Drive conflict handling:

1. Synchronisation loops infinitely after resolving conflicts, and concurrent local/remote file creations are not correctly detected, surfaced, or resolvable.
2. Once folder conflicts started surfacing correctly, resolving one left the folder pair postponing itself every 60 seconds forever.

### Root Cause

1. **Duplicate `DocPair` Creation & Database Integrity Errors**:
   - When a file was created locally and the same file existed remotely before local upload finished, `AlfrescoRemoteWatcher._scan_remote_recursive()` unconditionally inserted a second `DocPair` row with the same `local_path`.
   - When the local upload subsequently completed and attempted to update `remote_ref`, SQLite threw `sqlite3.IntegrityError: UNIQUE constraint failed: States.remote_ref, States.local_path`.
   - This failure caused the pair to postpone for 60 seconds and loop infinitely on every retry, continuously uploading and creating redundant versions on the server.

2. **Silent Server Overwrites & Missing Conflict Detection**:
   - Unlike Nuxeo, Alfresco does not provide a content digest by default. `stream_file` silently updated existing same-named nodes via `iter_children` without comparing content.
   - When conflicts were raised, the Alfresco conflict resolver's timestamp freshness heuristic (`remote_ts == db_ts`) saw timestamps updated during poll/adopt cycles and immediately auto-resolved the conflict back to `locally_modified`.
   - B-raised conflicts lacked `remote_ref` and permission flags, causing crashes (`TypeError: unsupported operand type(s) for &: 'NoneType' and 'NoneType'`) during "Use remote" resolution.

3. **Folder Conflict Resolution Never Settled**:
   - `_synchronize_locally_resolved()` computed a local digest unconditionally and, whenever `remote_ref` was set, routed the pair to `_synchronize_locally_modified()`. Neither function guarded against folders.
   - Hashing a directory ends in `compute_digest()`, which opens the path for reading. `IsADirectoryError` is a subclass of `OSError` and is swallowed by the `except (OSError, MemoryError)` arm, which returns the `UNACCESSIBLE_HASH` sentinel.
   - That sentinel means "could not read, retry later", so `_synchronize_locally_modified()` re-hashed the same directory, got the same sentinel, and called `_postpone_pair(doc_pair, "Unaccessible hash")` on a 60 second cycle indefinitely. The reason string is only logged at DEBUG, so production logs showed a bare postpone with no explanation.
   - Files inside the folder resolved correctly; only the folder pairs spun.

### Fixes Applied

- **Remote Watcher Child Adoption**:
  - In `AlfrescoRemoteWatcher`, added `_match_or_create_child()` to look up existing local pairs before inserting. If an unlinked pair exists at the same `local_path`, it is adopted rather than duplicated.
  - If the pair is an unlinked local creation, it is marked `conflicted` with a version bump so an in-flight processor cannot overwrite the conflict.
  - Conflicted pairs are skipped in remote scans so their metadata and timestamps are not prematurely refreshed.

- **Content Comparison Before Upload**:
  - Implemented `_conflicting_remote_twin()` in `AlfrescoProcessor`: checks name, size, and compares head (first 10 MB) + tail (last 10 MB) MD5 hashes using ranged downloads before performing initial uploads.
  - If content differs, the twin is bound via `EngineDAO.link_remote_ref()` (including permission flags) without modifying `last_remote_updated`, and the pair is marked `conflicted`.

- **Conflict Resolver Adjustments**:
  - `AlfrescoEngine.conflict_resolver()` now exempts pairs created on both sides (`created` / `created`) from timestamp freshness resets, ensuring conflicts remain surfaced for user arbitration.
  - Interrupts running processors on the affected path before emitting `newConflict`.

- **Folder Pairs Never Enter the Content Path**:
  - `_synchronize_locally_modified()` short-circuits folderish pairs to `_refresh_remote()` plus `synchronize_state()` and returns. A folder has no content to hash or upload, and its children synchronise as their own pairs.
  - `_synchronize_locally_resolved()` no longer refreshes the local digest for folderish pairs, so a resolved folder is never stamped with the sentinel in the first place.
  - The guard is applied in both places because `_synchronize_locally_modified()` is also reachable directly via `pair_state == "locally_modified"` and would hit the identical loop from there.
  - This also closes a latent defect: had the digest check ever passed, the folder would have been handed to `stream_update()`.

- **Duplicate Self-Healing & DAO Hardening**:
  - Added self-healing in `_synchronize_locally_created`: drops redundant pairs if another row already owns the same `remote_ref` and `local_path`.
  - Added `link_remote_ref()` to `EngineDAO` and logged colliding rows on `IntegrityError` before re-raising.

- **Tests & Documentation**:
  - Added unit test coverage for child adoption, conflicted pair skipping, twin detection, partial hashing, folder conflict resolution, and resolver behavior.
  - Documented fix in `docs/changes/8.0.0.md`.

### Review Feedback Addressed

- **Bounded memory when the server ignores `Range`**:
  - `get_content_range()` previously buffered from byte 0 up to `start + length` whenever the server replied `200` instead of `206`. For a tail read that meant holding almost the entire file in memory, defeating the partial-hash optimisation.
  - The fallback now discards the bytes preceding the requested window while streaming, so peak memory equals the window size rather than the offset plus the window.
  - A 20 MB ceiling (`RANGE_FALLBACK_MAX_BYTES`) was introduced. If satisfying the window would require reading past it, the call logs a warning and returns `None` instead of downloading the file.
  - Because the head read always starts at offset 0, it doubles as a free probe for whether the server honours `Range`, so the ceiling is only ever reached on the tail read.

- **Symmetric degradation to head-only comparison**:
  - `_remote_head_tail_digest()` now reports whether the tail could be retrieved, and `_local_head_tail_digest()` accepts the same flag.
  - Both sides therefore hash the same byte window. Without this, any file above the ceiling on a server that ignores `Range` would have been reported as a false conflict on every attempt.
  - The degradation is logged so that reduced detection accuracy is visible in support logs.

- **Accurate `IntegrityError` diagnostics**:
  - `States` carries two unique couples involving `remote_ref`: `(remote_ref, local_path)` and `(remote_ref, remote_parent_ref)`. The handler in `update_remote_state()` only queried the first, so a violation of the second logged a misleading message with no offending row.
  - The handler now probes both couples, excludes the row being updated, includes the SQLite message (which names the violated constraint), and falls back to an explicit "no conflicting row found" when the clash cannot be attributed.

- **Test coverage for the above**:
  - Ranged reads: zero-length short-circuit, `206` window with `Range` header assertion, `200` fallback slicing, and refusal beyond the ceiling without touching the response body.
  - Head-only degradation: matching heads are accepted, differing heads are still detected.
  - DAO: a violation of the `(remote_ref, remote_parent_ref)` couple is named correctly in the log.
  - Folder resolution: a folderish pair settles without hashing, uploading, or postponing.

### Note on Existing Tests

Several `TestSynchronizeLocallyModified` cases built their pair with a bare `Mock()`, which makes `pair.folderish` a truthy `Mock`. Those "file" tests were therefore silently exercising the folder path. `pair.folderish = False` is now set explicitly so they test what their names claim.

## Summary by Sourcery

Stop Alfresco synchronization loops after conflict resolution and reliably detect, surface, and settle concurrent file and folder conflicts.

Bug Fixes:
- Prevent Alfresco synchronization from looping indefinitely after conflict resolution by correctly adopting concurrent creations, preserving surfaced conflicts, and settling folder conflicts without repeated postponement.
- Detect differing same-named remote files before upload to avoid silent overwrites and provide complete conflict metadata for resolution.

Enhancements:
- Harden remote range reads and conflict comparisons with bounded-memory fallback behavior and symmetric head-only degradation when Range requests are unsupported.
- Improve duplicate-pair recovery and integrity-error diagnostics, and interrupt in-flight processors when conflicts are surfaced.

Documentation:
- Document the Alfresco conflict synchronization fix in the 8.0.0 release notes.

Tests:
- Add coverage for concurrent child adoption, remote twin comparison, ranged-read degradation, conflict resolver behavior, folder resolution, duplicate recovery, and DAO constraint diagnostics.