### PR TITLE
NXDRIVE-3234: Drive S3 structure update

### DIFF
--- a/.github/workflows/beta_to_prod.yml
+++ b/.github/workflows/beta_to_prod.yml
@@ -168,8 +168,9 @@ jobs:
             --prefix "$S3_PREFIX" \
             --root-url "$ROOT_URL" \
             --product-name "Nuxeo Drive" \
-            --folders alpha beta release \
+            --folders alpha beta release staging \
             --update-folders beta release \
+            --latest-release-version "${{ github.event.inputs.betaVersion }}" \
             --extra-files versions.yml \
             --output-dir index_pages
 

--- a/.github/workflows/beta_to_prod_alfresco.yml
+++ b/.github/workflows/beta_to_prod_alfresco.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Fetch versions.yml
         run: |
           bucket="$S3_BUCKET"
-          key="alfresco/drive-updates/versions.yml"
+          key="${S3_PREFIX}versions.yml"
           aws_err_file="$(mktemp)"
 
           if aws s3api get-object --bucket "$bucket" --key "$key" versions.yml 2>"$aws_err_file"; then
@@ -86,8 +86,8 @@ jobs:
 
           failed=0
           for file in "${files[@]}"; do
-            src="s3://$S3_BUCKET/alfresco/drive-updates/beta/$file"
-            dst="s3://$S3_BUCKET/alfresco/drive-updates/release/$file"
+            src="s3://$S3_BUCKET/${S3_PREFIX}beta/$file"
+            dst="s3://$S3_BUCKET/${S3_PREFIX}release/$file"
 
             echo ">>> Moving $file from beta to release"
             output=$(aws s3 mv "$src" "$dst" 2>&1)
@@ -121,7 +121,7 @@ jobs:
           echo ">>> Promoting beta version $beta_version to release in versions.yml"
           python tools/versions.py --promote "$beta_version" --type "release"
           echo ">>> Copying updated versions.yml to S3"
-          aws s3 cp versions.yml "s3://$S3_BUCKET/alfresco/drive-updates/" --cache-control "no-cache, max-age=0, must-revalidate"
+          aws s3 cp versions.yml "s3://$S3_BUCKET/$S3_PREFIX" --cache-control "no-cache, max-age=0, must-revalidate"
           echo ">>> Removing versions.yml from local workspace"
           rm -f versions.yml
 
@@ -139,8 +139,9 @@ jobs:
             --prefix "$S3_PREFIX" \
             --root-url "$ROOT_URL" \
             --product-name "Hyland Drive for Alfresco" \
-            --folders alpha beta release \
+            --folders alpha beta release staging \
             --update-folders beta release \
+            --latest-release-version "${{ github.event.inputs.betaVersion }}" \
             --extra-files versions.yml \
             --output-dir index_pages
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -417,8 +417,13 @@ jobs:
       - name: Upload artifacts to software channel
         run: |
           release="${{ github.event.inputs.releaseType }}"
+          sign_exe="${{ github.event.inputs.signExe }}"
           if [ "$release" = "alpha" ] || [ -z "$release" ]; then
-            aws s3 cp dist/ "s3://$S3_BUCKET/${S3_PREFIX}alpha/" --recursive
+            if [ "$sign_exe" = "true" ]; then
+              aws s3 cp dist/ "s3://$S3_BUCKET/${S3_PREFIX}alpha/" --recursive
+            else
+              aws s3 cp dist/ "s3://$S3_BUCKET/${S3_PREFIX}staging/" --recursive
+            fi
           elif [ "$release" = "release" ]; then
             aws s3 cp dist/ "s3://$S3_BUCKET/${S3_PREFIX}beta/" --recursive
           else
@@ -429,14 +434,19 @@ jobs:
       - name: Update versions.yml
         run: |
           drive_version="$(grep __version__ nxdrive/__init__.py | cut -d'"' -f2)"
-          type="${{ github.event.inputs.releaseType }}"
+          release="${{ github.event.inputs.releaseType }}"
+          sign_exe="${{ github.event.inputs.signExe }}"
           echo ">>> drive_version=$drive_version"
-          if [ "$type" = "alpha" ] || [ -z "$type" ]; then
-            type="alpha"
-          elif [ "$type" = "release" ]; then
+          if [ "$release" = "alpha" ] || [ -z "$release" ]; then
+            if [ "$sign_exe" = "true" ]; then
+              type="alpha"
+            else
+              type="staging"
+            fi
+          elif [ "$release" = "release" ]; then
             type="beta"
           else
-            echo ">>> Invalid release type: $type"
+            echo ">>> Invalid release type: $release"
             exit 1
           fi
           echo ">>> type=$type"
@@ -456,8 +466,15 @@ jobs:
           # refreshed. The root index is always refreshed so its "generated
           # on" timestamp stays current.
           release="${{ github.event.inputs.releaseType }}"
+          sign_exe="${{ github.event.inputs.signExe }}"
           case "$release" in
-            ""|alpha) update_folder="alpha" ;;
+            ""|alpha)
+              if [ "$sign_exe" = "true" ]; then
+                update_folder="alpha"
+              else
+                update_folder="staging"
+              fi
+              ;;
             release) update_folder="beta" ;;
             *)
               echo ">>> Unknown releaseType '$release', skipping index update"
@@ -470,7 +487,7 @@ jobs:
             --prefix "$S3_PREFIX" \
             --root-url "$ROOT_URL" \
             --product-name "Nuxeo Drive" \
-            --folders alpha beta release \
+            --folders alpha beta release staging \
             --update-folders "$update_folder" \
             --extra-files versions.yml \
             --output-dir index_pages

--- a/.github/workflows/release_alfresco.yml
+++ b/.github/workflows/release_alfresco.yml
@@ -292,7 +292,7 @@ jobs:
       - name: Fetch versions.yml
         run: |
           bucket="$S3_BUCKET"
-          key="alfresco/drive-updates/versions.yml"
+          key="${S3_PREFIX}versions.yml"
           aws_err_file="$(mktemp)"
 
           if aws s3api get-object --bucket "$bucket" --key "$key" versions.yml 2>"$aws_err_file"; then
@@ -321,11 +321,16 @@ jobs:
 
       - name: Upload artifacts to software channel
         run: |
-          release=${{ github.event.inputs.releaseType }}
-          if [ "$release" = "alpha" ]; then
-            aws s3 cp dist/ "s3://$S3_BUCKET/alfresco/drive-updates/alpha/" --recursive
+          release="${{ github.event.inputs.releaseType }}"
+          sign_exe="${{ github.event.inputs.signExe }}"
+          if [ "$release" = "alpha" ] || [ -z "$release" ]; then
+            if [ "$sign_exe" = "true" ]; then
+              aws s3 cp dist/ "s3://$S3_BUCKET/${S3_PREFIX}alpha/" --recursive
+            else
+              aws s3 cp dist/ "s3://$S3_BUCKET/${S3_PREFIX}staging/" --recursive
+            fi
           elif [ "$release" = "release" ]; then
-            aws s3 cp dist/ "s3://$S3_BUCKET/alfresco/drive-updates/beta/" --recursive
+            aws s3 cp dist/ "s3://$S3_BUCKET/${S3_PREFIX}beta/" --recursive
           else
             echo ">>> Invalid release type: $release"
             exit 1
@@ -335,20 +340,25 @@ jobs:
         run: |
           export SERVER="alfresco"
           drive_version="$(grep __alfresco_version__ nxdrive/__init__.py | cut -d'"' -f2)"
-          type="${{ github.event.inputs.releaseType }}"
+          release="${{ github.event.inputs.releaseType }}"
+          sign_exe="${{ github.event.inputs.signExe }}"
           echo ">>> drive_version=$drive_version"
-          if [ "$type" = "alpha" ]; then
-            type="alpha"
-          elif [ "$type" = "release" ]; then
+          if [ "$release" = "alpha" ] || [ -z "$release" ]; then
+            if [ "$sign_exe" = "true" ]; then
+              type="alpha"
+            else
+              type="staging"
+            fi
+          elif [ "$release" = "release" ]; then
             type="beta"
           else
-            echo ">>> Invalid release type: $type"
+            echo ">>> Invalid release type: $release"
             exit 1
           fi
           echo ">>> type=$type"
           python tools/versions.py --add "$drive_version" --type "$type" || exit 1
           python tools/versions.py --merge || exit 1
-          aws s3 cp versions.yml "s3://$S3_BUCKET/alfresco/drive-updates/" --cache-control "no-cache, max-age=0, must-revalidate"
+          aws s3 cp versions.yml "s3://$S3_BUCKET/$S3_PREFIX" --cache-control "no-cache, max-age=0, must-revalidate"
           python tools/versions.py --delete "$drive_version" || exit 1
           rm versions.yml
 
@@ -363,8 +373,15 @@ jobs:
           # beta/. The root index is always refreshed so its "generated on"
           # timestamp stays current.
           release="${{ github.event.inputs.releaseType }}"
+          sign_exe="${{ github.event.inputs.signExe }}"
           case "$release" in
-            alpha) update_folder="alpha" ;;
+            ""|alpha)
+              if [ "$sign_exe" = "true" ]; then
+                update_folder="alpha"
+              else
+                update_folder="staging"
+              fi
+              ;;
             release) update_folder="beta" ;;
             *)
               echo ">>> Unknown releaseType '$release', skipping index update"
@@ -377,7 +394,7 @@ jobs:
             --prefix "$S3_PREFIX" \
             --root-url "$ROOT_URL" \
             --product-name "Hyland Drive for Alfresco" \
-            --folders alpha beta release \
+            --folders alpha beta release staging \
             --update-folders "$update_folder" \
             --extra-files versions.yml \
             --output-dir index_pages

--- a/docs/changes/8.0.0.md
+++ b/docs/changes/8.0.0.md
@@ -6,7 +6,7 @@ Release date: `2026-xx-xx`
 
 - [NXDRIVE-3201](https://hyland.atlassian.net/browse/NXDRIVE-3201): [Implementation] Publish Nuxeo Drive release tag on successful GA release
 - [NXDRIVE-3208](https://hyland.atlassian.net/browse/NXDRIVE-3208): [SPIKE] Automate release tag publish on GitHub
-
+- [NXDRIVE-3234](https://hyland.atlassian.net/browse/NXDRIVE-3234): Drive S3 structure update
 ## Core
 
 - [NXDRIVE-3163](https://hyland.atlassian.net/browse/NXDRIVE-3163): Align on user and group generated UUID at Drive

--- a/docs/changes/8.0.0.md
+++ b/docs/changes/8.0.0.md
@@ -7,6 +7,7 @@ Release date: `2026-xx-xx`
 - [NXDRIVE-3201](https://hyland.atlassian.net/browse/NXDRIVE-3201): [Implementation] Publish Nuxeo Drive release tag on successful GA release
 - [NXDRIVE-3208](https://hyland.atlassian.net/browse/NXDRIVE-3208): [SPIKE] Automate release tag publish on GitHub
 - [NXDRIVE-3234](https://hyland.atlassian.net/browse/NXDRIVE-3234): Drive S3 structure update
+
 ## Core
 
 - [NXDRIVE-3163](https://hyland.atlassian.net/browse/NXDRIVE-3163): Align on user and group generated UUID at Drive

--- a/tools/generate_s3_index.py
+++ b/tools/generate_s3_index.py
@@ -15,6 +15,7 @@ import argparse
 import html
 import json
 import os
+import re
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -118,6 +119,7 @@ def _page(title, body):
         "    body { font-family: -apple-system, Segoe UI, Roboto, sans-serif;"
         " margin: 2rem; color: #222; }\n"
         "    h1 { border-bottom: 1px solid #ddd; padding-bottom: .5rem; }\n"
+        "    h2 { margin-top: 1.5rem; font-size: 1.2rem; color: #333; }\n"
         "    table { border-collapse: collapse; width: 100%; }\n"
         "    th, td { text-align: left; padding: .4rem .8rem;"
         " border-bottom: 1px solid #eee; }\n"
@@ -139,24 +141,109 @@ def _page(title, body):
     )
 
 
-def _render_root(root_url, prefix, folders, extra_files, product_name=None):
-    items = []
+def _version_key(v):
+    """Sort key for versions (e.g. 5.3.0, 1.0.0-rc1)."""
+
+    parts = []
+    for token in re.split(r"[-.]", v):
+        if token.isdigit():
+            parts.append((0, int(token)))
+        else:
+            parts.append((1, token))
+    return parts
+
+
+_RELEASE_FILE_PATTERN = re.compile(
+    r"^(?P<prefix>(?:nuxeo|alfresco)-drive-)"
+    r"(?P<ver>\d[a-zA-Z0-9.\-_]*?)"
+    r"(?P<suffix>-admin\.exe|-x86_64\.AppImage|\.dmg|\.exe)$"
+)
+
+
+def _find_latest_release_files(release_files, latest_version=None):
+    """Identify files in release/ corresponding to the latest release version.
+
+    Returns a list of tuples: (unversioned_name, filename).
+    """
+
+    if not release_files:
+        return []
+
+    parsed = []
+    addons = []
+    for f in release_files:
+        name = f["name"]
+        m = _RELEASE_FILE_PATTERN.match(name)
+        if m:
+            ver = m.group("ver")
+            suffix = m.group("suffix")
+            prefix = m.group("prefix")
+            if suffix.startswith("-"):
+                unversioned = prefix + suffix[1:]
+            else:
+                unversioned = prefix[:-1] + suffix
+            parsed.append((ver, unversioned, name))
+        elif "addons" in name.lower():
+            addons.append((name, name))
+
+    if not parsed:
+        return [(unv, orig) for unv, orig in addons]
+
+    if not latest_version:
+        versions = {ver for ver, _, _ in parsed}
+        latest_version = max(versions, key=_version_key)
+
+    links = [(unv, name) for ver, unv, name in parsed if ver == latest_version]
+    links.extend(addons)
+    links.sort(key=lambda x: x[0].lower())
+    return links
+
+
+def _render_root(
+    root_url, prefix, folders, extra_files, latest_links=None, product_name=None
+):
+    sections = []
+
+    folder_items = []
     for folder in folders:
         # Link straight to the folder's index.html so the page works even
         # when the bucket has no default index document configured.
         href = f"{root_url}/{prefix}{folder}/index.html"
-        items.append(
+        folder_items.append(
             f'    <li>&#128193; <a href="{html.escape(href)}">'
             f"{html.escape(folder)}/</a></li>"
         )
+    if folder_items:
+        sections.append(
+            "  <h2>Channels</h2>\n  <ul>\n" + "\n".join(folder_items) + "\n  </ul>"
+        )
+
+    if latest_links:
+        link_items = []
+        for unversioned_name, filename in latest_links:
+            target_url = f"{root_url}/{prefix}release/{filename}"
+            link_items.append(
+                f'    <li>&#128230; <a href="{html.escape(target_url)}"'
+                f' title="{html.escape(filename)}">'
+                f"{html.escape(unversioned_name)}</a></li>"
+            )
+        sections.append(
+            "  <h2>Latest Release</h2>\n  <ul>\n" + "\n".join(link_items) + "\n  </ul>"
+        )
+
+    file_items = []
     for name in extra_files:
         href = f"{root_url}/{prefix}{name}"
-        items.append(
+        file_items.append(
             f'    <li>&#128196; <a href="{html.escape(href)}">'
             f"{html.escape(name)}</a></li>"
         )
+    if file_items:
+        sections.append(
+            "  <h2>Files</h2>\n  <ul>\n" + "\n".join(file_items) + "\n  </ul>"
+        )
 
-    body = "  <ul>\n" + "\n".join(items) + "\n  </ul>"
+    body = "\n".join(sections)
     title = product_name or "Hyland Drive for Alfresco"
     return _page(f"{title} – Software Channel", body)
 
@@ -210,7 +297,7 @@ def main():
     parser.add_argument(
         "--folders",
         nargs="+",
-        default=["alpha", "beta", "release"],
+        default=["alpha", "beta", "release", "staging"],
         help="Folders to link from the root index.html.",
     )
     parser.add_argument(
@@ -221,6 +308,10 @@ def main():
             "Subset of --folders whose per-folder index.html should be"
             " (re)generated. Defaults to all of --folders."
         ),
+    )
+    parser.add_argument(
+        "--latest-release-version",
+        help="Explicit version to use for latest release links in the root index.",
     )
     parser.add_argument(
         "--extra-files",
@@ -241,10 +332,27 @@ def main():
 
     root_url = args.root_url.rstrip("/")
 
+    folder_cache = {}
+
+    def get_folder_files(fld):
+        if fld not in folder_cache:
+            folder_cache[fld] = _list_folder(args.bucket, f"{prefix}{fld}")
+        return folder_cache[fld]
+
+    release_files = get_folder_files("release")
+    latest_links = _find_latest_release_files(
+        release_files, args.latest_release_version
+    )
+
     _write(
         os.path.join(args.output_dir, "index.html"),
         _render_root(
-            root_url, prefix, args.folders, args.extra_files, args.product_name
+            root_url,
+            prefix,
+            args.folders,
+            args.extra_files,
+            latest_links=latest_links,
+            product_name=args.product_name,
         ),
     )
 
@@ -261,7 +369,7 @@ def main():
         sys.exit(2)
 
     for folder in update_folders:
-        files = _list_folder(args.bucket, f"{prefix}{folder}")
+        files = get_folder_files(folder)
         _write(
             os.path.join(args.output_dir, folder, "index.html"),
             _render_folder(folder, root_url, prefix, files, args.product_name),

--- a/tools/versions.py
+++ b/tools/versions.py
@@ -168,7 +168,7 @@ def main():
     parser.add_argument(
         "--type",
         choices=("alpha", "beta", "release", "staging"),
-        help="version type (mandatory for --create and --promote)",
+        help="version type (mandatory for --add and --promote)",
     )
     args = parser.parse_args()
 

--- a/tools/versions.py
+++ b/tools/versions.py
@@ -167,7 +167,7 @@ def main():
     parser.add_argument("--promote", help="change a given version to the next category")
     parser.add_argument(
         "--type",
-        choices=("alpha", "beta", "release"),
+        choices=("alpha", "beta", "release", "staging"),
         help="version type (mandatory for --create and --promote)",
     )
     args = parser.parse_args()


### PR DESCRIPTION
## Summary by Sourcery

Update Drive software-channel publishing to support staging artifacts and provide clearer access to the latest release files.

New Features:
- Add a staging software channel for unsigned builds across Nuxeo and Alfresco Drive releases.
- Expose direct links to the latest release artifacts from the S3 root index.

Bug Fixes:
- Align S3 artifact, version metadata, and index generation paths with the configured product prefix.

Enhancements:
- Support explicit latest release versions and staging entries when generating software-channel indexes.
- Allow staging versions in version metadata management.

CI:
- Update release workflows to route unsigned builds to staging and signed builds to alpha while refreshing the corresponding S3 indexes.
- Update beta-to-production workflows to include staging and latest-release metadata in generated indexes.

Documentation:
- Document the Drive S3 structure update in the 8.0.0 change log.