### PR TITLE
NXDRIVE-3270: Clear text password logging in GitHub CI

### DIFF
--- a/docs/changes/8.0.0.md
+++ b/docs/changes/8.0.0.md
@@ -64,6 +64,7 @@ Release date: `2026-xx-xx`
 - [NXDRIVE-3232](https://hyland.atlassian.net/browse/NXDRIVE-3232): pip Dependabot security alert
 - [NXDRIVE-3233](https://hyland.atlassian.net/browse/NXDRIVE-3233): setuptools Dependabot security alert
 - [NXDRIVE-3265](https://hyland.atlassian.net/browse/NXDRIVE-3265): pip - Handle doubly-encoded package URL
+- [NXDRIVE-3270](https://hyland.atlassian.net/browse/NXDRIVE-3270): Clear text password logging in GitHub CI
 
 ## Sentry
 

--- a/tools/scripts/check_update_process.py
+++ b/tools/scripts/check_update_process.py
@@ -209,6 +209,11 @@ def install_drive(installer, server_name: str = "nuxeo"):
         subprocess.check_call(cmd)
 
 
+def redact(cmd):
+    """Mask credentials passed on the command line before displaying it."""
+    return [re.sub(r"(--password=).*", r"\1******", arg) for arg in cmd]
+
+
 def launch_drive(executable, server_name: str = "nuxeo", args=None):
     """Launch Drive and wait for auto-update."""
 
@@ -244,7 +249,7 @@ def launch_drive(executable, server_name: str = "nuxeo", args=None):
                 *args,
             ]
 
-    print(">>> Command:", cmd, flush=True)
+    print(">>> Command:", redact(cmd), flush=True)
     subprocess.check_call(cmd)
 
 


### PR DESCRIPTION
## Summary by Sourcery

Redact command-line passwords before logging update commands in CI.

Bug Fixes:
- Prevent GitHub CI logs from exposing clear-text passwords when displaying update commands.

Documentation:
- Document NXDRIVE-3270 in the 8.0.0 release notes.